### PR TITLE
Calendar - date jump links

### DIFF
--- a/site/themes/s2b_hugo_theme/layouts/caledit/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/caledit/single.html
@@ -56,9 +56,6 @@
 
   <script type="text/javascript">
     window.legacycal_renderpage = "{{ .Params.id }}";
-    console.log("window.legacycal_renderpage: ", window.legacycal_renderpage);
-
-    console.log("legacycalpage/single.html - 2");
   </script>
 
 </body>

--- a/site/themes/s2b_hugo_theme/layouts/calevents/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/calevents/single.html
@@ -62,9 +62,6 @@
 
   <script type="text/javascript">
     window.legacycal_renderpage = "{{ .Params.id }}";
-    console.log("window.legacycal_renderpage: ", window.legacycal_renderpage);
-
-    console.log("legacycalpage/single.html - 2");
   </script>
 
 </body>

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
@@ -30,6 +30,7 @@
         },
         nowIndicator: true,
         eventLimit: true,
+        navLinks: true,
         events: '{{ .Site.BaseURL }}api/events.php',
         startParam: 'startdate',
         endParam: 'enddate',
@@ -136,82 +137,6 @@
 </script>
 
 {{ partial "cal-icons.html" . }}
-
-<script id="jump-to-date" type="text/template">
-  <button type="button" aria-expanded="false" data-toggle-target="#date-select-container-pedalpalooza" class="jump-to-date">
-    <span>Jump to date</span>
-    <svg class="icon expand" role="img" aria-hidden="true">
-      <use xlink:href="#icon-arrow-down" />
-    </svg>
-  </button>
-  <div id="date-select-container-pedalpalooza" class="date-select-container-style jump-to-date form-group" hidden>
-    <table class="day-of-week">
-      <tbody><tr>
-        <td class="calendar-month-title"></td>
-        <td>Sun</td>
-        <td>Mon</td>
-        <td>Tue</td>
-        <td>Wed</td>
-        <td>Thu</td>
-        <td>Fri</td>
-        <td>Sat</td>
-      </tr></tbody>
-    </table>
-    <div id="date-select-pp">
-      <table id="date-picker-pedalpalooza" class="date-picker-style">
-        <tr class="calendar-row">
-          <td rowspan="3" class="calendar-month-title"><span>June 2018</span></td>
-          <td class="calendar-day   color-jun"></td>
-          <td class="calendar-day   color-jun-odd"></td>
-          <td class="calendar-day   color-jun"></td>
-          <td class="calendar-day   color-jun-odd"></td>
-          <td class="calendar-day   color-jun"></td>
-          <td class="calendar-day   color-jun-odd featured" data-date="2018-06-01" aria-describedby="pp-featured-day-label">1</td>
-          <td class="calendar-day   color-jun" data-date="2018-06-02">2</td>
-        </tr>
-        <tr class="calendar-row">
-          <td class="calendar-day   color-jun" data-date="2018-06-03">3</td>
-          <td class="calendar-day   color-jun-odd" data-date="2018-06-04">4</td>
-          <td class="calendar-day   color-jun featured" data-date='2018-06-05' aria-describedby="pp-featured-day-label">5</td>
-          <td class="calendar-day   color-jun-odd" data-date="2018-06-06">6</td>
-          <td class="calendar-day   color-jun" data-date="2018-06-07">7</td>
-          <td class="calendar-day   color-jun-odd featured" data-date="2018-06-08" aria-describedby="pp-featured-day-label">8</td>
-          <td class="calendar-day   color-jun featured" data-date="2018-06-09" aria-describedby="pp-featured-day-label">9</td>
-        </tr>
-        <tr class="calendar-row">
-          <td class="calendar-day   color-jun" data-date="2018-06-10">10</td>
-          <td class="calendar-day   color-jun-odd" data-date="2018-06-11">11</td>
-          <td class="calendar-day   color-jun" data-date='2018-06-12'>12</td>
-          <td class="calendar-day   color-jun-odd" data-date="2018-06-13">13</td>
-          <td class="calendar-day   color-jun" data-date="2018-06-14">14</td>
-          <td class="calendar-day   color-jun-odd featured" data-date="2018-06-15" aria-describedby="pp-featured-day-label">15</td>
-          <td class="calendar-day   color-jun featured" data-date="2018-06-16" aria-describedby="pp-featured-day-label">16</td>
-        </tr>
-        <tr class="calendar-row">
-          <td rowspan="2" class="calendar-month-title">&nbsp;</td>
-          <td class="calendar-day   color-jun" data-date="2018-06-17">17</td>
-          <td class="calendar-day   color-jun-odd" data-date="2018-06-18">18</td>
-          <td class="calendar-day   color-jun" data-date="2018-06-19">19</td>
-          <td class="calendar-day   color-jun-odd" data-date="2018-06-20">20</td>
-          <td class="calendar-day   color-jun" data-date="2018-06-21">21</td>
-          <td class="calendar-day   color-jun-odd" data-date="2018-06-22">22</td>
-          <td class="calendar-day   color-jun featured" data-date="2018-06-23" aria-describedby="pp-featured-day-label">23</td>
-        </tr>
-
-        <tr class="calendar-row">
-          <td class="calendar-day   color-jun featured" data-date="2018-06-24" aria-describedby="pp-featured-day-label">24</td>
-          <td class="calendar-day   color-jun-odd" data-date="2018-06-25">25</td>
-          <td class="calendar-day   color-jun" data-date="2018-06-26">26</td>
-          <td class="calendar-day   color-jun-odd featured" data-date="2018-06-27" aria-describedby="pp-featured-day-label">27</td>
-          <td class="calendar-day   color-jun" data-date="2018-06-28">28</td>
-          <td class="calendar-day   color-jun-odd" data-date="2018-06-29">29</td>
-          <td class="calendar-day   color-jun featured" data-date="2018-06-30" aria-describedby="pp-featured-day-label">30</td>
-        </tr>
-      </table>
-    </div>
-    <p class="legend" aria-hidden="true"><span class="example">★</span> = <span id="pp-featured-day-label">day with featured event</span></p>
-  </div>
-</script>
 
 <script id="scrollToTop" type="text/template">
   <a href="#" class="scrollToTop">Back To Top</a>

