### PR TITLE
Pedalpalooza 2020 calendar

### DIFF
--- a/site/content/pedalpalooza-calendar.md
+++ b/site/content/pedalpalooza-calendar.md
@@ -3,25 +3,19 @@ title: "Pedalpalooza calendar"
 description: "Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
-type: pp-landing
+type: pp-cal
 pp: true
 year: 2020
 startdate: 2020-06-01
-enddate: 2020-07-05
+enddate: 2020-07-06 # end date is exclusive
 daterange: June 1–July 5, 2020
 banner-image: "/images/pp/pp2020-banner.png"
 poster-image: "/images/pp/pp2020.png"
 
 ---
 
-----
-
 <strong class="pp-headline">Pedalpalooza is going to be different this year!</strong>
 
 Pedalpalooza 2020 is about individuals finding ways to celebrate the joy of cycling. We will not be encouraging people to gather, as we have in previous years.
 
-Join the movement! Find out ways you can promote #bikefun separately, but together.
-
-<p class="pp-headline">Check out <a href="http://pedalpalooza.org">Pedalpalooza.org</a> for themed solo ride ideas!</p>
-
-More details coming here soon!
+**But wait!** You can still have #bikefun — separately, but together! Check out the solo ride themes below, and see [Pedalpalooza.org](https://www.pedalpalooza.org/ride) for more info.

--- a/site/data/carousel/pedalpalooza.yaml
+++ b/site/data/carousel/pedalpalooza.yaml
@@ -1,5 +1,5 @@
 weight: 1
 title: "Pedalpalooza"
-description: "<p>June 1 to July 5, 2020 &mdash; <br>over a month of bike fun!</p>"
+description: "<p>June 1 to July 5, 2020 &mdash; <br>over a month of <br>(separate but shared) bike fun!</p>"
 image: "images/carousel/pedalpalooza-2020.png"
 link: "/pedalpalooza-calendar/"

--- a/site/themes/s2b_hugo_theme/layouts/partials/alert_banner.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/alert_banner.html
@@ -1,6 +1,6 @@
 <div id="alert-banner" class="newsflash">
   <div>
     <p><strong><a href="https://govstatus.egov.com/OR-OHA-COVID-19">Regarding the  COVID-19 pandemic</a>: The Oregon Health Authority is responding to an outbreak of respiratory illness, called COVID-19, caused by a novel (new) coronavirus. Health officials urge <a href="https://sharedsystems.dhsoha.state.or.us/DHSForms/Served/le2268.pdf">social distancing</a>, good hand hygiene, covering coughs, and staying home if you are sick. For additional information and resources, see the <a href="https://multco.us/novel-coronavirus-covid-19/novel-coronavirus-covid-19-faq">Multnomah County COVID-19 FAQ</a>.</strong></p>
-    <p><strong>To stem the spread of COVID-19 in Oregon, <a href="https://www.oregon.gov/newsroom/Pages/NewsDetail.aspx?newsid=36240">Executive Order 20-12</a> prohibits all non-essential social and recreational gatherings of individuals, regardless of size. Until further notice, all events on or after March 23, 2020 are cancelled. Stay safe and stay home!</strong></p>
+    <p><strong>To stem the spread of COVID-19 in Oregon, <a href="https://www.oregon.gov/newsroom/Pages/NewsDetail.aspx?newsid=36240">Executive Order 20-12</a> prohibits all non-essential social and recreational gatherings of individuals, regardless of size. Until further notice, all events on or after March 23, 2020 are cancelled. Stay safe, stay healthy!</strong></p>
   </div>
 </div>

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/pedalpalooza.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/pedalpalooza.html
@@ -64,4 +64,4 @@
 
 <div id="fullcalendar"></div>
 
