### PR TITLE
Remove link for expired Pedalpalooza 2019 shirt sale

### DIFF
--- a/site/content/pedalpalooza-calendar.md
+++ b/site/content/pedalpalooza-calendar.md
@@ -13,10 +13,3 @@ banner-image: "/images/pp/pp2019-banner.png"
 poster-image: "/images/pp/pp2019.jpg"
 
 ---
-
-<!-- to be removed after May 27, 2019 -->
-<div class="donate" style="margin-bottom: 2em;">
-  <p><strong>Limited time</strong> &mdash; buy a 2019 Pedalpalooza shirt by May 27th!</p>
-
-  <p><a href="https://www.customink.com/fundraising/pedalpalooza-2019" target="_blank" rel="noopener">Buy a shirt</a></p>
-</div>


### PR DESCRIPTION
After adding the temporary link in #187, this removes the link and closes the loop on #186. 