### PR TITLE
Pedalpalooza 2019 shirt sale

### DIFF
--- a/site/content/pedalpalooza-calendar.md
+++ b/site/content/pedalpalooza-calendar.md
@@ -15,7 +15,7 @@ poster-image: "/images/pp/pp2019.jpg"
 ---
 
 <!-- to be removed after May 27, 2019 -->
-<div class="donate">
+<div class="donate" style="margin-bottom: 2em;">
   <p><strong>Limited time</strong> &mdash; buy a 2019 Pedalpalooza shirt by May 27th!</p>
 
   <p><a href="https://www.customink.com/fundraising/pedalpalooza-2019" target="_blank" rel="noopener">Buy a shirt</a></p>

--- a/site/content/pedalpalooza-calendar.md
+++ b/site/content/pedalpalooza-calendar.md
@@ -13,3 +13,10 @@ banner-image: "/images/pp/pp2019-banner.png"
 poster-image: "/images/pp/pp2019.jpg"
 
 ---
+
+<!-- to be removed after May 27, 2019 -->
+<div class="donate">
+  <p><strong>Limited time</strong> &mdash; buy a 2019 Pedalpalooza shirt by May 27th!</p>
+
+  <p><a href="https://www.customink.com/fundraising/pedalpalooza-2019" target="_blank" rel="noopener">Buy a shirt</a></p>
+</div>

--- a/site/themes/s2b_hugo_theme/layouts/partials/pp_header.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/pp_header.html
@@ -18,7 +18,9 @@
       {{ end }}
 
       <div class="donate">
-        <p><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=BNL2NY7U8GH3Q" target="_blank" data-content="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=BNL2NY7U8GH3Q" data-type="external" role="button" id="comp-j2nmjo3ulink" class="style-j2nmcorulink"><span id="comp-j2nmjo3ulabel" class="style-j2nmcorulabel">Donate</span></a></p>
+        <p><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=BNL2NY7U8GH3Q" target="_blank" data-content="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=BNL2NY7U8GH3Q" data-type="external" role="button" id="comp-j2nmjo3ulink" class="style-j2nmcorulink"><span id="comp-j2nmjo3ulabel" class="style-j2nmcorulabel">Donate</span></a> <a href="https://www.customink.com/fundraising/pedalpalooza-2019" target="_blank" rel="noopener">Buy a shirt</a></p>
+
+        <p>Limited time &mdash; buy a 2019 Pedalpalooza shirt by May 27th!</p>
       </div>
 
   </div>

--- a/site/themes/s2b_hugo_theme/layouts/partials/pp_header.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/pp_header.html
@@ -18,9 +18,7 @@
       {{ end }}
 
       <div class="donate">
-        <p><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=BNL2NY7U8GH3Q" target="_blank" data-content="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=BNL2NY7U8GH3Q" data-type="external" role="button" id="comp-j2nmjo3ulink" class="style-j2nmcorulink"><span id="comp-j2nmjo3ulabel" class="style-j2nmcorulabel">Donate</span></a> <a href="https://www.customink.com/fundraising/pedalpalooza-2019" target="_blank" rel="noopener">Buy a shirt</a></p>
-
-        <p>Limited time &mdash; buy a 2019 Pedalpalooza shirt by May 27th!</p>
+        <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=BNL2NY7U8GH3Q" target="_blank" data-content="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=BNL2NY7U8GH3Q" data-type="external" role="button" id="comp-j2nmjo3ulink" class="style-j2nmcorulink"><span id="comp-j2nmjo3ulabel" class="style-j2nmcorulabel">Donate</span></a>
       </div>
 
   </div>

--- a/site/themes/s2b_hugo_theme/layouts/partials/pp_header.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/pp_header.html
@@ -18,7 +18,7 @@
       {{ end }}
 
       <div class="donate">
-        <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=BNL2NY7U8GH3Q" target="_blank" data-content="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=BNL2NY7U8GH3Q" data-type="external" role="button" id="comp-j2nmjo3ulink" class="style-j2nmcorulink"><span id="comp-j2nmjo3ulabel" class="style-j2nmcorulabel">Donate</span></a>
+        <p><a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=BNL2NY7U8GH3Q" target="_blank" data-content="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=BNL2NY7U8GH3Q" data-type="external" role="button" id="comp-j2nmjo3ulink" class="style-j2nmcorulink"><span id="comp-j2nmjo3ulabel" class="style-j2nmcorulabel">Donate</span></a></p>
       </div>
 
   </div>


### PR DESCRIPTION
Temporary link to PP 2019 shirt sale. This will be removed after May 27th when the shirt campaign is over.