### PR TITLE
Legacy shareable redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -42,6 +42,12 @@
   from = "/fun2/*"
   to = "/calendar/:splat"
   status = 301
+# we can't translate REALLY legacy links - they used some odd format.  
+# But let's at least land on the calendar page.
+[[redirects]]
+  from = "/cal/*"
+  to = "/calendar/"
+  status = 301
 [[redirects]]
   from = "/eventimages/*"
   to = "https://api.shift2bikes.org/eventimages/:splat"

--- a/netlify.toml
+++ b/netlify.toml
@@ -36,11 +36,11 @@
 # these two are needed for legacy "shareable links"
 [[redirects]]
   from = "/fun/*"
-  to = "https://shift2bikes.org/calendar/:splat"
+  to = "/calendar/:splat"
   status = 301
 [[redirects]]
   from = "/fun2/*"
-  to = "https://shift2bikes.org/calendar/:splat"
+  to = "/calendar/:splat"
   status = 301
 [[redirects]]
   from = "/eventimages/*"

--- a/netlify.toml
+++ b/netlify.toml
@@ -33,6 +33,15 @@
   from = "/api/*"
   to = "https://api.shift2bikes.org/api/:splat"
   status = 200
+# these two are needed for legacy "shareable links"
+[[redirects]]
+  from = "/fun/*"
+  to = "https://shift2bikes.org/calendar/:splat"
+  status = 301
+[[redirects]]
+  from = "/fun2/*"
+  to = "https://shift2bikes.org/calendar/:splat"
+  status = 301
 [[redirects]]
   from = "/eventimages/*"
   to = "https://api.shift2bikes.org/eventimages/:splat"


### PR DESCRIPTION
events from the new calendar, but the old site used either /fun or /fun2 instead of /calendar

This makes them work.