### PR TITLE
FullCal bug fixes & clean-up

### DIFF
--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
@@ -31,43 +31,46 @@
         nowIndicator: true,
         eventLimit: true,
         navLinks: true,
-        events: '{{ .Site.BaseURL }}api/events.php',
-        startParam: 'startdate',
-        endParam: 'enddate',
-        eventSourceSuccess: function( content ) {
-          // our API returns { "events": [ ] }
-          // and this will return just the inner array as fullcalendar expects
-          return content.events;
-        },
-        eventDataTransform: function( eventData ) {
-          // this transforms the data for individual rides
-          // into the format needed by fullcalendar
-          var event = {
-              id: eventData.caldaily_id,
-              title: (eventData.tinytitle ? eventData.tinytitle : eventData.title),
-              start: eventData.date + 'T' + eventData.time
-          };
+        eventSources: [
+          {
+            url: '{{ .Site.BaseURL }}api/events.php',
+            startParam: 'startdate',
+            endParam: 'enddate',
+            success: function( content ) {
+              // our API returns { "events": [ ] }
+              // and this will return just the inner array as fullcalendar expects
+              return content.events;
+            },
+            eventDataTransform: function( eventData ) {
+              // this transforms the data for individual rides
+              // into the format needed by fullcalendar
+              var event = {
+                  id: eventData.caldaily_id,
+                  title: (eventData.tinytitle ? eventData.tinytitle : eventData.title),
+                  start: eventData.date + 'T' + eventData.time,
+                  url: '/calendar/event-' + eventData.caldaily_id,
+              };
 
-          // Events after Oregon State "stay home" order are all marked as cancelled
-          if ( eventData.date >= {{ .Site.Params.stayHomeStartDate }} ) {
-            eventData.cancelled = true;
-          }
+              // Events after Oregon State "stay home" order are all marked as cancelled
+              if ( eventData.date >= {{ .Site.Params.stayHomeStartDate }} ) {
+                eventData.cancelled = true;
+              }
 
-          if (eventData.cancelled == true) {
-            event.classNames = [ 'cancelled' ];
-          }
-          if (eventData.featured == true) {
-            event.classNames = [ 'featured' ];
-          }
-          return event;
-        },
-        eventClick: function ( info ) {
-          // what happens when you click an event from the calendar grid
-          window.open("/calendar/event-" + info.event.id, "_self");
-        }
+              event.classNames = [];
+              if (eventData.cancelled == true) {
+                event.classNames.push('cancelled');
+              }
+              if (eventData.featured == true) {
+                event.classNames.push('featured');
+              }
+
+              return event;
+            },
+          },
+        ]
       });
 
-        calendar.render();
+      calendar.render();
     });
 
   }
