### PR TITLE
Calendar - explicitly drop image when duplicating an event

### DIFF
--- a/site/themes/s2b_hugo_theme/static/js/cal/addevent.js
+++ b/site/themes/s2b_hugo_theme/static/js/cal/addevent.js
@@ -221,6 +221,7 @@
             shiftEvent.id = '';
             shiftEvent.secret = '';
             shiftEvent.datestatuses = [];
+            shiftEvent.image = '';
             shiftEvent.codeOfConduct = false;
             shiftEvent.readComic = false;
             populateEditForm(shiftEvent, function(eventHTML) {


### PR DESCRIPTION
It wasn't getting duplicated to the new event, but it looked like it was. We could've changed it to intentionally dupe the image, but people often use the image for a flyer which includes date & time info so the old image could've lead to mismatched info in the image vs. listing.

Fixes #448.