### PR TITLE
Wrap location details on small screens if needed

### DIFF
--- a/site/themes/s2b_hugo_theme/static/css/main_fun_legacy.css
+++ b/site/themes/s2b_hugo_theme/static/css/main_fun_legacy.css
@@ -178,6 +178,10 @@ svg.icon {
     overflow-wrap: break-word;
 }
 
+.location {
+    overflow-wrap: break-word;
+}
+
 .col-xs-2 {
     width: 20%;
 }


### PR DESCRIPTION
Long-ish locacation details might cause the event list to scroll horizontally; this adds wrapping when needed. 