### PR TITLE
Calendar - double-post error fix

### DIFF
--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
@@ -67,7 +67,7 @@
   <br>
   <form id="event-entry">
     <input type="hidden" name="id" value="[[id]]" />
-    <input type="hidden" name="secret" value="[[secret]]" />
+    <input type="hidden" name="secret" id="secret" value="[[secret]]" />
     <div class="panel-group" id="event-fields">
       <div class="panel panel-default">
         <div class="panel-heading">


### PR DESCRIPTION
Added `id` to hidden `secret` field to match expectation by another script (`addevent.js`). This was mostly a non-issue, with the exception that it could result in a confusing error if an event was double-submitted when it was created. Fixes #233. 
