### PR TITLE
Calendar -  Add more details to ICS export

### DIFF
--- a/backend/iCalExporter.php
+++ b/backend/iCalExporter.php
@@ -59,10 +59,15 @@ class iCalExporter {
 		$this->append( "DTSTART:$startString" );
 		if ( !empty( $details['eventduration'] ) ) {
 			$durString = "PT{$details['eventduration']}M";
-			$date->add( new DateInterval( $durString ) );
-			$endString = $this->formatTime( $date->getTimestamp() );
-			$this->append( "DTEND:$endString" );
 		}
+		else {
+			// set duration of 1 hour, if not specified
+			$durString = "PT60M";
+		}
+		$date->add( new DateInterval( $durString ) );
+		$endString = $this->formatTime( $date->getTimestamp() );
+		$this->append( "DTEND:$endString" );
+
 		$location = $this->formatLocation( $details );
 		if ( !empty( $location ) ) {
 			$this->append( "LOCATION:$location" );

--- a/backend/iCalExporter.php
+++ b/backend/iCalExporter.php
@@ -107,6 +107,10 @@ class iCalExporter {
 		if ( !empty( $details['timedetails'] ) ) {
 			$description .= "\\n" . $details['timedetails'];
 		}
+		// if location details are set, append to the description
+		if ( !empty( $details['locdetails'] ) ) {
+			$description .= "\\n" . $details['locdetails'];
+		}
 		// append the event's share link to the description;
 		// this should always be set, but test for prescence to be sure
 		if ( !empty( $details['shareable'] ) ) {

--- a/backend/iCalExporter.php
+++ b/backend/iCalExporter.php
@@ -72,8 +72,12 @@ class iCalExporter {
 		if ( !empty( $location ) ) {
 			$this->append( "LOCATION:$location" );
 		}
+
 		$this->append( "SUMMARY:{$details['title']}" );
-		$this->append( "DESCRIPTION:{$details['details']}" );
+
+		$description = $this->formatDescription( $details );
+		$this->append( "DESCRIPTION:$description" );
+
 		$this->append( 'END:VEVENT' );
 	}
 
@@ -95,6 +99,20 @@ class iCalExporter {
 			$address .= "  {$details['locdetails']}";
 		}
 		return $address;
+	}
+
+	protected function formatDescription( $details ) {
+		$description = $details['details'];
+		// if time details are set, append to the description
+		if ( !empty( $details['timedetails'] ) ) {
+			$description .= "\\n" . $details['timedetails'];
+		}
+		// append the event's share link to the description;
+		// this should always be set, but test for prescence to be sure
+		if ( !empty( $details['shareable'] ) ) {
+			$description .= "\\n" . $details['shareable'];
+		}
+		return $description;
 	}
 
 	protected function append( $string ) {


### PR DESCRIPTION
* Sets default duration of 1 hr, if not otherwise set
* Append time details to description, if set
* Append location details to description, if set (this is getting appended to the address field already, but some clients seem to ignore that part, e.g. Apple Calendar)
* Append share link to description

Addresses #198. 