### PR TITLE
Media redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -103,7 +103,7 @@
 [[redirects]]
   from = "/calendar/pedalpalooza"
   to = "/pages/pedalpalooza"
-  status = 200
+  status = 301
 
   
 # remove-add trailing slashes kinda?  fool can't really believe this works :P

--- a/netlify.toml
+++ b/netlify.toml
@@ -97,6 +97,14 @@
   from = "/cal/*"
   to = "/calendar/"
   status = 301
+
+
+# testing out a special redirect for a URL that someone made up
+[[redirects]]
+  from = "/calendar/pedaloalooza"
+  to = "/pages/pedalpalooza"
+  status = 200
+
   
 # remove-add trailing slashes kinda?  fool can't really believe this works :P
 [[redirects]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -101,7 +101,7 @@
 
 # testing out a special redirect for a URL that someone made up
 [[redirects]]
-  from = "/calendar/pedaloalooza"
+  from = "/calendar/pedalpalooza"
   to = "/pages/pedalpalooza"
   status = 200
 


### PR DESCRIPTION
/calendar/pedalpalooza now redirects to /pages/pedalpalooza which is the PP landing page