-<p style="text-align: center; margin-top: 1.5em;">Got an idea for an open day? <a href="https://forms.gle/GRVGLAVzu4AZYdnV8">Submit a theme!</a></p>
+<p style="text-align: center; margin-top: 1.5em;">Got an idea? <a href="https://forms.gle/GRVGLAVzu4AZYdnV8">Submit a theme</a> or <a href="https://forms.gle/YdwYqnS2KAhCiC1Y8">share a route</a>!</p>

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/pedalpalooza.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/pedalpalooza.html
@@ -1,0 +1,66 @@
+<script src="{{ .Site.BaseURL }}legacycaljs/fullcalendar/core/main.min.js"></script>
+<script src="{{ .Site.BaseURL }}legacycaljs/fullcalendar/daygrid/main.min.js"></script>
+<script src="{{ .Site.BaseURL }}legacycaljs/fullcalendar/timegrid/main.min.js"></script>
+<script src="{{ .Site.BaseURL }}legacycaljs/fullcalendar/list/main.min.js"></script>
+
+{{ partial "cal/pp-2020-themes.html" . }}
+
+<script type="text/javascript">
+  document.addEventListener('DOMContentLoaded', function() {
+    var calendarEl = document.getElementById('fullcalendar');
+  
+    var calendar = new FullCalendar.Calendar(calendarEl, {
+      plugins: [ 'dayGrid', 'timeGrid', 'list' ],
+      defaultView: 'dayGridSixWeeks',
+      contentHeight: 'auto',
+      views: {
+        dayGridSixWeeks: {
+          type: 'dayGridMonth',
+          duration: { weeks: 6 },
+          buttonText: 'month'
+        },
+        listDaySixWeeks: {
+          type: 'listDay',
+          duration: { weeks: 6 },
+          buttonText: 'list'
+        }
+      },
+      listDayFormat: {
+        month: 'short',
+        year: 'numeric',
+        day: 'numeric',
+        weekday: 'short'
+      },
+      buttonText: {
+        // dayGridSixWeeks defined in view, above
+        // listDaySixWeeks defined in view, above
+        listDay: 'day'
+      },
+      header: {
+        left: 'prev,next today',
+        center: 'title',
+        right: 'dayGridSixWeeks,listDaySixWeeks,listDay'
+      },
+      noEventsMessage: "Open day — submit a theme at Pedalpalooza.org!",
+      defaultDate: {{ .Param "startdate" }},
+      validRange: {
+        start: {{ .Param "startdate" }},
+        end: {{ .Param "enddate" }}
+      },
+      nowIndicator: true,
+      eventLimit: true,
+      navLinks: true,
+      eventSources: [
+        {
+          events: ppThemesData // from pp-2020-themes.html
+        }
+      ]
+    });
+  
+    calendar.render();
+  });
+</script>
+
+<div id="fullcalendar"></div>
+
+<p style="text-align: center; margin-top: 1.5em;">Got an idea for an open day? <a href="https://forms.gle/GRVGLAVzu4AZYdnV8">Submit a theme!</a></p>

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/pedalpalooza.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/pedalpalooza.html
@@ -52,7 +52,8 @@
       navLinks: true,
       eventSources: [
         {
-          events: ppThemesData // from pp-2020-themes.html
+          events: ppThemesData, // from pp-2020-themes.html
+          allDayDefault: true,
         }
       ]
     });

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-2020-themes.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-2020-themes.html
@@ -1,0 +1,38 @@
+<script type="text/javascript">
+var ppThemesData = [
+  {
+    title: 'Food by Bike',
+    start: '2020-06-01',
+    url: 'https://www.pedalpalooza.org/post/food-by-bike-day-june-1st-2020',
+  },
+  {
+    title: 'Art Friday',
+    start: '2020-06-05',
+  },
+  {
+    title: 'Mystery Day',
+    start: '2020-06-12',
+  },
+  {
+    title: 'For the Birds',
+    start: '2020-06-14',
+  },
+  {
+    title: 'Rainbow Day',
+    start: '2020-06-18',
+  },
+  {
+    title: 'Loud n Lit',
+    start: '2020-06-19',
+  },
+  {
+    title: 'Ride Naked',
+    start: '2020-06-27',
+    url: 'https://pdxwnbr.org/'
+  },
+  {
+    title: 'Stars & Stripes',
+    start: '2020-07-04',
+  },
+]
+</script>

