### PR TITLE
Pedalpalooza 2023 landing page

### DIFF
--- a/site/content/pedalpalooza-calendar.md
+++ b/site/content/pedalpalooza-calendar.md
@@ -3,21 +3,21 @@ title: "Pedalpalooza calendar"
 description: "Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
-type: calevents
+type: pp-landing
 pp: true
-year: 2022
-startdate: 2022-06-01
-enddate: 2022-09-01 # end date is exclusive
-daterange: June 1–August 31, 2022
-banner-image: "/images/pp/pp2022-banner.jpg"
-poster-image: "/images/pp/pp2022.jpg"
+year: 2023
+startdate: 2023-06-01
+enddate: 2023-09-01 # end date is exclusive
+daterange: June 1–August 31, 2023
+banner-image: "/images/pp/pp-general-banner.png"
+poster-image: "/images/pp/pp-general.png"
 
 ---
 
 <!--
 [Use only when in "landing page" mode before full launch for the year]
+-->
 
-Stay tuned for more information on [Pedalpalooza](/pages/pedalpalooza/) 2022! Be sure to follow [Pedalpalooza on Instagram](https://www.instagram.com/pedalpaloozapdx/) and [Pedalpalooza.org](https://www.pedalpalooza.org/) for updates!
+Stay tuned for more information on [Pedalpalooza](/pages/pedalpalooza/) 2023! Be sure to follow [Pedalpalooza on Instagram](https://www.instagram.com/pedalpaloozapdx/) and [Pedalpalooza.org](https://www.pedalpalooza.org/) for updates!
 
 Seeking inspiration? View the [Pedalpalooza archives](/archive/pedal-palooza-archives/) for past bicycle fun events. Looking for current events? Check out the current [ride calendar](/calendar/).
--->


### PR DESCRIPTION
Switches the PP calendar page from last year's calendar to a landing page hyping this year. When more info is available about this year's fest, this will be reverted back to the regular calendar page.