### PR TITLE
Adding support for calendar date range params

### DIFF
--- a/backend/www/events.php
+++ b/backend/www/events.php
@@ -35,9 +35,20 @@ if (isset($_GET['enddate']) && ($parseddate = strtotime($_GET['enddate']))) {
 
 $json = array();
 
+function daysInRange($startdate, $enddate) {
+    $days = 86400; // seconds in a day
+    return round(($enddate / $days) - ($startdate / $days));
+}
+
 if ($enddate < $startdate) {
     http_response_code(400);
     $message = "enddate: " . date('Y-m-d', $enddate) . " is before startdate: " . date('Y-m-d', $startdate);
+    $json['error'] = array(
+        'message' => $message
+    );
+} elseif (daysInRange($startdate, $enddate) > 45) {
+    http_response_code(400);
+    $message = "event range too large: " . daysInRange($startdate, $enddate) . " days requested; max 45 days";
     $json['error'] = array(
         'message' => $message
     );

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
@@ -8,17 +8,16 @@
 
   $(document).ready(function() {
     var params = parseURL();
+
     if ('eventId' in params) {
       viewEvent(params['eventId']);
+
     } else if ('editId' in params) {
       var eventid = params["editId"];
       var secret = params["editSecret"];
-
-      console.log("Loading viewAddEventForm with eventid: ", eventid, ", secret: ", secret);
       viewAddEventForm(eventid, secret);
 
     } else if (window.legacycal_renderpage == "addevent") {
-      console.log("Loading viewAddEventForm for a new event")
       viewAddEventForm();
 
     } else {
@@ -28,18 +27,34 @@
         params["enddate"] = {{ .Param "enddate" }};
       }
 
-      console.log("Rendering normal event list");
       viewEvents(params);
 
     }
   });
 
-
+  // move parseURL() to helpers.js?
   function parseURL() {
     var urlParams = {};
-    var parts = window.location.pathname.split('/');
-    var lastPart = parts[parts.length-1];
+    var path = window.location.pathname.split('/');
+    var lastPart = path[path.length-1];
 
+    var query = new URLSearchParams(location.search);
+
+    // get dates from URL e.g. /calendar/?startdate=2019-01-01&enddate=2019-01-08
+    if (query.has('startdate')) {
+      urlParams['startdate'] = query.get('startdate');
+    }
+    if (query.has('enddate')) {
+      urlParams['enddate'] = query.get('enddate');
+    }
+    // if startdate is provided but enddate is not, current day + 10 is used.
+    // this could end up being a huge range.
+    // double-check logic in main.js and update if needed.
+
+    // also consider adding "Show all upcoming events" partial
+    // if requesting anything other than current timeframe
+
+    // "Re" means "RegEx"? use full name for clarity
     var singleEventRe = /event-([0-9]+)/g;
     var singleEvent = singleEventRe.exec(lastPart);
     if (singleEvent && singleEvent.length === 2) {

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
@@ -32,29 +32,11 @@
     }
   });
 
-  // move parseURL() to helpers.js?
   function parseURL() {
     var urlParams = {};
     var path = window.location.pathname.split('/');
     var lastPart = path[path.length-1];
 
-    var query = new URLSearchParams(location.search);
-
-    // get dates from URL e.g. /calendar/?startdate=2019-01-01&enddate=2019-01-08
-    if (query.has('startdate')) {
-      urlParams['startdate'] = query.get('startdate');
-    }
-    if (query.has('enddate')) {
-      urlParams['enddate'] = query.get('enddate');
-    }
-    // if startdate is provided but enddate is not, current day + 10 is used.
-    // this could end up being a huge range.
-    // double-check logic in main.js and update if needed.
-
-    // also consider adding "Show all upcoming events" partial
-    // if requesting anything other than current timeframe
-
-    // "Re" means "RegEx"? use full name for clarity
     var singleEventRe = /event-([0-9]+)/g;
     var singleEvent = singleEventRe.exec(lastPart);
     if (singleEvent && singleEvent.length === 2) {
@@ -66,6 +48,15 @@
     if (editEvent && editEvent.length === 3) {
       urlParams['editId'] = parseInt(editEvent[1]);
       urlParams['editSecret'] = editEvent[2];
+    }
+
+    var query = new URLSearchParams(location.search);
+
+    if (query.has('startdate')) {
+      urlParams['startdate'] = query.get('startdate');
+    }
+    if (query.has('enddate')) {
+      urlParams['enddate'] = query.get('enddate');
     }
 
     return urlParams;

--- a/site/themes/s2b_hugo_theme/static/legacycaljs/main.js
+++ b/site/themes/s2b_hugo_theme/static/legacycaljs/main.js
@@ -93,11 +93,12 @@ $(document).ready(function() {
 
         var currentDateTime = new Date();
         var firstDayOfRange = new Date(currentDateTime.setHours(0,0,0,0)); // set time to midnight
-        var lastDayOfRange = daysAfter(firstDayOfRange, dayRange);
 
         if ('startdate' in options) {
           firstDayOfRange = new Date(options['startdate']);
         }
+
+        var lastDayOfRange = daysAfter(firstDayOfRange, dayRange);
 
         if ('enddate' in options) {
           lastDayOfRange = new Date(options['enddate']);

--- a/site/themes/s2b_hugo_theme/static/legacycaljs/main.js
+++ b/site/themes/s2b_hugo_theme/static/legacycaljs/main.js
@@ -84,6 +84,7 @@ $(document).ready(function() {
     }
 
     function viewEvents(options){
+
         function daysAfter(d, days) {
             return new Date ((new Date(d)).setDate(d.getDate() + days));
         }
@@ -289,7 +290,6 @@ $(document).ready(function() {
         }
     }
 
-    console.log("Vincent's main.js - 2");
     window.viewAddEventForm = viewAddEventForm;
     window.viewEvents = viewEvents;
     window.viewEvent = viewEvent;

--- a/site/themes/s2b_hugo_theme/static/legacycaljs/main.js
+++ b/site/themes/s2b_hugo_theme/static/legacycaljs/main.js
@@ -93,16 +93,20 @@ $(document).ready(function() {
         var dayRange = 10;
 
         var currentDateTime = new Date();
+        var timezoneOffset = (currentDateTime.getTimezoneOffset() / 60);
+
         var firstDayOfRange = new Date(currentDateTime.setHours(0,0,0,0)); // set time to midnight
 
         if ('startdate' in options) {
-          firstDayOfRange = new Date(options['startdate']);
+          startDate = new Date(options['startdate']).setUTCHours(timezoneOffset,0,0,0);
+          firstDayOfRange = new Date(startDate);
         }
 
         var lastDayOfRange = daysAfter(firstDayOfRange, dayRange);
 
         if ('enddate' in options) {
-          lastDayOfRange = new Date(options['enddate']);
+          endDate = new Date(options['enddate']).setUTCHours(timezoneOffset,0,0,0);
+          lastDayOfRange = new Date(endDate);
         }
 
         container.empty()


### PR DESCRIPTION
You can now make requests to the calendar front end like `{base_url}/calendar/?startdate=2018-01-01&enddate=2018-01-14`. You can specify `startdate`, `enddate`, or both; it's recommended that you provide both for predictable results. The application isn't using this code yet, but it's added in anticipation of standing feature requests like the ability to jump backwards in the event list. 

Note: There's currently an annoying off-by-one error. Requesting `startdate=2018-01-01` actually returns events starting with 2017-12-31. I traced through this for a while and had trouble making heads or tails of it, but it seems to be rooted in some non-intuitive Javascript time zone nonsense. I'll file an issue to track this and make sure we address it.