### PR TITLE
updating CMS branch config master to main

### DIFF
--- a/site/static/admin/config.yml
+++ b/site/static/admin/config.yml
@@ -1,6 +1,6 @@
 backend:
   name: git-gateway
-  branch: master # Branch to update (optional; defaults to master)
+  branch: main # Branch to update 
 
 # publish_mode: editorial_workflow
 


### PR DESCRIPTION
I think this will fix @carrythebanner 's reported issue with the Git-Gateway token needing to be recreated (since I did that a few times with no effect, but I think maybe the underlying problem is targeting a missing branch...)

Should be able to login from the deploy preview to confirm if it is working or no.