### PR TITLE
SVG style fix for Windows High Contrast Mode

### DIFF
--- a/site/themes/s2b_hugo_theme/static/css/custom.css
+++ b/site/themes/s2b_hugo_theme/static/css/custom.css
@@ -54,3 +54,11 @@ main .donate a {
     font-size: 32px;
   }
 }
+
+/* see https://github.com/shift-org/shift-docs/issues/326 */
+@media (-ms-high-contrast: active), (forced-colors: active) {
+  svg.icon, svg.logo {
+    -ms-high-contrast-adjust: auto;
+    forced-color-adjust: auto;
+  }
+}


### PR DESCRIPTION
Style adjustment to address Chrome v89's changes to SVG color in Windows High Contrast Mode. Fixes #326.