### PR TITLE
Calendar form updates

### DIFF
--- a/backend/models/Event.php
+++ b/backend/models/Event.php
@@ -79,7 +79,10 @@ class Event extends fActiveRecord {
         $event->setHidecontact(get($input['hidecontact'], 0));
         $event->setDescr(get($input['details'], ''));
         $event->setEventtime(get($input['time'], ''));
-        $event->setHighlight(0);
+        // default highlight to off (zero); but if it's already set, leave it as-is
+        if ( $event->getHighlight() == null ) {
+          $event->setHighlight(0);
+        }
         $event->setTimedetails(get($input['timedetails'], ''));
         $event->setLocdetails(get($input['locdetails'], ''));
         $event->setEventduration(get($input['eventduration'], 0));

--- a/backend/www/manage_event.php
+++ b/backend/www/manage_event.php
@@ -26,7 +26,7 @@ function validate_json_request($data) {
     $_POST = $data; // fValidation inspects $_POST for field data
     $validator = new fValidation();
 
-    $validator->addRequiredFields('title', 'details', 'venue', 'address', 'organizer', 'email', 'read_comic');
+    $validator->addRequiredFields('title', 'details', 'venue', 'address', 'organizer', 'email', 'code_of_conduct', 'read_comic');
     // required only from March to June, during Pedalpalooza
     $validator->addRequiredFields('tinytitle', 'printdescr');
     $validator->addEmailFields('email');

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
@@ -272,12 +272,6 @@
                   Don't publish my email address online
                 </label>
               </div>
-              <div class="checkbox">
-                <label class="control-label" for="email-me">
-                  <input type="checkbox" name="email-me" id="email-me" value="1" [[# emailMe ]]checked[[/ emailMe ]] />
-                  Send forum messages to this email address
-                </label>
-              </div>
             </div>
 
             <div>Website for additional details</div>

--- a/site/themes/s2b_hugo_theme/static/legacycaljs/addevent.js
+++ b/site/themes/s2b_hugo_theme/static/legacycaljs/addevent.js
@@ -70,6 +70,11 @@
             }
         }
         shiftEvent.timeOptions.push({ time: "11:59 PM" });
+        if (!shiftEvent.time) {
+            // default to 5:00pm if not set;
+            // 0 = 12:00am, 1 = 12:15am, 2 = 12:30am, ... 68 = 5:00pm
+            shiftEvent.timeOptions[68].isSelected = true;
+        }
 
         if (!shiftEvent.audience) {
             shiftEvent.audience = 'G';


### PR DESCRIPTION
* Removed the now-unused forum checkbox
* Default event time to 5pm
* The featured event flag is no longer clobbered when an event is updated
* Added a secondary check that code of conduct was agreed to