### PR TITLE
Add aria-current to the current date in the date picker

### DIFF
--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
@@ -493,7 +493,7 @@
     <td rowspan="[[weeksInMonth]]" class="calendar-month-title"><span>[[monthTitle]]</span></td>
     [[/monthTitle]]
     [[#days]]
-    <td class="calendar-day [[classes]]" data-date="[[date]]" [[#title]]title="[[title]]"[[/title]]>[[day]]</td>
+    <td class="calendar-day [[classes]]" data-date="[[date]]" [[#today]]aria-current="date" title="today"[[/today]]>[[day]]</td>
     [[/days]]
   </tr>
   [[/weeks]]

--- a/site/themes/s2b_hugo_theme/static/js/cal/datepicker.js
+++ b/site/themes/s2b_hugo_theme/static/js/cal/datepicker.js
@@ -185,7 +185,7 @@
             day['day'] = date.getDate();
             day['date'] = normalizeDate(date);
             day['classes'] = (isToday(date) ? "today" : "") + " " + (isSelected(date) ? "selected" : "") + " " + cellClases[date.getMonth()] + (date.getDay() % 2 === 0 ? "-odd" : "");
-            day['title'] = isToday(date) ? "today" : "";
+            day['today'] = isToday(date);
             week.push(day);
 
             date = new Date(date.getFullYear(), date.getMonth(), date.getDate() + 1);


### PR DESCRIPTION
The current date in the date picker now has `aria-current="date"` which provides an additional, consistent semantic indicator for screen readers. The date picker probably needs an overhaul/replacement (read: it definitely does) but this is a small tweak to improve in the meantime.