### PR TITLE
Add Event - Image upload available only after event is confirmed

### DIFF
--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
@@ -109,7 +109,7 @@
               <div class="image-form">
                 <div class="image-display">
                   [[^ image]]
-                  <img src="{{ .Site.BaseURL }}legacycalimages/icons/image.svg" alt="" class="event-image" style="opacity: 0.5;" />
+                  <img src="{{ .Site.BaseURL }}legacycalimages/icons/image.svg" alt="" class="event-image placeholder" />
                   [[/ image]]
                   [[# image]]
                   <a href="[[image]]" target="_blank" title="View full size in a new window">

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
@@ -103,26 +103,31 @@
               </select>
             </div>
 
-            [[# image]]
-            <img src="[[image]]" />
-            [[/ image]]
-
             <div class="form-group">
-              [[^ image]]
               <label class="control-label optional-label" for="image">Image</label>
-              [[/ image]]
-              [[# image]]
-              <label class="control-label optional-label" for="image">Update Image</label>
-              [[/ image]]
 
-              [[^ id ]]
-              <input type="file" class="form-control" name="image" id="image" aria-describedby="image-help" disabled />
-              <p class="input-help" id="image-help">To add an image, save and confirm the event first.</p>
-              [[/ id ]]
-              [[# id ]]
-              <input type="file" class="form-control" name="image" id="image" aria-describedby="image-help" />
-              <p class="input-help" id="image-help">Image files must be less than 2 <abbr title="megabytes">MB</abbr>.</p>
-              [[/ id ]]
+              <div class="image-form">
+                <div class="image-display">
+                  [[^ image]]
+                  <img src="{{ .Site.BaseURL }}legacycalimages/icons/image.svg" alt="" class="event-image" style="opacity: 0.5;" />
+                  [[/ image]]
+                  [[# image]]
+                  <a href="[[image]]" target="_blank" title="View full size in a new window">
+                    <img src="[[image]]" alt="User-uploaded image" class="event-image" />
+                  </a>
+                  [[/ image]]
+                </div>
+                <div class="image-input">
+                  [[^ id ]]
+                  <input type="file" class="form-control" name="image" id="image" aria-describedby="image-help" disabled />
+                  <p class="input-help" id="image-help">To add an image, save and confirm the event first.</p>
+                  [[/ id ]]
+                  [[# id ]]
+                  <input type="file" class="form-control" name="image" id="image" aria-describedby="image-help" />
+                  <p class="input-help" id="image-help">Image files must be less than 2 <abbr title="megabytes">MB</abbr>.</p>
+                  [[/ id ]]
+                </div>
+              </div>
             </div>
 
           </div>

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
@@ -106,14 +106,23 @@
             [[# image]]
             <img src="[[image]]" />
             [[/ image]]
+
             <div class="form-group">
-              [[# image]]
-              <label class="control-label optional-label" for="image">Update Image (must have file size less than 2MB) </label>
-              [[/ image]]
               [[^ image]]
-              <label class="control-label optional-label" for="image">Image (must have file size less than 2MB) </label>
+              <label class="control-label optional-label" for="image">Image</label>
               [[/ image]]
-              <input type="file" class="form-control" name="image" id="image" />
+              [[# image]]
+              <label class="control-label optional-label" for="image">Update Image</label>
+              [[/ image]]
+
+              [[^ id ]]
+              <input type="file" class="form-control" name="image" id="image" aria-describedby="image-help" disabled />
+              <p class="input-help" id="image-help">To add an image, save and confirm the event first.</p>
+              [[/ id ]]
+              [[# id ]]
+              <input type="file" class="form-control" name="image" id="image" aria-describedby="image-help" />
+              <p class="input-help" id="image-help">Image files must be less than 2 <abbr title="megabytes">MB</abbr>.</p>
+              [[/ id ]]
             </div>
 
           </div>

--- a/site/themes/s2b_hugo_theme/static/css/main_fun_legacy.css
+++ b/site/themes/s2b_hugo_theme/static/css/main_fun_legacy.css
@@ -570,6 +570,15 @@ button.more-events {
   max-height: 200px;
 }
 
+#event-fields .image-form .image-display img.placeholder {
+  width: 80px;
+  height: 80px;
+  border: 2px dashed #707070;
+  border-radius: 2px;
+  padding: 4px;
+  opacity: 0.5;
+}
+
 .ride-comic {
     margin-top: 10px;
     margin-bottom: 10px;

--- a/site/themes/s2b_hugo_theme/static/css/main_fun_legacy.css
+++ b/site/themes/s2b_hugo_theme/static/css/main_fun_legacy.css
@@ -554,6 +554,22 @@ button.more-events {
     transform: rotate(-90deg);
 }
 
+#event-fields .image-form {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+#event-fields .image-form .image-display {
+  margin-right: 1em;
+}
+
+#event-fields .image-form .image-display img {
+  max-width: 200px;
+  max-height: 200px;
+}
+
 .ride-comic {
     margin-top: 10px;
     margin-bottom: 10px;


### PR DESCRIPTION
While we continue to chase down gremlins in the image uploader, this change will defensively prohibit image uploads until after the event is saved & confirmed. This isn't ideal — you *should* be able to add an image during initial event creation. But dealing with event images is one of the most common support issues we have, so this shortcuts it. At least this way the problem is narrowed to "How do I get an image added to my event?" instead of "How can I get my event posted?" 

There are 3 states for the Image field: 
* When initially creating an event, the image uploader is disabled. A placeholder image is displayed. 
* After the event is saved & confirmed, the image uploader becomes enabled. A placeholder image is displayed here unless you replace it.
* If you upload an image, save the event, and reload the form, a thumbnail of the image will be displayed. Clicking the thumbnail opens the full image in another tab. 