### PR TITLE
Disclaimer on calendar view pages

### DIFF
--- a/site/themes/s2b_hugo_theme/layouts/calevents/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/calevents/single.html
@@ -35,6 +35,8 @@
 
                 </div>
 
+                {{ partial "disclaimer.html" . }}
+
               </div>
 
             </div>

--- a/site/themes/s2b_hugo_theme/layouts/partials/disclaimer.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/disclaimer.html
@@ -1,0 +1,3 @@
+<div class="disclaimer">
+  <p>SHIFT hosts this calendar as a public service. Rides and events are posted to the SHIFT calendar by community members, not by SHIFT. Rides and events posted to the SHIFT calendar are not sponsored by SHIFT or SHIFT’s fiscal sponsor Umbrella.</p>
+</div>

--- a/site/themes/s2b_hugo_theme/static/css/main_fun_legacy.css
+++ b/site/themes/s2b_hugo_theme/static/css/main_fun_legacy.css
@@ -484,6 +484,14 @@ button.more-events {
     border: 1px solid transparent;
 }
 
+.disclaimer {
+  margin: 2em auto 1em auto;
+  max-width: 75%;
+  text-align: center;
+  font-size: small;
+  color: #707070;
+}
+
 #email-suggestion {
     display:none;
     color: red;


### PR DESCRIPTION
Disclaimer is visible at the bottom of each public ride listing page type: 
* general events list
* single event page
* PP calendar

Not shown on the add/edit form (people already have to agree to the CoC to submit). 