### PR TITLE
replacing the work in https://github.com/shift-org/shift-docs/pull/217

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
 [build]
 
   base = "site/"
-  publish = "site/public/"
+  publish = "public/"
 
 [build.environment]
   HUGO_VERSION = "0.37.1"
@@ -14,11 +14,11 @@
   command = 'hugo -D && cp public/404/index.html public/404.html'
 
 [context.branch-deploy]
-  # this command builds draft content for deploy previews
+  # this command builds draft content for branches
   command = 'hugo -D  && cp public/404/index.html public/404.html'
 
 [context.production]
-  # drafts are excluded (no `-D` option to hugo) for prod build
+  # drafts are excluded (no `-D` option to hugo) for prod build.  We also pull new code to the server in this case!
   command = 'hugo && cp public/404/index.html public/404.html && mkdir -p ~/.ssh && echo -e "${SSH_KEY//_/\\n}" > ~/.ssh/id_rsa && chmod og-rwx ~/.ssh/id_rsa && ssh -v -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@api.shift2bikes.org "cd /opt/shift-docs && ./shift pull"'
 
 


### PR DESCRIPTION
this is a subset of PR https://github.com/shift-org/shift-docs/pull/217 which I'm about to kill off and restart; license changes were unrelated and are covered in a different PR now.  This does require changes at Netlify before it should be merged;  for fool's notes:

- update build image in Netlify UI to latest
- that should set `base_rel_dir` to true automagically
- which should use these settings.