### PR TITLE
Fix nav bar logo alignment and hamburger menu visibility on mobile

### DIFF
--- a/site/themes/s2b_hugo_theme/static/css/custom.css
+++ b/site/themes/s2b_hugo_theme/static/css/custom.css
@@ -21,10 +21,10 @@ header {
   text-align: center;
 }
 
-#navbar svg.logo {
-    fill: currentColor;
+#navbar .navbar-header {
+  text-align: left;
 }
 
-.navbar-affix-placeholder {
-  height: 67px;
+#navbar svg.logo {
+  fill: currentColor;
 }


### PR DESCRIPTION
This should fix #97 and #91. 

I took a quick pass on the Add Event page, because the `.navbar-affix-placeholder` change was introduced in #88. It seems to work OK still, but another check would be helpful, especially from @sdobz since it was his PR. 