### PR TITLE
fixup some dead code?

### DIFF
--- a/backend/www/manage_event.php
+++ b/backend/www/manage_event.php
@@ -111,23 +111,24 @@ function validate_date_statuses($data, $messages) {
     return $validatedDateStatuses;
 }
 
-function get_dates_type($validDateStatuses) {
-    if (count($validDateStatuses) === 1) {
-        return 'O';
-    } else {
-        // not dealing with 'consecutive'
-        return 'S';
-    }
-}
+// function get_dates_type($validDateStatuses) {
+//     if (count($validDateStatuses) === 1) {
+//         return 'O';
+//     } else {
+//         // not dealing with 'consecutive'
+//         return 'S';
+//     }
+// }
 
-function get_date_string($validDateStatuses) {
-    if (count($validDateStatuses) === 1) {
-        return date_format(end($validDateStatuses)['date'], 'l, F j');
-    } else {
-        // not dealing with 'consecutive'
-        return 'Scattered days';
-    }
-}
+// function get_date_string($validDateStatuses) {
+//     if (count($validDateStatuses) === 1) {
+//         // a "kitchen date": "Mon, Jan 2"
+//         return date_format(end($validDateStatuses)['date'], 'l, F j');
+//     } else {
+//         // not dealing with 'consecutive'
+//         return 'Scattered days';
+//     }
+// }
 
 function get_new_date_statuses($dateStatuses) {
     $newDateStatuses = array();
@@ -209,8 +210,11 @@ function build_json_response() {
     $validDateStatuses = $validatedDateStatuses['validDateStatuses'];
     $messages = $validatedDateStatuses['messages'];
 
-    $data['datestype'] = get_dates_type($validDateStatuses);
-    $data['datestring'] = get_date_string($validDateStatuses);
+    // fix? data is not read from after this, so these calls don't have an effect.
+    // they would have to be above the fromArray call.
+    // this has been broken since 2019-07-12 #40045bed5f66d1ca4df897b2f0c9c5c111ed217a.
+    // $data['datestype'] = get_dates_type($validDateStatuses);
+    // $data['datestring'] = get_date_string($validDateStatuses);
 
     $newDateStatuses = get_new_date_statuses($validDateStatuses);
     $existingDateStatuses = get_existing_date_statuses($validDateStatuses);


### PR DESCRIPTION
i have a question about some dead code... so figure i could make a pr for the discussion.  ( @carrythebanner maybe? )

there are two lines -- 212, and 213 -- which setup the pending event `data` with `datestype` and `datestring`:
```
    $data['datestype'] = get_dates_type($validDateStatuses);
    $data['datestring'] = get_date_string($validDateStatuses);
```

the problem is that `data` only gets _read_ from at one place, and that's much earlier on line 198.  
```
    $event = Event::fromArray($data);
```
that means that the computing and storing the `datestype` and `datestring` doesn't do anything. those fields never get read.

it looks like that broke way back on [Jul 14, 2018](https://github.com/shift-org/shift-docs/commit/40045bed5f66d1ca4df897b2f0c9c5c111ed217a)

should those lines be removed? or should the data get fixed? ( the two fields seem to be legacy, and i think they might not be used anymore. )