### PR TITLE
Print details are optional

### DIFF
--- a/backend/www/manage_event.php
+++ b/backend/www/manage_event.php
@@ -28,7 +28,7 @@ function validate_json_request($data) {
 
     $validator->addRequiredFields('title', 'details', 'venue', 'address', 'organizer', 'email', 'code_of_conduct', 'read_comic');
     // required only from March to June, during Pedalpalooza
-    $validator->addRequiredFields('tinytitle', 'printdescr');
+    // $validator->addRequiredFields('tinytitle', 'printdescr');
     $validator->addEmailFields('email');
     $validator->addRegexReplacement('#^(.*?): (.*)$#', '\2 for <span class="field-name">\1</span>');
     // If id is specified require secret
@@ -178,6 +178,12 @@ function build_json_response() {
 
     if (!$data['read_comic']) {
         $messages['read_comic'] = "You must have read the Ride Leading Comic";
+    }
+
+    if (!$data['tinytitle']) {
+        // if print title (aka tinytitle) isn't set,
+        // use the first 24 chars of the regular title
+        $data['tinytitle'] = substr($data['title'], 0, 24);
     }
 
     if (!$data['code_of_conduct']) {

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
@@ -326,19 +326,21 @@
           <div class="panel-body">
             <p class="input-help">The printed calendar has limited space for each event, so we must limit the amount of info for some fields. Be as brief as reasonably possible!</p>
             <div class="checkbox">
+<!--
               <input type="hidden" name="printevent" value="0" />
               <label class="control-label" for="printevent">
                 <input type="checkbox" name="printevent" id="printevent" aria-describedby="printevent-help" value="1" [[# printevent ]]checked[[/ printevent ]] />
                 Include in the print calendar
               </label>
-              <p class="input-help" id="printevent-help">You must submit at least 3 weeks in advance. Inclusion not guaranteed.</p>
+ -->
+              <p class="input-help" id="printevent-help">You must submit at least 3 weeks in advance of the print deadline. We can't guarantee that all submitted rides will be printed, sorry!</p>
             </div>
             <div class="form-group">
-              <label class="control-label" for="tinytitle">Print title (24 characters)</label>
+              <label class="control-label optional-label" for="tinytitle">Print title (24 characters)</label>
               <input type="text" class="form-control" name="tinytitle" id="tinytitle" value="[[tinytitle]]" maxlength="24" />
             </div>
             <div class="form-group">
-              <label class="control-label" for="printdescr">Print description (120 characters)</label>
+              <label class="control-label optional-label" for="printdescr">Print description (120 characters)</label>
               <textarea class="form-control" name="printdescr" id="printdescr" maxlength="120" >[[printdescr]]</textarea>
             </div>
 

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
@@ -325,16 +325,7 @@
         <div id="print-fields" class="panel-collapse collapse in">
           <div class="panel-body">
             <p class="input-help">The printed calendar has limited space for each event, so we must limit the amount of info for some fields. Be as brief as reasonably possible!</p>
-            <div class="checkbox">
-<!--
-              <input type="hidden" name="printevent" value="0" />
-              <label class="control-label" for="printevent">
-                <input type="checkbox" name="printevent" id="printevent" aria-describedby="printevent-help" value="1" [[# printevent ]]checked[[/ printevent ]] />
-                Include in the print calendar
-              </label>
- -->
-              <p class="input-help" id="printevent-help">You must submit at least 3 weeks in advance of the print deadline. We can't guarantee that all submitted rides will be printed, sorry!</p>
-            </div>
+            <p class="input-help">You must submit at least 3 weeks in advance of the print deadline. We can't guarantee that all submitted rides will be printed, sorry!</p>
             <div class="form-group">
               <label class="control-label optional-label" for="tinytitle">Print title (24 characters)</label>
               <input type="text" class="form-control" name="tinytitle" id="tinytitle" value="[[tinytitle]]" maxlength="24" />


### PR DESCRIPTION
* Print title (aka tinytitle) and print description are no longer required fields 
* Tinytitle is required in the database, so if tinytitle isn't provided we automatically grab the 1st 24 characters of the full title. This is similar to what the legacy calendar did, and also what you get if you manually copy & paste a long title into the tinytitle field (which a decent number of people do). 
* Removed "Include in the print calendar" checkbox; it was apparently only used by frontend validation and wasn't stored on the backend. That was confusing for ride posters (the checkbox state wasn't persistent) and also for me 😅

Fixes #11. 