### PR TITLE
Up Next for PP 2020

### DIFF
--- a/site/themes/s2b_hugo_theme/layouts/index.html
+++ b/site/themes/s2b_hugo_theme/layouts/index.html
@@ -27,10 +27,10 @@
 
         <!--{{ partial "recent_posts.html" . }}-->
 
-<!--         {{ partial "alert_banner.html" . }} -->
+        {{ partial "alert_banner.html" . }}
 
-        <!-- up next now will show PP themes, but hide widget until within 1 week of PP -->
-        <!-- {{ partial "up-next.html" . }} -->
+        <!-- up next showing PP themes for now -->
+        {{ partial "up-next.html" . }}
 
         {{ partial "sponsors.html" . }}
 

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/pedalpalooza.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/pedalpalooza.html
@@ -64,4 +64,4 @@
 
 <div id="fullcalendar"></div>
 
-<p style="text-align: center; margin-top: 1.5em;">Got an idea? <a href="https://forms.gle/GRVGLAVzu4AZYdnV8">Submit a theme</a> or <a href="https://forms.gle/YdwYqnS2KAhCiC1Y8">share a route</a>!</p>
+<p style="text-align: center; margin-top: 1.5em;">Got an idea? <a href="https://forms.gle/YdwYqnS2KAhCiC1Y8">Share a route!</a></p>

--- a/site/themes/s2b_hugo_theme/layouts/partials/up-next.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/up-next.html
@@ -7,6 +7,15 @@
   document.addEventListener('DOMContentLoaded', function() {
     var calendarEl = document.getElementById('fullcalendar');
 
+    var today = new Date();
+    var ppStartDate = new Date("2020-06-01");
+    var ppNoEventsMessage;
+    if (today < ppStartDate) {
+      ppNoEventsMessage = "Pedalpalooza is coming soon!";
+    } else {
+      ppNoEventsMessage = "No scheduled events";
+    }
+
     var calendar = new FullCalendar.Calendar(calendarEl, {
       plugins: [ 'list' ],
       defaultView: 'listDayTodayAndTomorrow',
@@ -27,7 +36,7 @@
         }
       },
 //       noEventsMessage: "No events happening today or tomorrow",
-      noEventsMessage: "Open day — submit a theme at Pedalpalooza.org!",
+      noEventsMessage: ppNoEventsMessage,
       eventSources: [
         {
           events: ppThemesData, // from pp-2020-themes.html
@@ -72,5 +81,6 @@
 <div id="up-next">
   <h2>Bike fun happening soon!</h2>
   <div id="fullcalendar"></div>
-  <p><a href="/calendar/">See all upcoming events</a> or <a href="/addevent/">add an event</a></p>
+  <p><a href="/pedalpalooza-calendar/">See all upcoming events</a></p>
+<!--   <p><a href="/calendar/">See all upcoming events</a> or <a href="/addevent/">add an event</a></p> -->
 </div>


### PR DESCRIPTION
Re-enabled the "up next" widget on the home page, plus related content updates. Fixes #266. 