### PR TITLE
Move blanket cancellation to post-PP

### DIFF
--- a/backend/models/EventTime.php
+++ b/backend/models/EventTime.php
@@ -110,7 +110,7 @@ class EventTime extends fActiveRecord {
     protected function getCancelled() {
         if ($this->getEventstatus() == 'C') {
             return true;
-        } elseif ($this->getFormattedDate() >= '2020-03-23') {
+        } elseif ($this->getFormattedDate() >= '2020-07-06') {
             // stay home start date
             return true;
         } else {


### PR DESCRIPTION
All of the "regular" events in June and early July were cleared or hidden from the calendar to avoid confusion with Pedalpalooza theme days. Additionally, events between March 23, 2020 and May 31, 2020, were updated in the database to be officially cancelled. This moves the blanket cancellation forward to July 6, 2020, after Pedalpalooza. This opens up people to post the kind of events that are inline with PP: themes, ride anytime routes, distributed rides, etc. Moderators will determine if rides meet the guidelines. 