--- a/site/themes/s2b_hugo_theme/layouts/partials/scripts.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/scripts.html
@@ -28,6 +28,5 @@
     $(".s2b-external-link").attr("rel", "noopener");
     $(".s2b-external-link").attr("title", "Opens in a new window");
     $(".s2b-external-link").prepend($("<i class='glyphicon glyphicon-new-window' aria-hidden='true'></i>"));
-    //console.log("decorated links")
   });
 </script>

--- a/site/themes/s2b_hugo_theme/static/css/main_fun_legacy.css
+++ b/site/themes/s2b_hugo_theme/static/css/main_fun_legacy.css
@@ -339,9 +339,6 @@ a.expand-details {
 #date-select-container {
     margin: 0 auto;
 }
-#date-select-container-pedalpalooza {
-    margin: 10px 0px;
-}
 .date-select-container-style {
     width: 310px;
     background-color: #fff56f;
@@ -368,10 +365,6 @@ button.jump-to-date[aria-expanded="true"] .icon.expand {
 
 #date-select {
     height: 140px;
-}
-
-#date-select-pp {
-    background-color: #ffbd2c;
 }
 
 .date-select-style {

--- a/site/themes/s2b_hugo_theme/static/legacycaljs/main.js
+++ b/site/themes/s2b_hugo_theme/static/legacycaljs/main.js
@@ -164,21 +164,6 @@ $(document).ready(function() {
         });
     }
 
-    function dateJump(ev) {
-        var e = ev.target;
-        if (e.hasAttribute('data-date')) {
-            var $e = $(e);
-            var yyyymmdd = $e.attr('data-date');
-            var $jumpTo = $("div[data-date='" + yyyymmdd + "']");
-            if($jumpTo.children().length >= 0) {
-
-                $('html, body').animate({
-                    scrollTop: $jumpTo.offset().top
-                }, 500);
-            }
-        }
-    }
-
     function viewAddEventForm(id, secret) {
         container.getAddEventForm( id, secret, function(eventHTML) {
             container.empty().append(eventHTML);
@@ -194,14 +179,6 @@ $(document).ready(function() {
 
     $(document).on('click', '#confirm-cancel, #success-ok', function() {
         visitRoute('viewEvents');
-    });
-
-    $(document).on('click', '#date-picker-pedalpalooza', function(ev) {
-        dateJump(ev);
-    });
-
-    $(document).on('touchstart', '#date-picker-pedalpalooza', function(ev) {
-        dateJump(ev);
     });
 
     $(document).on('click', '#date-picker-prev-month', function(ev) {


### PR DESCRIPTION
* Removed old hand-rolled date jump widget; it hasn't been used since we added the month view back.
* Enabled FullCalendar's `navLinks` option, which makes the day labels into links and switches to the day view of the chosen date when clicked. 
* As I was cleaning up my debugging on this feature, I also found a few stray `console.log` calls in other various files so I removed those. 

Addresses #190. 