### PR TITLE
Change link underlining styles

### DIFF
--- a/site/themes/s2b_hugo_theme/static/css/custom.css
+++ b/site/themes/s2b_hugo_theme/static/css/custom.css
@@ -13,8 +13,17 @@ footer {
   text-align: center;
 }
 
-#footer ul a {
+footer #footer-ul a {
   color: #ccc;
+}
+
+footer a {
+  text-decoration: underline;
+}
+
+footer a:hover,
+footer a:focus {
+  text-decoration: none;
 }
 
 header {
@@ -29,12 +38,19 @@ header {
   fill: currentColor;
 }
 
-main a {
-  color: #337AB7;
+#navbar ul.nav > li > a {
+  text-decoration: none;
 }
 
-main a:hover, a:focus {
+main a {
+  color: #337AB7;
+  text-decoration: underline;
+}
+
+main a:hover,
+main a:focus {
   color: #23527C;
+  text-decoration: none;
 }
 
 main .donate {


### PR DESCRIPTION
Currently, most links are not underlined by default, and only show an underline on hover or focus. It can sometimes be difficult to differentiate links from surrounding text (especially in paragraphs, e.g. on https://www.shift2bikes.org/pages/pedalpalooza/), doubly so if you're on mobile in direct sunlight. 

Underlining links by default is an accessibility best practice, so this flips the style to be underlined by default and no underline on hover/focus. This applies to the main section and the footer; in the header, it's already obvious what's clickable (and the dropdowns function as buttons, not links, even though they use `<a>` elements), so underline isn't needed there.