### PR TITLE
better filename for the download

### DIFF
--- a/legacy/cal/new-icalpp.php
+++ b/legacy/cal/new-icalpp.php
@@ -3,6 +3,7 @@
     include("include/common.php");
     include("include/view.php");
     header("Content-type: text/calendar");
+    header("Content-Disposition: attachment; filename=\"pedalpalooza.ics\"");
     header("Cache-control: private");
     
     


### PR DESCRIPTION
changed from the default ("match scriptname") filename, to one that at least says what it is:  `pedalpalooza.ics`