### PR TITLE
[shift 304] - improve instructions post-submission, pre-publish.

### DIFF
--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
@@ -37,6 +37,7 @@
   </div><!-- /.modal-dialog -->
 </div><!-- /.modal -->
 
+<!-- for changes to events, including deletion success. -->
 <div class="modal fade" tabindex="-1" id="success-modal" role="dialog">
   <div class="modal-dialog modal-sm">
     <div class="modal-content">
@@ -45,6 +46,24 @@
       </div>
       <div class="modal-footer">
         <button type="button" class="btn" data-dismiss="modal" id="success-ok">OK</button>
+      </div>
+    </div><!-- /.modal-content -->
+  </div><!-- /.modal-dialog -->
+</div><!-- /.modal -->
+
+<!-- for initial submit -->
+<div class="modal fade" tabindex="-1" id="submit-modal" role="dialog">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-body">
+        <h4>Event Submitted</h4>
+        <p>A confirmation email has been sent to you at <span id="submit-email">example@example.com</span>.
+        <p>You <em>must</em> use the link in the email to publish your event.
+        <p>If you don't receive your confirmation within 20 minutes please contact <a href="mailto:bikecal@shift2bikes.org">bikecal@shift2bikes.org</a> for help.
+        <p>Thanks!
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn" data-dismiss="modal" id="submit-ok">OK</button>
       </div>
     </div><!-- /.modal-content -->
   </div><!-- /.modal-dialog -->

--- a/site/themes/s2b_hugo_theme/static/css/cal/main.css
+++ b/site/themes/s2b_hugo_theme/static/css/cal/main.css
@@ -537,7 +537,7 @@ button.jump-to-date[aria-expanded="true"] .icon.expand {
     color: #404040;
 }
 /* /Date Picker CSS */
-.modal-body {
+.modal-dialog.modal-sm .modal-body {
     text-align:center;
 }
 

--- a/site/themes/s2b_hugo_theme/static/js/cal/addevent.js
+++ b/site/themes/s2b_hugo_theme/static/js/cal/addevent.js
@@ -147,28 +147,26 @@
                 cache: false,
                 data: data,
                 success: function(returnVal) {
-                    var msg = isNew ?
-                        'Thank you! A link with a URL to edit and manage the ' +
-                            'event has been emailed to ' + postVars.email + '. ' +
-                            'You must follow this link and publish the event for it to become visible. ' +
-                            'If you don\'t receive that email within 20 minutes, please contact bikecal@shift2bikes.org for help.' :
-                        'Your event has been updated!';
                     if (returnVal.published) {
                         $('.unpublished-event').remove();
                         $('.published-save-button').show();
                         $('.duplicate-button').show();
                         _isFormDirty = false;
                     }
-
-                    if (isNew) {
-                        var newUrl = 'event-submitted';
+                    if (!isNew) {
+                      $('#success-message').text('Your event has been updated!');
+                      $('#success-modal').modal('show');
+                    } else {
+                        let newUrl = 'event-submitted';
                         history.pushState({}, newUrl, newUrl);
+                        // hide the edit button on the page
                         $('.edit-buttons').prop('hidden', true);
+                        // set the text of the page
                         $('#mustache-html').html('<p>Event submitted! Check your email to finish publishing your event.</p><p><a href="/calendar/">See all upcoming events</a> or <a href="/addevent/">add another event</a>.</p>');
                         _isFormDirty = false;
+                        $('#submit-email').text(postVars.email);
+                        $('#submit-modal').modal('show');
                     }
-                    $('#success-message').text(msg);
-                    $('#success-modal').modal('show');
                     shiftEvent.id = returnVal.id;
                 },
                 error: function(returnVal) {


### PR DESCRIPTION
* changed the isNew event to uses a separate modal dialog ( this seemed the most easily customizable way of having specific html and styling for the popup. )
* added a new dialog with the customized html that doesn't use modal-sm.
* tweaked the css so that centered text only applies to modal-sm.