### PR TITLE
Posting events requires publishing

### DIFF
--- a/backend/models/Event.php
+++ b/backend/models/Event.php
@@ -41,6 +41,7 @@ class Event extends fActiveRecord {
             'printphone' => $this->getPrintphone() != 0,
             'printweburl' => $this->getPrintweburl() != 0,
             'printcontact' => $this->getPrintcontact() != 0,
+            'published' => $this->getHidden() == 0,
         );
 
         $details['email']   = $this->getHideemail() == 0   || $include_hidden ? $this->getEmail() : null;

--- a/backend/models/Event.php
+++ b/backend/models/Event.php
@@ -167,7 +167,7 @@ class Event extends fActiveRecord {
         $subject = "Shift2Bikes Secret URL for " . $this->getTitle();
         $message = "Dear " . $this->getName();
         $message = $message . ", \r\n\r\nThank you for adding your event, " . $this->getTitle();
-        $message = $message . ", to the Shift Calendar. To activate and manage it, you must visit " . $secret_url;
+        $message = $message . ", to the Shift Calendar. To activate the event listing, you must visit " . $secret_url . " and publish it.";
         $message = $message . "\r\n\r\nThis link is like a password. Anyone who has it can delete and change your event. Please keep this email so you can manage your event in the future.";
         $message = $message . "\r\n\r\nBike on!\r\n\r\n-Shift";
         mail($this->getEmail(), $subject, $message, $headers);

--- a/backend/www/manage_event.php
+++ b/backend/www/manage_event.php
@@ -218,6 +218,8 @@ function build_json_response() {
         $includeSecret = true;
     } else {
         $includeSecret = false;
+        // saving an existing event publishes it
+        $event->unhide();
     }
 
     // If there are validation errors this starts spewing html, so we validate before

--- a/backend/www/retrieve_event.php
+++ b/backend/www/retrieve_event.php
@@ -26,10 +26,6 @@ if (isset($_GET['id'])) {
         $event = new Event($event_id);
         $secret_valid = isset($_GET['secret']) && $event->secretValid($_GET['secret']);
 
-        if ($secret_valid) {
-            $event->unhide();
-        }
-
         $response = $event->toDetailArray($secret_valid);
     } catch (fExpectedException $e) {
         http_response_code(400);

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
@@ -54,16 +54,16 @@
   [[^ id ]]<h1>Add Event</h1>[[/ id ]]
   [[# id ]]<h1>Edit Event</h1>[[/ id ]]
 
-  <div class="edit-buttons" >
-    <button type="button" class="preview-edit-button btn btn-add-event">Edit</button>
-    <button type="button" class="preview-button btn btn-add-event">Preview</button>
-    <button type="button" class="save-button btn btn-add-event">Save</button>
-    [[^ id ]]
-    <button type="button" class="cancel-button btn btn-add-event" data-toggle="modal" data-target="#cancel-modal">Cancel</button>
-    [[/ id ]]
-
-    <span class="save-result"></span>
+  [[# id ]]
+  [[^ published ]]
+  <!-- event has been created, but is not yet published -->
+  <div class="unpublished-event">
+    <p>Almost there! Publish the event to go live on the calendar.</p>
+    <button type="button" class="publish-button btn btn-add-event">Publish</button>
   </div>
+  [[/ published ]]
+  [[/ id ]]
+
   <br>
   <form id="event-entry">
     <input type="hidden" name="id" value="[[id]]" />
@@ -443,11 +443,14 @@
     </div>
   </form>
   <div class="edit-buttons" >
-      <button type="button" class="preview-edit-button btn btn-add-event">Edit</button>
+      <button type="button" class="preview-edit-button btn btn-add-event" style="display: none;">Edit</button>
       <button type="button" class="preview-button btn btn-add-event">Preview</button>
-      <button type="button" class="save-button btn btn-add-event">Save</button>
+      [[# id ]]
+      <button type="button" class="save-button published-save-button btn btn-add-event" style="display: none;">Save</button>
+      [[/ id ]]
       [[^ id ]]
-      <button type="button" class="cancel-button btn btn-add-event" data-toggle="modal" data-target="#cancel-modal">Cancel</button>
+      <button type="button" class="save-button btn btn-add-event">Save</button>
+      <button type="button" class="cancel-button btn btn-add-event" data-toggle="modal" data-target="#cancel-modal">Discard</button>
       [[/ id ]]
 
       <span class="save-result"></span>

--- a/site/themes/s2b_hugo_theme/static/css/main_fun_legacy.css
+++ b/site/themes/s2b_hugo_theme/static/css/main_fun_legacy.css
@@ -279,6 +279,16 @@ h3 {
     background: #f90;
 }
 
+.btn:focus {
+    outline: 2px solid #37b;
+    outline-offset: 1px;
+}
+
+.btn-add-event:focus {
+    outline: 2px solid #630;
+    outline-offset: 1px;
+}
+
 .mainDetails p {
     margin-top: 1em;
 }
@@ -331,7 +341,8 @@ a.expand-details {
     font-weight: normal;
 }
 
-#pp-banner {
+#pp-banner,
+.unpublished-event {
     text-align: center;
     color: #663300;
     background: #FCFAF2;
@@ -475,19 +486,24 @@ button.jump-to-date[aria-expanded="true"] .icon.expand {
     table-layout: fixed;
     color: #404040;
 }
-.preview-edit-button {
-    display: none;
-}
 /* /Date Picker CSS */
 .modal-body {
     text-align:center;
 }
 
-.modal-dialog .modal-footer .btn-warning {
-  color: #630;
+.modal-dialog .modal-footer .btn-warning,
+#delete-button {
+  color: #D00000;
   background-image: none;
-  background-color: #f90;
+  background-color: #F6E0E1;
+  border: 1px solid #D00000;
   text-shadow: none;
+}
+
+.modal-dialog .modal-footer .btn-warning:focus,
+#delete-button:focus {
+    outline: 2px solid #D00000;
+    outline-offset: 1px;
 }
 
 button.more-events {

--- a/site/themes/s2b_hugo_theme/static/legacycaljs/addevent.js
+++ b/site/themes/s2b_hugo_theme/static/legacycaljs/addevent.js
@@ -111,7 +111,12 @@
             $('.save-button').prop('disabled', true);
             $('.preview-button').prop('disabled', true);
         }
-        $('.save-button').click(function() {
+
+        if (shiftEvent.published) {
+          $('.published-save-button').show();
+        }
+
+        $('.save-button, .publish-button').click(function() {
             var postVars,
                 isNew = !shiftEvent.id;
             $('.form-group').removeClass('has-error');
@@ -140,6 +145,10 @@
                             'event has been emailed to ' + postVars.email +
                             '. You must click this link for the event to become visible.  If you don\'t receive that email within 20 minutes, please contact bikecal@shift2bikes.org for help.' :
                         'Your event has been updated!';
+                    if (returnVal.published) {
+                      $('.unpublished-event').remove();
+                      $('.published-save-button').show();
+                     }
 
                     if (returnVal.secret) {
                         var newUrl = 'edit-' + returnVal.id + '-' + returnVal.secret;

--- a/site/themes/s2b_hugo_theme/static/legacycaljs/addevent.js
+++ b/site/themes/s2b_hugo_theme/static/legacycaljs/addevent.js
@@ -142,19 +142,20 @@
                 success: function(returnVal) {
                     var msg = isNew ?
                         'Thank you! A link with a URL to edit and manage the ' +
-                            'event has been emailed to ' + postVars.email +
-                            '. You must click this link for the event to become visible.  If you don\'t receive that email within 20 minutes, please contact bikecal@shift2bikes.org for help.' :
+                            'event has been emailed to ' + postVars.email + '. ' +
+                            'You must follow this link and publish the event for it to become visible. ' +
+                            'If you don\'t receive that email within 20 minutes, please contact bikecal@shift2bikes.org for help.' :
                         'Your event has been updated!';
                     if (returnVal.published) {
-                      $('.unpublished-event').remove();
-                      $('.published-save-button').show();
-                     }
+                        $('.unpublished-event').remove();
+                        $('.published-save-button').show();
+                    }
 
-                    if (returnVal.secret) {
-                        var newUrl = 'edit-' + returnVal.id + '-' + returnVal.secret;
-						history.pushState({}, newUrl, newUrl);
-                        $('#secret').val(returnVal.secret);
-                        msg += ' You may also bookmark the current URL before you click OK.'
+                    if (isNew) {
+					    var newUrl = 'event-submitted';
+					    history.pushState({}, newUrl, newUrl);
+					    $('.edit-buttons').prop('hidden', true);
+					    $('#mustache-html').html('<p>Event submitted! Check your email to finish publishing your event.</p><p><a href="/calendar/">See all upcoming events</a> or <a href="/addevent/">add another event</a>.</p>');
                     }
                     $('#success-message').text(msg);
                     $('#success-modal').modal('show');

--- a/site/themes/s2b_hugo_theme/static/legacycaljs/main.js
+++ b/site/themes/s2b_hugo_theme/static/legacycaljs/main.js
@@ -181,8 +181,8 @@ $(document).ready(function() {
         });
     }
 
-    $(document).on('click', '#confirm-cancel, #success-ok', function() {
-        visitRoute('viewEvents');
+    $(document).on('click', '#confirm-cancel', function() {
+      window.location.href = '/calendar/';
     });
 
     $(document).on('click', '#date-picker-prev-month', function(ev) {


### PR DESCRIPTION
Previous publishing process was: 
1. Submit new event data via `manage_event`; event is not yet visible on the public calendar (`hidden = 1`)
2. When fetching it via `retrieve_event` for the first time, as long as valid secret is provided, publish the event (`hidden = 0`)

On step 1, after the event was submitted the page URL would update to the event's edit link. This means you never actually needed to check your email to get that link, which negated the (loose) identity check mechanism. 

Now: 
1. Submit new event data via `manage_event`; event is not yet visible on the public calendar
2. Fetching it via `retrieve_event` does **not** publish the event; you must save the event again with the prominent "Publish" button. Once that is completed, the publish button disappears and the usual Save button appears. 

This makes verification more reliable (since the posted has to actually check their email), and also makes it easier for moderators to look at an event listing without inadvertently publishing it. It also sets us up for moderator-gated postings, where the email goes to a moderator only and **not** to the original poster. 

Related changes: 
* There is now only 1 set of Save/Cancel/Preview buttons, at the bottom of the form. Previously there was a set at the top of the form as well, which made the code more confusing and wasn't really needed. 
* If you Discard the event while creating it, and confirm the subsequent dialog, it now actually discards and navigates you away. (Fixes #111)