### PR TITLE
Calendar - Additional Contact Info field usability improvements

### DIFF
--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
@@ -302,7 +302,8 @@
 
             <div class="form-group">
               <label class="control-label optional-label" for="contact">Additional Contact Info</label>
-              <input type="text" class="form-control" name="contact" id="contact" value="[[contact]]" />
+              <input type="text" class="form-control" name="contact" id="contact" value="[[contact]]" aria-describedby="contact-help" />
+              <p class="input-help" id="contact-help">This can be a name, an email address, another web URL, social media link, PO Box, or anything else!</p>
 
               <label class="control-label" for="hidecontact">
                 <input type="checkbox" name="hidecontact" id="hidecontact" value="1" [[# hidecontact ]]checked[[/ hidecontact ]] />

--- a/site/themes/s2b_hugo_theme/static/legacycaljs/helpers.js
+++ b/site/themes/s2b_hugo_theme/static/legacycaljs/helpers.js
@@ -56,9 +56,14 @@
         }
 
         var urlPattern = /^https*:\/\//;
+        var emailPattern = /.+@.+[.].+/;
+
         if (contactInfo.match(urlPattern)) {
             // if add'l contact info is an http/s link, return it as-is
             return contactInfo;
+        } else if (contactInfo.match(emailPattern)) {
+            // if add'l contact info is an email address, return a mailto link
+            return 'mailto:' + contactInfo;
         } else {
             // if it's not a link, return nothing
             return;


### PR DESCRIPTION
* Brief help text that explains some possible uses of the Add'l Contact Info field. 
* Helper function that makes a clickable `mailto:` link if the field contains an email address.

Fixes #294 and #317.