### PR TITLE
Post-Pedalpalooza clean-up

### DIFF
--- a/site/content/archive/pedal-palooza-archives.md
+++ b/site/content/archive/pedal-palooza-archives.md
@@ -9,6 +9,10 @@ weight: 2
 
 In 2002, Portland hosted [Bike Summer](http://criticalmass.wikia.com/wiki/Bike_Summer!), and it was great! So, every summer since then, we've had another festival which is now called <dfn>Pedalpalooza</dfn>. Choose one of the following years to see its calendar of events.
 
+*   [2020](/archive/pedalpalooza/pedalpalooza-2020/)
+
+    Something different this year — we rode separate, but together. 5 weeks long, with a different theme every day!
+
 *   [2019](/archive/pedalpalooza/pedalpalooza-2019/)
 
     Started on a Saturday, lasted all month! 342 events!

--- a/site/content/archive/pedalpalooza/pedalpalooza-2020.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2020.md
@@ -3,14 +3,23 @@ title: "2020 Pedalpalooza calendar"
 description: "2020 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
-type: calevents
+type: pp-cal
 pp: true
 year: 2020
 startdate: 2020-06-01
-enddate: 2020-06-30
-daterange: June 1–30, 2020
-banner-image: "/images/pp/pp2020-banner-tmp.jpg"
-poster-image: "/images/pp/pp2020-tmp.jpg"
+enddate: 2020-07-06 # end date is exclusive
+daterange: June 1–July 5, 2020
+banner-image: "/images/pp/pp2020-banner.png"
+poster-image: "/images/pp/pp2020.png"
 
 ---
 
+<strong class="pp-headline">Pedalpalooza is going to be different this year!</strong>
+
+[Pedalpalooza](/pages/pedalpalooza/) 2020 is about individuals finding ways to celebrate the joy of cycling. We will not be encouraging people to gather, as we have in previous years. Read more on our [public health](/pages/public-health/) page.
+
+**But wait!** You can still have #bikefun — separately, but together! Check out the solo ride themes below, and see [Pedalpalooza.org](https://www.pedalpalooza.org/ride) for more info.
+
+<strong class="pp-headline">Update</strong>
+
+Bicycles can be a tool for positive change. If you would like to contribute ways to mobilize cyclists for the community, please <a href="mailto:pedalpalooza@gmail.com?subject=Here's how I can help Pedalpalooza mobilize cyclists">contact Pedalpalooza</a>. Learn more and stay up-to-date at <a href="https://www.pedalpalooza.org/blog">Pedalpalooza.org/blog</a> and on social media.

--- a/site/content/pages/pedalpalooza.md
+++ b/site/content/pages/pedalpalooza.md
@@ -9,9 +9,9 @@ menu:
 
 Pedalpalooza is an annual festival in Metro Portland, Oregon.  During the festival, there are hundreds of volunteer-organized free bike events.
 
-<p style="padding: 1em; color: #663300; border: 1px solid #FFDD66; background: #FCFAF2; font-weight: bold;"><strong>This year will be something different! Pedalpalooza 2020 is about individuals finding ways to celebrate the joy of cycling — separate, but together.</strong></p>
+<p style="padding: 1em; color: #663300; border: 1px solid #FFDD66; background: #FCFAF2; font-weight: bold;"><strong>This year was something different! Pedalpalooza 2020 was about individuals finding ways to celebrate the joy of cycling — separate, but together.</strong></p>
 
-Pedalpalooza 2020 starts on the 1st of June and ends on the 5th of July — over a full month of bike fun! Check the <a href="/pedalpalooza-calendar/">Pedalpalooza calendar</a> and [Pedalpalooza.org](https://www.pedalpalooza.org/) for details.
+Pedalpalooza 2020 started on the 1st of June and ended on the 5th of July — over a full month of bike fun! Check the <a href="/pedalpalooza-calendar/">Pedalpalooza calendar</a> and [Pedalpalooza.org](https://www.pedalpalooza.org/) for details.
 
 ## History
 

--- a/site/themes/s2b_hugo_theme/layouts/calevents/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/calevents/single.html
@@ -29,7 +29,8 @@
                     {{ partial "pp_header.html" . }}
                   {{ else }}
                     <!-- on other cal pages, display smaller banner that links to PP cal page -->
-                    {{ partial "cal/pp-promo-banner.html" . }}
+                    <!-- only display when PP is coming soon or happening now -->
+                    <!-- {{ partial "cal/pp-promo-banner.html" . }} -->
                   {{ end }}
 
                   {{ .Content }}

--- a/site/themes/s2b_hugo_theme/layouts/calgrid/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/calgrid/single.html
@@ -27,7 +27,8 @@
 
                 {{ partial "alert_banner.html" . }}
 
-                {{ partial "cal/pp-promo-banner.html" . }}
+                <!-- only display when PP is coming soon or happening now -->
+                <!-- {{ partial "cal/pp-promo-banner.html" . }} -->
 
                 {{ partial "cal/view-options.html" . }}
                 {{ partial "cal/fullcal.html" . }} 

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/pedalpalooza.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/pedalpalooza.html
@@ -79,4 +79,4 @@
 
 <div id="fullcalendar"></div>
 
-<p style="text-align: center; margin-top: 1.5em;">Got an idea? <a href="https://forms.gle/YdwYqnS2KAhCiC1Y8">Share a route!</a></p>
+<!-- <p style="text-align: center; margin-top: 1.5em;">Got an idea? <a href="https://forms.gle/YdwYqnS2KAhCiC1Y8">Share a route!</a></p> -->


### PR DESCRIPTION
* Updated content to reflect that PP 2020 is over
* Updated 2020 archive page to use custom PP calendar layout & theme data

PP ends on July 5th; merge on July 6th or later.