@@ -115,6 +118,7 @@
   [[#dates]]
   <div data-date="[[yyyymmdd]]" class="date[[#preview]] preview[[/preview]]">
     <h2>[[date]]</h2>
+
     <ul class="events-list">
       [[#events]]
 

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/fullcal.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/fullcal.html
@@ -34,40 +34,42 @@
       nowIndicator: true,
       eventLimit: true,
       navLinks: true,
-      events: '{{ .Site.BaseURL }}api/events.php',
-      startParam: 'startdate',
-      endParam: 'enddate',
-      eventSourceSuccess: function( content ) {
-        // our API returns { "events": [ ] }
-        // and this will return just the inner array as fullcalendar expects
-        return content.events;
-      },
-      eventDataTransform: function( eventData ) {
-        // this transforms the data for individual rides
-        // into the format needed by fullcalendar
-        var event = {
-            id: eventData.caldaily_id,
-            title: (eventData.tinytitle ? eventData.tinytitle : eventData.title),
-            start: eventData.date + 'T' + eventData.time
-        };
+      eventSources: [
+        {
+          url: '{{ .Site.BaseURL }}api/events.php',
+          startParam: 'startdate',
+          endParam: 'enddate',
+          success: function( content ) {
+            // our API returns { "events": [ ] }
+            // and this will return just the inner array as fullcalendar expects
+            return content.events;
+          },
+          eventDataTransform: function( eventData ) {
+            // this transforms the data for individual rides
+            // into the format needed by fullcalendar
+            var event = {
+                id: eventData.caldaily_id,
+                title: (eventData.tinytitle ? eventData.tinytitle : eventData.title),
+                start: eventData.date + 'T' + eventData.time,
+                url: '/calendar/event-' + eventData.caldaily_id,
+            };
 
-        // Events after Oregon State "stay home" order are all marked as cancelled
-        if ( eventData.date >= {{ .Site.Params.stayHomeStartDate }} ) {
-          eventData.cancelled = true;
-        }
+            // Events after Oregon State "stay home" order are all marked as cancelled
+            if ( eventData.date >= {{ .Site.Params.stayHomeStartDate }} ) {
+              eventData.cancelled = true;
+            }
 
-        if (eventData.cancelled == true) {
-          event.classNames = [ 'cancelled' ];
+            event.classNames = [];
+            if (eventData.cancelled == true) {
+              event.classNames.push('cancelled');
+            }
+            if (eventData.featured == true) {
+              event.classNames.push('featured');
+            }
+            return event;
+          },
         }
-        if (eventData.featured == true) {
-          event.classNames = [ 'featured' ];
-        }
-        return event;
-      },
-      eventRender: function(info) {
-        link = info.el;
-        link.setAttribute('href', '/calendar/event-' + info.event.id, '_self');
-      },
+      ]
     });
 
     calendar.render();

--- a/site/themes/s2b_hugo_theme/layouts/partials/up-next.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/up-next.html
@@ -24,41 +24,43 @@
           buttonText: '2 day'
         }
       },
-      events: '{{ .Site.BaseURL }}api/events.php',
-      startParam: 'startdate',
-      endParam: 'enddate',
-      eventSourceSuccess: function( content ) {
-        // our API returns { "events": [ ] }
-        // and this will return just the inner array as fullcalendar expects
-        return content.events;
-      },
-      eventDataTransform: function( eventData ) {
-        // this transforms the data for individual rides
-        // into the format needed by fullcalendar
-        var event = {
-            id: eventData.caldaily_id,
-            title: eventData.title, // full-length title is OK in list view
-            start: eventData.date + 'T' + eventData.time
-        };
-
-        // Events after Oregon State "stay home" order are all marked as cancelled
-        if ( eventData.date >= {{ .Site.Params.stayHomeStartDate }} ) {
-          eventData.cancelled = true;
-        }
-
-        if (eventData.cancelled == true) {
-          event.classNames = [ 'cancelled' ];
-        }
-        if (eventData.featured == true) {
-          event.classNames = [ 'featured' ];
-        }
-        return event;
-      },
-      eventRender: function(info) {
-        link = info.el.getElementsByTagName("a")[0];
-        link.setAttribute('href', '/calendar/event-' + info.event.id, '_self');
-      },
       noEventsMessage: "No events happening today or tomorrow",
+      eventSources: [
+        {
+          url: '{{ .Site.BaseURL }}api/events.php',
+          startParam: 'startdate',
+          endParam: 'enddate',
+          success: function( content ) {
+            // our API returns { "events": [ ] }
+            // and this will return just the inner array as fullcalendar expects
+            return content.events;
+          },
+          eventDataTransform: function( eventData ) {
+            // this transforms the data for individual rides
+            // into the format needed by fullcalendar
+            var event = {
+                id: eventData.caldaily_id,
+                title: eventData.title, // full-length title is OK in list view
+                start: eventData.date + 'T' + eventData.time,
+                url: '/calendar/event-' + eventData.caldaily_id,
+            };
+
+            // Events after Oregon State "stay home" order are all marked as cancelled
+            if ( eventData.date >= {{ .Site.Params.stayHomeStartDate }} ) {
+              eventData.cancelled = true;
+            }
+
+            event.classNames = [];
+            if (eventData.cancelled == true) {
+              event.classNames.push('cancelled');
+            }
+            if (eventData.featured == true) {
+              event.classNames.push('featured');
+            }
+            return event;
+          },
+        }
+      ]
     });
 
     calendar.render();


### PR DESCRIPTION
* Removed custom click/link handling of calendar events, in favor of FullCal's built-in `url` attribute. Previously, I didn't understand how it worked and wrote code I didn't need to. 
* Fixed styles for events that are both featured and cancelled (previously, only the featured style would be applied). 
* Switched from single-source `events` attribute to `eventSources` array. This adds some general clarity around which settings are specific to the event data source and which ones apply generally to FullCal's appearance/configuration. It also supports multiple sources, so if we want to add another data source in the future (such as a list of theme days, as has been suggested) we can do so more easily. 