### PR TITLE
Add autocomplete for email address when adding/editing an event

### DIFF
--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
@@ -285,7 +285,7 @@
 
             <div class="form-group">
               <label class="control-label req-label" for="email">Email</label>
-              <input type="text" class="form-control" name="email" id="email" value="[[email]]" aria-describedby="email-help" required="true" aria-invalid="false" />
+              <input type="text" class="form-control" name="email" id="email" value="[[email]]" autocomplete="email" aria-describedby="email-help" required="true" aria-invalid="false" />
               <p class="input-help" id="email-help">This must be a valid email address where we can reach you. A confirmation message will be mailed to this address.</p>
               <div id="email-suggestion"></div>
 


### PR DESCRIPTION
One reason why people may not get their confirmation link is because they enter a typo in their email address. Supporting autocomplete for the email field can help avoid manual entry and reduce the likelihood of typos.