### PR TITLE
Up Next widget for PP

### DIFF
--- a/site/themes/s2b_hugo_theme/layouts/index.html
+++ b/site/themes/s2b_hugo_theme/layouts/index.html
@@ -29,8 +29,7 @@
 
         {{ partial "alert_banner.html" . }}
 
-        <!-- up next now shows PP themes;
-        hide widget until within 1 week of PP -->
+        <!-- up next now shows PP themes; hide widget until within 1 week of PP -->
         {{ if ge (now.Format "2020-01-01") "2020-05-25" }}
           {{ partial "up-next.html" . }}
         {{ end }}

--- a/site/themes/s2b_hugo_theme/layouts/index.html
+++ b/site/themes/s2b_hugo_theme/layouts/index.html
@@ -29,7 +29,11 @@
 
         {{ partial "alert_banner.html" . }}
 
-        {{ partial "up-next.html" . }}
+        <!-- up next now shows PP themes;
+        hide widget until within 1 week of PP -->
+        {{ if ge (now.Format "2020-01-01") "2020-05-25" }}
+          {{ partial "up-next.html" . }}
+        {{ end }}
 
         {{ partial "sponsors.html" . }}
 

--- a/site/themes/s2b_hugo_theme/layouts/partials/up-next.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/up-next.html
@@ -1,6 +1,8 @@
 <script src="{{ .Site.BaseURL }}legacycaljs/fullcalendar/core/main.min.js"></script>
 <script src="{{ .Site.BaseURL }}legacycaljs/fullcalendar/list/main.min.js"></script>
 
+{{ partial "cal/pp-2020-themes.html" . }}
+
 <script type="text/javascript">
   document.addEventListener('DOMContentLoaded', function() {
     var calendarEl = document.getElementById('fullcalendar');
@@ -24,37 +26,42 @@
           buttonText: '2 day'
         }
       },
-      noEventsMessage: "No events happening today or tomorrow",
+//       noEventsMessage: "No events happening today or tomorrow",
+      noEventsMessage: "Open day — submit a theme at Pedalpalooza.org!",
       eventSources: [
         {
-          url: '{{ .Site.BaseURL }}api/events.php',
-          startParam: 'startdate',
-          endParam: 'enddate',
-          success: function( content ) {
-            // our API returns { "events": [ ] }
-            // and this will return just the inner array as fullcalendar expects
-            return content.events;
-          },
-          eventDataTransform: function( eventData ) {
-            // this transforms the data for individual rides
-            // into the format needed by fullcalendar
-            var event = {
-                id: eventData.caldaily_id,
-                title: eventData.title, // full-length title is OK in list view
-                start: eventData.date + 'T' + eventData.time,
-                url: '/calendar/event-' + eventData.caldaily_id,
-            };
-
-            event.classNames = [];
-            if (eventData.cancelled == true) {
-              event.classNames.push('cancelled');
-            }
-            if (eventData.featured == true) {
-              event.classNames.push('featured');
-            }
-            return event;
-          },
-        }
+          events: ppThemesData, // from pp-2020-themes.html
+          allDayDefault: true,
+        },
+//         {
+//           url: '{{ .Site.BaseURL }}api/events.php',
+//           startParam: 'startdate',
+//           endParam: 'enddate',
+//           success: function( content ) {
+//             // our API returns { "events": [ ] }
+//             // and this will return just the inner array as fullcalendar expects
+//             return content.events;
+//           },
+//           eventDataTransform: function( eventData ) {
+//             // this transforms the data for individual rides
+//             // into the format needed by fullcalendar
+//             var event = {
+//                 id: eventData.caldaily_id,
+//                 title: eventData.title, // full-length title is OK in list view
+//                 start: eventData.date + 'T' + eventData.time,
+//                 url: '/calendar/event-' + eventData.caldaily_id,
+//             };
+//
+//             event.classNames = [];
+//             if (eventData.cancelled == true) {
+//               event.classNames.push('cancelled');
+//             }
+//             if (eventData.featured == true) {
+//               event.classNames.push('featured');
+//             }
+//             return event;
+//           },
+//         }
       ]
     });
 


### PR DESCRIPTION
Temporarily changed the homepage Up Next widget to use PP themes instead of events feed. Since it will be empty until June 1, added some logic to hide the widget until PP is about to start (1 week away). 