### PR TITLE
Calendar - add null check for address

### DIFF
--- a/site/themes/s2b_hugo_theme/static/legacycaljs/helpers.js
+++ b/site/themes/s2b_hugo_theme/static/legacycaljs/helpers.js
@@ -16,8 +16,8 @@
     };
 
     $.fn.getMapLink = function(address) {
-        if (address == 'TBA' || address == 'TBD') {
-            // if address isn't available yet, don't try to map it
+        if (!address || address == 'TBA' || address == 'TBD') {
+            // if address is null or not available yet, don't try to map it
             return;
         }
 


### PR DESCRIPTION
If `address` is null, this would cause a JS error that would break front-end rendering. Address should never be null, but once in a while there's a stray occurrence of an old event which has unexpected null fields. 