### PR TITLE
Defensive code to ignore unsupported URLSearchParams function on IE

### DIFF
--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
@@ -113,13 +113,17 @@
       urlParams['editSecret'] = editEvent[2];
     }
 
-    var query = new URLSearchParams(location.search);
+    // IE doesn't support URLSearchParams, so IE will
+    // skip this block and ignore the startdate/enddate params
+    if (typeof URLSearchParams === "function") {
+      var query = new URLSearchParams(location.search);
 
-    if (query.has('startdate')) {
-      urlParams['startdate'] = query.get('startdate');
-    }
-    if (query.has('enddate')) {
-      urlParams['enddate'] = query.get('enddate');
+      if (query.has('startdate')) {
+        urlParams['startdate'] = query.get('startdate');
+      }
+      if (query.has('enddate')) {
+        urlParams['enddate'] = query.get('enddate');
+      }
     }
 
     return urlParams;


### PR DESCRIPTION
IE doesn't support the `URLSearchParams` function, so this checks for it and just skips its functionality if not recognized. This means that the URL params feature added in #132 won't work on IE; those params will just be ignored. 

Fixes #172.