### PR TITLE
improved helper functions for setting an event's map link and web lin…

### DIFF
--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
@@ -178,23 +178,18 @@
                   [[#cancelled]]<del>[[/cancelled]]
 
                   <div class="location">
-                    [[#mapLink]]
-                    <a href="[[mapLink]]" target="_blank">
+                    <p>
+                      [[#mapLink]]
+                      <a href="[[mapLink]]" target="_blank" rel="noopener" title="Opens in a new window">
+                      [[/mapLink]]
                       <svg class="icon" role="img" aria-label="Location"><use xlink:href="#icon-location" /></svg>
 
-                      [[/mapLink]]
-                      [[^mapLink]]
-                      <p>
-                        [[/mapLink]]
+                      [[venue]][[#address]][[#venue]], [[/venue]][[address]][[/address]]
 
-                        [[venue]][[#address]][[#venue]], [[/venue]][[address]][[/address]]
-
-                        [[^mapLink]]
-                      </p>
-                      [[/mapLink]]
                       [[#mapLink]]
-                    </a>
-                    [[/mapLink]]
+                      </a>
+                      [[/mapLink]]
+                    </p>
 
                     [[#locdetails]]
                     <p>[[locdetails]]</p>
@@ -243,7 +238,7 @@
 
           [[ #weburl ]]
           <p class="contactInfo">
-            <a href="[[webLink]]" target="_blank" rel="noopener">
+            <a href="[[webLink]]" target="_blank" rel="noopener" title="Opens in a new window">
               <svg class="icon" role="img" aria-label="Website"><use xlink:href="#icon-website" /></svg>
               [[#webname]][[webname]][[/webname]]
               [[^webname]][[weburl]][[/webname]]
@@ -307,6 +302,9 @@
   </ul>
   </div>
   [[/dates]]
+  [[^dates]]
+  <p class="no-events">No matching events</p>
+  [[/dates]]
 </script>
 
 <script id="load-more-template" type="text/template">
@@ -314,7 +312,7 @@
 </script>
 
 <script id="show-all-template" type="text/template">
-  <a id="show-all" class="more-events" href="/calendar/">Show all upcoming events</a>
+  <a id="show-all" href="/calendar/">Show all upcoming events</a>
 </script>
 
 <script id="view-as-options" type="text/template">

--- a/site/themes/s2b_hugo_theme/static/css/main_fun_legacy.css
+++ b/site/themes/s2b_hugo_theme/static/css/main_fun_legacy.css
@@ -490,14 +490,23 @@ button.jump-to-date[aria-expanded="true"] .icon.expand {
   text-shadow: none;
 }
 
-button.more-events {
-    display:block;
-    width:100%;
-    text-align:center;
+.more-events {
+    display: block;
+    margin: 0 auto;
+    text-align: center;
     font-size: 1.5em;
     color: #630;
-    background:none;
-    border: 1px solid transparent;
+    background: none;
+    border: 2px solid #630;
+    border-radius: 4px;
+}
+
+.no-events {
+    display: block;
+    width: 100%;
+    text-align: center;
+    font-size: 1.5em;
+    color: #630;
 }
 
 .disclaimer {

--- a/site/themes/s2b_hugo_theme/static/legacycaljs/helpers.js
+++ b/site/themes/s2b_hugo_theme/static/legacycaljs/helpers.js
@@ -16,21 +16,36 @@
     };
 
     $.fn.getMapLink = function(address) {
-        return 'http://maps.google.com/' +
-            '?bounds=45.389771,-122.829208|45.659647,-122.404175&q=' +
-            encodeURIComponent(address);
+        if (address == 'TBA' || address == 'TBD') {
+            // if address isn't available yet, don't try to map it
+            return;
+        }
+
+        var urlPattern = /^https*:\/\//;
+        if (address.match(urlPattern)) {
+            // if address starts with http/s, return it as-is
+            return address;
+        } else {
+            // otherwise, map it with Google Maps
+            return 'https://maps.google.com/' +
+                '?bounds=45.389771,-122.829208|45.659647,-122.404175&q=' +
+                encodeURIComponent(address);
+        }
     };
 
     $.fn.getWebLink = function(url) {
         if (!url) {
+            // if url is not set, return nothing
             return;
         }
-        // if url doesn't start with http/s, prepend http
-        if (url.split('http://').length == 1 && url.split('https://').length == 1) {
-            return 'http://' + url;
-        } else {
-        // if it already starts with http/s, return it as-is
+
+        var urlPattern = /^https*:\/\//;
+        if (url.match(urlPattern)) {
+            // if url already starts with http/s, return it as-is
             return url;
+        } else {
+            // if it doesn't start with http/s, prepend http
+            return 'http://' + url;
         }
     };
 

--- a/site/themes/s2b_hugo_theme/static/legacycaljs/helpers.js
+++ b/site/themes/s2b_hugo_theme/static/legacycaljs/helpers.js
@@ -23,7 +23,7 @@
 
         var urlPattern = /^https*:\/\//;
         if (address.match(urlPattern)) {
-            // if address starts with http/s, return it as-is
+            // if address is a URL rather than a street address, return it as-is
             return address;
         } else {
             // otherwise, map it with Google Maps


### PR DESCRIPTION
* Improved helper functions for setting an event's map link and web link. 
  * When an address is "TBA" or "TBD", don't try to map it (location will be displayed, but won't be a link). 
  * If the location address is already a URL, use that for the map link. We encourage people to enter a real, mappable street address for this field (e.g. 1234 Main St) and that works for most rides. But this will also allow for virtual events, and a way to use an alternative mapping service (like RideWithGPS) if for some reason Google won't properly map the address. 
* Cleaned up event HTML for map link elements. 
* Added visible message when event request doesn't return anything. You can test this by: 
  * Navigating to a future date like `/calendar/?startdate=2021-12-01` and pressing "Show additional events" a few times
  * Navigating to an invalid ride like `/calendar/event-99999`