### PR TITLE
Calendar - moved cancelled status modifier to back end

### DIFF
--- a/backend/models/EventTime.php
+++ b/backend/models/EventTime.php
@@ -106,12 +106,23 @@ class EventTime extends fActiveRecord {
         return "$base/calendar/event-" . $caldaily_id;
     }
 
+    protected function getCancelled() {
+        if ($this->getEventstatus() == 'C') {
+            return true;
+        } elseif ($this->getFormattedDate() >= '2020-03-23') {
+            // stay home start date
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     public function toEventSummaryArray() {
         $eventArray = $this->getEvent()->toArray();
         $eventArray['date'] = $this->getFormattedDate();
         $eventArray['caldaily_id'] = $this->getPkid();
         $eventArray['shareable'] = $this->getShareable();
-        $eventArray['cancelled'] = $this->getEventstatus() == 'C';
+        $eventArray['cancelled'] = $this->getCancelled();
         $eventArray['newsflash'] = $this->getNewsflash();
         $eventArray['endtime'] = $this->getEndTime($eventArray['time'], $eventArray['eventduration']);
 

--- a/site/config.toml
+++ b/site/config.toml
@@ -176,8 +176,6 @@ paginate = 10
     latitude = "-12.043333"
     longitude = "-77.028333"
 
-    stayHomeStartDate = "2020-03-23"
-
 [Permalinks]
     blog = "/blog/:year/:month/:day/:filename/"
 

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
@@ -51,11 +51,6 @@
                   url: '/calendar/event-' + eventData.caldaily_id,
               };
 
-              // Events after Oregon State "stay home" order are all marked as cancelled
-              if ( eventData.date >= {{ .Site.Params.stayHomeStartDate }} ) {
-                eventData.cancelled = true;
-              }
-
               event.classNames = [];
               if (eventData.cancelled == true) {
                 event.classNames.push('cancelled');

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/fullcal.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/fullcal.html
@@ -54,11 +54,6 @@
                 url: '/calendar/event-' + eventData.caldaily_id,
             };
 
-            // Events after Oregon State "stay home" order are all marked as cancelled
-            if ( eventData.date >= {{ .Site.Params.stayHomeStartDate }} ) {
-              eventData.cancelled = true;
-            }
-
             event.classNames = [];
             if (eventData.cancelled == true) {
               event.classNames.push('cancelled');

--- a/site/themes/s2b_hugo_theme/layouts/partials/head.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/head.html
@@ -90,6 +90,4 @@
   <link rel="stylesheet" type="text/css" href="/legacycaljs/fullcalendar/list/main.min.css"/>
   {{ end }}
 
-  <meta name="stay_home_start_date" content="{{ .Site.Params.stayHomeStartDate }}" />
-
 </head>

--- a/site/themes/s2b_hugo_theme/layouts/partials/up-next.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/up-next.html
@@ -45,11 +45,6 @@
                 url: '/calendar/event-' + eventData.caldaily_id,
             };
 
-            // Events after Oregon State "stay home" order are all marked as cancelled
-            if ( eventData.date >= {{ .Site.Params.stayHomeStartDate }} ) {
-              eventData.cancelled = true;
-            }
-
             event.classNames = [];
             if (eventData.cancelled == true) {
               event.classNames.push('cancelled');

--- a/site/themes/s2b_hugo_theme/static/legacycaljs/main.js
+++ b/site/themes/s2b_hugo_theme/static/legacycaljs/main.js
@@ -32,13 +32,6 @@ $(document).ready(function() {
                   value.displayEndTime = container.formatTime(value.endtime);
                 }
 
-                // Events after Oregon State "stay home" order are all marked as cancelled;
-                // can't reference Hugo variables directly in JS, so pull the date from page meta tags
-                var STAY_HOME_START_DATE = document.getElementsByName('stay_home_start_date')[0].content;
-                if (value.date >= STAY_HOME_START_DATE) {
-                  value.cancelled = true;
-                }
-
                 value.audienceLabel = container.getAudienceLabel(value.audience);
                 value.mapLink = container.getMapLink(value.address);
 


### PR DESCRIPTION
Follow-up to #255: 
* The 'stay home' cancelled check has been moved to the API level. The non-privileged `events` endpoints returns the modified cancelled status. The privileged management endpoints (`manage_event` and `retrieve_event`, when secret is provided) still returns the true status. The actual status in the database remains unaffected.  
* Events (past, present or future) that were properly cancelled by the host are still correctly marked as cancelled. 
* Removed now-unneeded front end hacks.

The result on the front end should be the same — when viewing the calendar, any event on or after March 23, 2020, should appear cancelled. 