### PR TITLE
URL param to expand ride details

### DIFF
--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
@@ -114,7 +114,7 @@
     }
 
     // IE doesn't support URLSearchParams, so IE will
-    // skip this block and ignore the startdate/enddate params
+    // skip this block and ignore all URL params
     if (typeof URLSearchParams === "function") {
       var query = new URLSearchParams(location.search);
 
@@ -123,6 +123,9 @@
       }
       if (query.has('enddate')) {
         urlParams['enddate'] = query.get('enddate');
+      }
+      if (query.has('show_details')) {
+        urlParams['show_details'] = true;
       }
     }
 

--- a/site/themes/s2b_hugo_theme/static/legacycaljs/main.js
+++ b/site/themes/s2b_hugo_theme/static/legacycaljs/main.js
@@ -35,7 +35,7 @@ $(document).ready(function() {
                 value.audienceLabel = container.getAudienceLabel(value.audience);
                 value.mapLink = container.getMapLink(value.address);
 
-                if ('id' in options) {
+                if ( 'id' in options || options['show_details'] == true ) {
                     value.expanded = true;
                 }
                 value.webLink = container.getWebLink(value.weburl);
@@ -109,13 +109,19 @@ $(document).ready(function() {
           lastDayOfRange = new Date(endDate);
         }
 
+        var isExpanded = false;
+        if ('show_details' in options) {
+          isExpanded = true;
+        }
+
         container.empty()
              .append($('#scrollToTop').html())
 
         // range is inclusive -- all rides on end date are included, even if they start at 11:59pm
         getEventHTML({
             startdate: firstDayOfRange,
-            enddate: lastDayOfRange
+            enddate: lastDayOfRange,
+            show_details: isExpanded
         }, function (eventHTML) {
              container.append(eventHTML);
              if ( !('pp' in options) ) {

--- a/site/themes/s2b_hugo_theme/static/legacycaljs/main.js
+++ b/site/themes/s2b_hugo_theme/static/legacycaljs/main.js
@@ -35,7 +35,7 @@ $(document).ready(function() {
                 value.audienceLabel = container.getAudienceLabel(value.audience);
                 value.mapLink = container.getMapLink(value.address);
 
-                if ( 'id' in options || options['show_details'] == true ) {
+                if ( 'show_details' in options && options['show_details'] == true ) {
                     value.expanded = true;
                 }
                 value.webLink = container.getWebLink(value.weburl);
@@ -151,7 +151,10 @@ $(document).ready(function() {
             .append($('#show-all-template').html())
             .append($('#scrollToTop').html());
 
-        getEventHTML({id:id}, function (eventHTML) {
+        getEventHTML({
+            id: id,
+            show_details: true // always expand details for a single event
+        }, function (eventHTML) {
             container.append(eventHTML);
             checkAnchors();
         });


### PR DESCRIPTION
Adds a "secret" option to expand ride details: 
* Add `show_details` param to any cal page URL, e.g. `/pedalpalooza-calendar/?show_details`
* This intentionally makes `getEventHTML()` a little "dumber" — it just displays what we ask it to, instead of needing to know the difference between the list and single ride views (by way of the presence of `id` param). This moves that decision up the chain to whoever calls `getEventHTML()`.