--- a/site/themes/s2b_hugo_theme/layouts/partials/head.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/head.html
@@ -73,19 +73,19 @@
   <meta property="og:image:width" content="1200" />
 
   <!-- load calendar styles on calendar list, edit, or grid pages, or on homepage for "up next" widget -->
-  {{ if or (eq .Type "calevents") (eq .Type "caledit") (eq .Type "calgrid") (eq .Type "pp-landing") (eq .Type "homepage") }}
+  {{ if or (eq .Type "calevents") (eq .Type "caledit") (eq .Type "calgrid") (eq .Type "pp-landing") (eq .Type "pp-cal") (eq .Type "homepage") }}
   <link rel="stylesheet" type="text/css" href="/css/main_fun_legacy.css">
   {{ end }}
 
   <!-- only load grid view styles on calendar list pages; not needed on edit pages -->
-  {{ if or (eq .Type "calevents") (eq .Type "calgrid") }}
+  {{ if or (eq .Type "calevents") (eq .Type "calgrid") (eq .Type "pp-cal") }}
   <link rel="stylesheet" type="text/css" href="/legacycaljs/fullcalendar/core/main.min.css">
   <link rel="stylesheet" type="text/css" href="/legacycaljs/fullcalendar/daygrid/main.min.css">
   <link rel="stylesheet" type="text/css" href="/legacycaljs/fullcalendar/timegrid/main.min.css">
   {{ end }}
 
-  <!-- only load list view styles on homepage for "up next" widget -->
-  {{ if eq .Type "homepage" }}
+  <!-- only load list view styles on homepage for "up next" widget and PP cal page -->
+  {{ if or (eq .Type "homepage") (eq .Type "pp-cal") }}
   <link rel="stylesheet" type="text/css" href="/legacycaljs/fullcalendar/core/main.min.css"/>
   <link rel="stylesheet" type="text/css" href="/legacycaljs/fullcalendar/list/main.min.css"/>
   {{ end }}

--- a/site/themes/s2b_hugo_theme/layouts/pp-cal/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/pp-cal/single.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="{{ .Site.LanguageCode }}">
+
+{{ partial "head.html" . }}
+
+<body>
+  <!-- legacycalpage/single.html -->
+
+  <div id="all">
+    <header>
+      {{ partial "nav.html" . }}
+    </header>
+
+    <main>
+        {{ partial "breadcrumbs.html" . }}
+
+        <div id="content">
+          <div class="container">
+
+            <div class="row">
+
+              <div class="col-md-12">
+
+<!--                 {{ partial "alert_banner.html" . }} -->
+
+                  <!-- modified pp_heading partial -->
+                  <div id="pp-banner">
+                    <a href="{{ .Param "poster-image" }}"><img alt="Pedalpalooza" id="pedalpalooza-img" src="{{ .Param "banner-image" }}"></a>
+                    {{ .Content }}
+                  </div> <!-- end pp_heading -->
+
+                {{ partial "cal/pedalpalooza.html" . }}
+
+                {{ partial "disclaimer.html" . }}
+
+              </div>
+
+            </div>
+            <!-- /.row -->
+
+          </div>
+          <!-- /.container -->
+        </div>
+        <!-- /#content -->
+    </main>
+
+    <footer>
+
+        {{ partial "footer.html" . }}
+
+    </footer>
+
+  </div>
+  <!-- /#all -->
+
+  {{ partial "scripts.html" . }}
+
+</body>
+</html>


### PR DESCRIPTION
Replaces the temp landing page with a special header message, month/list view of themes thus far, and links to submit theme or route ideas. 

The theme data is just getting pulled from a static file, so we'll need to update it manually as the themes are finalized. 