### PR TITLE
Restore nav headers

### DIFF
--- a/site/content/pages/bike-racks.md
+++ b/site/content/pages/bike-racks.md
@@ -1,7 +1,10 @@
 ---
 title: Bike Rack Rental
 date: 2019-03-15T07:24:00.000Z
-weight: 2
+weight: 9
+menu:	
+    main:	
+        parent: communitynav
 ---
 
 Shift has built some easily-transportable bike racks which we'd love to loan to your community or nonprofit group for your event.  They'll accomodate around 70 bikes.

--- a/site/content/pages/bonb.md
+++ b/site/content/pages/bonb.md
@@ -2,6 +2,9 @@
 title: Breakfast on the Bridges
 date: 2019-03-12T22:52:28.000Z
 weight: 2
+menu:	
+    main:	
+        parent: featuredevents
 ---
 
 <img src=/images/BonB_header.jpg align=center alt="breakfast on the bridges logo">

--- a/site/content/pages/email-list.md
+++ b/site/content/pages/email-list.md
@@ -2,6 +2,9 @@
 title: Email List
 date: 2019-03-13T08:19:34.000Z
 weight: '2'
+menu:	
+    main:	
+        parent: communitynav
 ---
 For the first 10 years of its life, shift was centered around bikes, but also... an email list with hundreds of participants: all from or interested in Portland.
 Shenanigans and flame wars and over a hundred messaages a month.

--- a/site/content/pages/get-involved.md
+++ b/site/content/pages/get-involved.md
@@ -2,6 +2,9 @@
 title: Get Involved
 date: 2019-03-13T08:19:34.000Z
 weight: '1'
+menu:	
+    main:	
+        parent: communitynav
 ---
 Shift welcomes all respectful participants. There are a lot of ways to get involved:
 

--- a/site/content/pages/lead-a-ride.md
+++ b/site/content/pages/lead-a-ride.md
@@ -2,6 +2,9 @@
 title: Leading a Social Ride
 date: 2019-03-14T21:58:11.032Z
 weight: 7
+menu:	
+    main:	
+        parent: communitynav
 ---
 
 You should consider the below points when creating your ride.  They're all optional, but strongly suggested to keep things going smoothly.  For more details than this checklist, check out [this detailed guide](/ride-leading-guide.pdf)!

--- a/site/content/pages/mission_statement.md
+++ b/site/content/pages/mission_statement.md
@@ -2,6 +2,9 @@
 title: Mission Statement
 date: 2017-11-12T23:56:33.000Z
 weight: 1
+menu:	
+    main:	
+        parent: aboutmenu
 ---
 
 ## SHIFT revels in expressing Portland’s creative bike culture through performance events and bike fun intended to highlight the positive contributions of bicycling for the community at large.

--- a/site/content/pages/participation.md
+++ b/site/content/pages/participation.md
@@ -1,7 +1,11 @@
 ---
 title: Participation
 date: 2019-03-13T08:17:13.000Z
+weight: 4
 
+menu:	
+    main:	
+        parent: communitynav
 ---
 Shift welcomes all respectful participants!  There are a lot of ways to get involved:
 

--- a/site/content/pages/pedalpalooza.md
+++ b/site/content/pages/pedalpalooza.md
@@ -2,6 +2,9 @@
 title: Pedalpalooza
 date: 2019-03-13T01:15:16.319Z
 weight: 1
+menu:	
+    main:	
+        parent: featuredevents
 ---
 Pedalpalooza is an annual festival in Metro Portland, Oregon.  During the festival, there are hundreds of volunteer-organized free events open to the general public.  Each year there are well over 10,000 participants in these events, which are almost entirely on bikes and free.  There are some annual flagship rides which usually have over 1000 riders, and many first-time ever rides - some of which will have only 1 or 2 riders.  They're all fun!
 

--- a/site/content/pages/posse.md
+++ b/site/content/pages/posse.md
@@ -2,6 +2,9 @@
 title: Posse
 date: 2019-03-13T08:14:32.000Z
 weight: '5'
+menu:	
+    main:	
+        parent: communitynav
 ---
 Think another group should be listed here?  [Let us know on the mailing list](/pages/email-list/)!
 

--- a/site/content/pages/safety.md
+++ b/site/content/pages/safety.md
@@ -1,11 +1,12 @@
 ---
 title: Safety
+description: "Tips to stay safe"
 date: 2019-03-15T07:26:39.604Z
+keywords: ["safety", "tips", "safe"]	
 weight: 8
-
- menu:	
-    main:	
-        parent: communitynav
+menu:	
+   main:	
+       parent: communitynav
 ---
 
 ## EDUCATION

--- a/site/content/pages/safety.md
+++ b/site/content/pages/safety.md
@@ -2,6 +2,10 @@
 title: Safety
 date: 2019-03-15T07:26:39.604Z
 weight: 8
+
+ menu:	
+    main:	
+        parent: communitynav
 ---
 
 ## EDUCATION

--- a/site/content/pages/safety.md
+++ b/site/content/pages/safety.md
@@ -1,12 +1,12 @@
 ---
 title: Safety
-description: "Tips to stay safe"
+description: Tips to stay safe
 date: 2019-03-15T07:26:39.604Z
 keywords: ["safety", "tips", "safe"]	
-weight: 8
+weight: '8'
 menu:	
-   main:	
-       parent: communitynav
+    main:	
+        parent: communitynav
 ---
 
 ## EDUCATION


### PR DESCRIPTION
the CMS wiped these out.  menus got shorter as I edited every page using it 🤦‍♂️ .  I need to update CMS config before anyone else uses it so I turned off invites for the login that people would sign up with for the time being (on this page: https://app.netlify.com/sites/shift-docs/settings/identity#registration-preferences)
