### PR TITLE
Duplicate event

### DIFF
--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
@@ -475,6 +475,7 @@
       <button type="button" class="preview-button btn btn-add-event">Preview</button>
       [[# id ]]
       <button type="button" class="save-button published-save-button btn btn-add-event" style="display: none;">Save</button>
+      <button type="button" class="duplicate-button btn btn-add-event" style="display: none;">Duplicate</button>
       [[/ id ]]
       [[^ id ]]
       <button type="button" class="save-button btn btn-add-event">Save</button>

--- a/site/themes/s2b_hugo_theme/static/js/cal/addevent.js
+++ b/site/themes/s2b_hugo_theme/static/js/cal/addevent.js
@@ -216,7 +216,6 @@
             shiftEvent.codeOfConduct = false;
             shiftEvent.readComic = false;
             populateEditForm(shiftEvent, function(eventHTML) {
-                // old value still present when duped event form is submitted
 				var newUrl = '/addevent/';
 				history.pushState({}, newUrl, newUrl);
                 $('#mustache-html').empty().append(eventHTML);

--- a/site/themes/s2b_hugo_theme/static/js/cal/addevent.js
+++ b/site/themes/s2b_hugo_theme/static/js/cal/addevent.js
@@ -216,8 +216,8 @@
             shiftEvent.codeOfConduct = false;
             shiftEvent.readComic = false;
             populateEditForm(shiftEvent, function(eventHTML) {
-				var newUrl = '/addevent/';
-				history.pushState({}, newUrl, newUrl);
+                var newUrl = '/addevent/';
+                history.pushState({}, newUrl, newUrl);
                 $('#mustache-html').empty().append(eventHTML);
                 $('html, body').animate({
                   scrollTop: 0

--- a/site/themes/s2b_hugo_theme/static/js/cal/addevent.js
+++ b/site/themes/s2b_hugo_theme/static/js/cal/addevent.js
@@ -114,6 +114,7 @@
 
         if (shiftEvent.published) {
           $('.published-save-button').show();
+          $('.duplicate-button').show();
         }
 
         $('.save-button, .publish-button').click(function() {
@@ -149,6 +150,7 @@
                     if (returnVal.published) {
                         $('.unpublished-event').remove();
                         $('.published-save-button').show();
+                        $('.duplicate-button').show();
                     }
 
                     if (isNew) {
@@ -203,6 +205,24 @@
             .on('click', '.preview-button', function(e) {
             previewEvent(shiftEvent, function(eventHTML) {
                 $('#mustache-html').append(eventHTML);
+            });
+        });
+
+        $(document).off('click', '.duplicate-button')
+            .on('click', '.duplicate-button', function(e) {
+            shiftEvent.id = '';
+            shiftEvent.secret = '';
+            shiftEvent.datestatuses = [];
+            shiftEvent.codeOfConduct = false;
+            shiftEvent.readComic = false;
+            populateEditForm(shiftEvent, function(eventHTML) {
+                // old value still present when duped event form is submitted
+				var newUrl = '/addevent/';
+				history.pushState({}, newUrl, newUrl);
+                $('#mustache-html').empty().append(eventHTML);
+                $('html, body').animate({
+                  scrollTop: 0
+                }, 1000)
             });
         });
     }

--- a/site/themes/s2b_hugo_theme/static/js/cal/datepicker.js
+++ b/site/themes/s2b_hugo_theme/static/js/cal/datepicker.js
@@ -235,7 +235,11 @@
     }
 
     function loadEarlierBottom() {
-        return ($loadEarlier.offset().top + $loadEarlier.prop('scrollHeight')) - $dateSelect.offset().top;
+        if ($loadEarlier) {
+            return ($loadEarlier.offset().top + $loadEarlier.prop('scrollHeight')) - $dateSelect.offset().top;
+        } else {
+            return 0;
+        }
     }
 
     var checking = false;


### PR DESCRIPTION
Adds "Duplicate" button to edit form: 
* Only appears once an event is published
* Duplicates all fields into a new event form, _except_: ID, secret, selected dates, and T&C acknowledgement (code of conduct, ride comic)

Fixes request #400.