### PR TITLE
Calendar: Check email ban list before saving ride

### DIFF
--- a/backend/config.php
+++ b/backend/config.php
@@ -21,3 +21,9 @@ $IMAGEURL = "/eventimages";
 $SITENAME = "SHIFT to Bikes";
 
 $ORIGIN = "*";
+
+$BANLIST = array(
+    'invalid@example.com',
+    'anything@banned.biz',
+    // add more here
+);

--- a/backend/www/manage_event.php
+++ b/backend/www/manage_event.php
@@ -42,13 +42,13 @@ function validate_json_request($data) {
 }
 
 function validate_email($email) {
-    // TODO: pull from a config file
-    $disallowed_emails = array('invalid@example.com');
-
     // lowercase provided email before checking against ban list
     $email = strtolower($email);
 
-    if (in_array($email, $disallowed_emails)) {
+    // load ban list from config
+    global $BANLIST;
+
+    if (in_array($email, $BANLIST)) {
         return FALSE;
     } else {
         return TRUE;

--- a/backend/www/manage_event.php
+++ b/backend/www/manage_event.php
@@ -41,6 +41,20 @@ function validate_json_request($data) {
     return $validator->validate(TRUE, TRUE);
 }
 
+function validate_email($email) {
+    // TODO: pull from a config file
+    $disallowed_emails = array('invalid@example.com');
+
+    // lowercase provided email before checking against ban list
+    $email = strtolower($email);
+
+    if (in_array($email, $disallowed_emails)) {
+        return FALSE;
+    } else {
+        return TRUE;
+    }
+}
+
 function upload_attached_file($event, $messages) {
     if (isset($_FILES['file'])) {
         $uploader = new fUpload();
@@ -175,6 +189,10 @@ function build_json_response() {
     }
 
     $messages = validate_json_request($data);
+
+    if (!validate_email($data['email'])) {
+        $messages['email'] = "Email is invalid";
+    }
 
     if (!$data['read_comic']) {
         $messages['read_comic'] = "You must have read the Ride Leading Comic";


### PR DESCRIPTION
See issue #138: 
* Banned emails are pulled from `backend/config.php`. Two default test values are provided (`invalid@example.com`, `anything@banned.biz`). 
* Email is lowercased before checking, so input match isn't case-sensitive. 
* If the email is not allowed, the API returns a `400` error with message `Email is invalid`.

This should be tested with a variety of input to ensure that there aren't any false positives. I tested it  locally a good deal, but since it touches the config we should make sure it works when deployed.