### PR TITLE
Calendar: Check email ban list before saving ride

### DIFF
--- a/backend/banlist.txt
+++ b/backend/banlist.txt
@@ -1,0 +1,2 @@
+invalid@example.com
+anything@banned.biz

--- a/backend/config.php
+++ b/backend/config.php
@@ -21,3 +21,10 @@ $IMAGEURL = "/eventimages";
 $SITENAME = "SHIFT to Bikes";
 
 $ORIGIN = "*";
+
+$banfile = ('../banlist.txt');
+if (file_exists($banfile)) {
+    $BANLIST = file('../banlist.txt', FILE_IGNORE_NEW_LINES);
+} else {
+    $BANLIST = [];
+}

--- a/backend/www/manage_event.php
+++ b/backend/www/manage_event.php
@@ -45,6 +45,13 @@ function validate_email($email) {
     // lowercase provided email before checking against ban list
     $email = strtolower($email);
 
+    // remove +tags, e.g. invalid+tag@example.com
+    $emailWithTagsPattern = '/(.+)([+].*)@(.+)/';
+    $emailReplacement = '$1@$3';
+    while (preg_match($emailWithTagsPattern, $email)) {
+        $email = preg_replace($emailWithTagsPattern, $emailReplacement, $email);
+    }
+
     // load ban list from config
     global $BANLIST;
 

--- a/backend/www/manage_event.php
+++ b/backend/www/manage_event.php
@@ -46,11 +46,9 @@ function validate_email($email) {
     $email = strtolower($email);
 
     // remove +tags, e.g. invalid+tag@example.com
-    $emailWithTagsPattern = '/(.+)([+].*)@(.+)/';
+    $emailWithTagsPattern = '/([^+]+)([+].*)@(.+)/';
     $emailReplacement = '$1@$3';
-    while (preg_match($emailWithTagsPattern, $email)) {
-        $email = preg_replace($emailWithTagsPattern, $emailReplacement, $email);
-    }
+    $email = preg_replace($emailWithTagsPattern, $emailReplacement, $email);
 
     // load ban list from config
     global $BANLIST;

--- a/backend/www/manage_event.php
+++ b/backend/www/manage_event.php
@@ -41,6 +41,20 @@ function validate_json_request($data) {
     return $validator->validate(TRUE, TRUE);
 }
 
+function validate_email($email) {
+    // lowercase provided email before checking against ban list
+    $email = strtolower($email);
+
+    // load ban list from config
+    global $BANLIST;
+
+    if (in_array($email, $BANLIST)) {
+        return FALSE;
+    } else {
+        return TRUE;
+    }
+}
+
 function upload_attached_file($event, $messages) {
     if (isset($_FILES['file'])) {
         $uploader = new fUpload();
@@ -175,6 +189,10 @@ function build_json_response() {
     }
 
     $messages = validate_json_request($data);
+
+    if (!validate_email($data['email'])) {
+        $messages['email'] = "Email is invalid";
+    }
 
     if (!$data['read_comic']) {
         $messages['read_comic'] = "You must have read the Ride Leading Comic";


### PR DESCRIPTION
See issue #138: 

* Banned emails are pulled from `backend/banlist.txt`. Two default test values are provided (`invalid@example.com`, `anything@banned.biz`). 
* Email is lowercased before checking, so input match isn't case-sensitive. 
* Checks for plus tags in the address, and removes them before checking against the ban list: `invalid+sneaky@example.com`, `invalid+sneaky+sneakier@example.com`, etc
* If the email is not allowed, the API returns a `400` error with message `Email is invalid`.