### PR TITLE
Updated alert banner 

### DIFF
--- a/site/content/pages/public-health.md
+++ b/site/content/pages/public-health.md
@@ -50,7 +50,7 @@ There are also alternatives to the typical group ride format that don't involve 
 
 * **Online events:** Bike-y online events like meetings, socials, livestreams, and more
 * **Distributed events:** Rides that happen at a specific time, but everyone participates from their own, separate location. The [May 2020 Midnight Mystery Ride](https://midnightmysteryride.wordpress.com/2020/05/05/may-ride-switching-things-up/) is a great example! 
-* **Ride anytime routes:** A specific route that people can ride at any time they'd like. Check out this year's special [Pedalpalooza calendar](/pedalpalooza-calendar/) for lots of great examples.
+* **Ride anytime routes:** A specific route that people can ride at any time they'd like. Check out the special [Pedalpalooza 2020 calendar](/archive/pedalpalooza/pedalpalooza-2020/) for lots of great examples.
 
 If necessary, moderators may modify or remove event listings if they aren't following safety guidelines. If you have any questions, [contact us](/pages/contact/). As conditions change and guidelines are updated, we'll be working to figure out additional ways for the calendar to facilitate new approaches to inclusive bike fun. Stay tuned!
 

--- a/site/themes/s2b_hugo_theme/layouts/calevents/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/calevents/single.html
@@ -21,16 +21,16 @@
 
               <div class="col-md-12">
 
-                {{ partial "alert_banner.html" . }}
-
                 <div>
                   {{ if isset .Params "pp" }}
                     <!-- on PP cal page, display full PP header -->
                     {{ partial "pp_header.html" . }}
+                    {{ partial "alert_banner.html" . }}
                   {{ else }}
                     <!-- on other cal pages, display smaller banner that links to PP cal page -->
                     <!-- only display when PP is coming soon or happening now -->
                     {{ partial "cal/pp-promo-banner.html" . }}
+                    <!-- alert banner is present, but will be added at the top or bottom conditionally by cal scripts -->
                   {{ end }}
 
                   {{ .Content }}

--- a/site/themes/s2b_hugo_theme/layouts/calgrid/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/calgrid/single.html
@@ -25,10 +25,10 @@
                   {{ .Content }}
                 </div>
 
-                {{ partial "alert_banner.html" . }}
-
                 <!-- only display when PP is coming soon or happening now -->
                 {{ partial "cal/pp-promo-banner.html" . }}
+
+                {{ partial "alert_banner.html" . }}
 
                 {{ partial "cal/view-options.html" . }}
                 {{ partial "cal/fullcal.html" . }} 

--- a/site/themes/s2b_hugo_theme/layouts/partials/alert_banner.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/alert_banner.html
@@ -1,7 +1,6 @@
 <div id="alert-banner" class="newsflash">
   <div>
-    <p><strong>To stem the spread of COVID-19 in the Portland area, Oregon and Washington state are taking a phased approach to reopen. All Portland-area counties have restrictions on gatherings. Health officials have set limits on the number of people for all social gatherings – indoor and outdoor. Participants should maintain social distance of six feet. Masks are required in outdoor public spaces when physical distancing of at least six feet is not possible.</strong></p>
-    <p><strong>We strongly encourage everyone on a ride to wear a mask. Group bike rides are dynamic events and it can be difficult to maintain six feet of distance at all times. At minimum, we recommend you keep a mask/face covering around your neck that you can easily pull up when near other people.</strong></p>
-    <p><strong>For more info on calendar updates, tips on riding safely in these times, and mobilizing bikes for the greater good, check out our <a href="/pages/public-health/">Public Health</a> and <a href="/pages/bike-for-justice/">Bike for Justice</a> pages. Stay safe, stay healthy!</strong></p>
+    <p><strong>Stay safe, stay healthy! Shift strongly encourages everyone on a ride to wear a mask and maintain six feet of social distance whenever possible.</strong></p>
+    <p><strong>Please read our <a href="/pages/public-health/">Public Health</a> page for more guidelines and ride recommendations.</strong></p>
   </div>
 </div>

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
@@ -338,3 +338,7 @@
 <script id="view-as-options" type="text/template">
   {{ partial "cal/view-options.html" . }}
 </script>
+
+<script id="alert-banner-template" type="text/template">
+  {{ partial "alert_banner.html" . }}
+</script>

--- a/site/themes/s2b_hugo_theme/static/legacycaljs/main.js
+++ b/site/themes/s2b_hugo_theme/static/legacycaljs/main.js
@@ -125,6 +125,10 @@ $(document).ready(function() {
             enddate: lastDayOfRange,
             show_details: isExpanded
         }, function (eventHTML) {
+             // don't load alert banner on PP page (it's already inserted elsewhere)
+             if ( !('pp' in options) ) {
+               container.append($('#alert-banner-template').html());
+             }
              // don't load list/grid toggle on PP page (always displays grid)
              if ( !('pp' in options) ) {
                container.append($('#view-as-options').html());
@@ -167,6 +171,8 @@ $(document).ready(function() {
             container.append(eventHTML);
             checkAnchors();
             lazyLoadEventImages();
+            // add alert banner at the bottom of single event listing
+            container.append($('#alert-banner-template').html());
         });
     }
 


### PR DESCRIPTION
Updated content and adjusted placement of public health alert banner. The banner now appears before content on list pages and after content on single ride listing. Fixes #318.