### PR TITLE
Improvements for main menu links that open in a new window

### DIFF
--- a/site/themes/s2b_hugo_theme/layouts/partials/scripts.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/scripts.html
@@ -25,7 +25,9 @@
 <script type="text/javascript">
   $(document).ready(function() {
     $(".s2b-external-link").attr("target", "_blank");
-    $(".s2b-external-link").prepend($("<i class='glyphicon glyphicon-new-window'></i>"));
+    $(".s2b-external-link").attr("rel", "noopener");
+    $(".s2b-external-link").attr("title", "Opens in a new window");
+    $(".s2b-external-link").prepend($("<i class='glyphicon glyphicon-new-window' aria-hidden='true'></i>"));
     //console.log("decorated links")
   });
 </script>


### PR DESCRIPTION
* Adds a little hint for screen reader users that some links will open in a new window. You'll also see the same text appear on hover. 
* Hides the icon from screen readers, since it's redundant. 

For why `rel="noopener"` is useful, see https://mathiasbynens.github.io/rel-noopener/.