### PR TITLE
adding an expires header for images

### DIFF
--- a/services/nginx/conf.d/shift.conf
+++ b/services/nginx/conf.d/shift.conf
@@ -1,3 +1,8 @@
+map $sent_http_content_type $expires {
+    default		off;
+    ~image/		48h;
+}
+
 server {
 
     listen 443;
@@ -8,6 +13,7 @@ server {
 
     server_name _;
     charset utf-8;
+    expires $expires;
 
     error_log  /var/log/nginx/error.log debug;
     access_log /var/log/nginx/access.log;


### PR DESCRIPTION
this will address https://github.com/shift-org/shift-docs/issues/160

Tested in deploy preview in the browser dev tools:

1. image URL had a `Cache-Control` header of `Cache-Control: max-age=172800`
2. non-image URL had no `Cache-Control` header.

I think we have to test this in production once it is in place.
