### PR TITLE
Pedalpalooza 2023 prep

### DIFF
--- a/site/content/pedalpalooza-calendar.md
+++ b/site/content/pedalpalooza-calendar.md
@@ -3,7 +3,7 @@ title: "Pedalpalooza calendar"
 description: "Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
-type: pp-landing
+type: calevents
 pp: true
 year: 2023
 startdate: 2023-06-01
@@ -18,6 +18,8 @@ poster-image: "/images/pp/pp-general.png"
 [Use only when in "landing page" mode before full launch for the year]
 -->
 
+<!--
 Stay tuned for more information on [Pedalpalooza](/pages/pedalpalooza/) 2023! Be sure to follow [Pedalpalooza on Instagram](https://www.instagram.com/pedalpaloozapdx/) and [Pedalpalooza.org](https://www.pedalpalooza.org/) for updates!
 
 Seeking inspiration? View the [Pedalpalooza archives](/archive/pedal-palooza-archives/) for past bicycle fun events. Looking for current events? Check out the current [ride calendar](/calendar/).
+-->

--- a/site/data/carousel/bike-for-justice.yaml
+++ b/site/data/carousel/bike-for-justice.yaml
@@ -1,4 +1,4 @@
-weight: 6
+weight: 32
 title: "Bike for justice"
 description: "<p>Mobilizing for the community</p>"
 image: "images/carousel/shift-logo-inv.jpg"

--- a/site/data/carousel/bike-fun.yaml
+++ b/site/data/carousel/bike-fun.yaml
@@ -1,4 +1,4 @@
-weight: 2
+weight: 11
 title: "Bringing people together for Bike Fun"
 description: "<p>in Portland, Oregon</p>"
 image: "images/carousel/bike_fun_md.jpg"

--- a/site/data/carousel/lead-rides.yaml
+++ b/site/data/carousel/lead-rides.yaml
@@ -1,4 +1,4 @@
-weight: 4
+weight: 13
 title: "You are encouraged to lead a ride of your own"
 description: "<p>Once you feel comfortable in the saddle</p>"
 image: "images/carousel/lead_md.jpg"

--- a/site/data/carousel/pedalpalooza.yaml
+++ b/site/data/carousel/pedalpalooza.yaml
@@ -1,8 +1,8 @@
-#weight: 1
-#title: "Pedalpalooza Bike Summer"
-#description: "<p>Post
-#<br>Pedalpalooza
-#<br>BIKE SUMMER 2022
-#<br>Rides Now</p>"
-#image: "images/carousel/pedalpalooza-2022.jpg"
-#link: "/pedalpalooza-calendar/"
+weight: 21
+title: "Pedalpalooza Bike Summer"
+description: "<p>Post
+<br>Pedalpalooza
+<br>BIKE SUMMER 2023
+<br>Rides Now</p>"
+image: "images/carousel/pedalpalooza-general.png"
+link: "/pedalpalooza-calendar/"

--- a/site/data/carousel/public-health.yaml
+++ b/site/data/carousel/public-health.yaml
@@ -1,4 +1,4 @@
-weight: 5
+weight: 31
 title: "Public Health"
 description: "<p>Staying safe and healthy</p>"
 image: "images/carousel/shift-logo.jpg"

--- a/site/data/carousel/welcome.yaml
+++ b/site/data/carousel/welcome.yaml
@@ -1,4 +1,4 @@
-weight: 3
+weight: 12
 title: "All are welcome to ride with us"
 description: "<p>Most rides are non-competitive and free-wheeling, <br>tending toward social gathering.</p>"
 image: "images/carousel/welcome_md.jpg"

--- a/site/themes/s2b_hugo_theme/layouts/calevents/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/calevents/single.html
@@ -29,7 +29,7 @@
                   {{ else }}
                     <!-- on other cal pages, display smaller banner that links to PP cal page -->
                     <!-- only display when PP is coming soon or happening now -->
-                    <!-- {{ partial "cal/pp-promo-banner.html" . }} -->
+                    {{ partial "cal/pp-promo-banner.html" . }}
 
                     <!-- only display during Steptember -->
                     <!-- {{ partial "cal/promo-banner-steptember.html" . }} -->

--- a/site/themes/s2b_hugo_theme/layouts/calgrid/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/calgrid/single.html
@@ -26,7 +26,7 @@
                 </div>
 
                 <!-- only display when PP is coming soon or happening now -->
-                <!-- {{ partial "cal/pp-promo-banner.html" . }} -->
+                {{ partial "cal/pp-promo-banner.html" . }}
 
                 <!-- only display during Steptember -->
                 <!-- {{ partial "cal/promo-banner-steptember.html" . }} -->

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
@@ -168,11 +168,9 @@
         <div id="timeandlocation-fields" class="panel-collapse collapse in">
           <div class="panel-body">
 
-			<!--
-			<div class="pp-banner">
-			  <a href="/pages/pedalpalooza/" target="_blank" title="opens in a new window">Pedalpalooza 2022</a> is on! Bike summer returns for all of June, July, and August!
-			</div>
-			-->
+            <div class="pp-banner">
+              <a href="/pages/pedalpalooza/" target="_blank" title="opens in a new window">Pedalpalooza 2023</a> is on! Bike summer returns for all of June, July, and August!
+            </div>
 
             <div class="form-group">
               <label class="control-label req-label" for="datestring">Date</label>

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-header.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-header.html
@@ -13,19 +13,18 @@
   <div id="pp-description">
       <p><a href="/pages/pedalpalooza/">Pedalpalooza</a> is a festival of bikey fun. Hundreds of different events are organized by people like you. Most rides are free and all are open to the public to join.</p>
 
-      {{ if or (eq (.Param "year") 2021) (eq (.Param "year") 2022) }}
+      {{ if or (eq (.Param "year") 2021) (eq (.Param "year") 2022) (eq (.Param "year") 2023) }}
       <p>Bike Summer will be <strong>three whole months</strong> of fun on two wheels. 
-<!--
 
-      {{ if eq (.Param "year") 2022 }}<a href="/addevent/"><strong>Add your events for June, July, and August {{ .Param "year" }} now!</strong></a>{{ end }} 
+      {{ if eq (.Param "year") 2023 }}<a href="/addevent/"><strong>Add your events for June, July, and August {{ .Param "year" }} now!</strong></a>{{ end }}
 
--->
+
       Seeking inspiration? View the <a href="/archive/pedal-palooza-archives/">Pedalpalooza archives</a> of past bicycle fun events. If you need help creating or editing an event, check out the <a href="/pages/calendar-faq/">calendar FAQ</a> or <a href="mailto:bikecal@shift2bikes.org">contact the calendar crew</a>.</p>
 
 <p>Check <a href="https://www.pedalpalooza.org/">Pedalpalooza.org</a> for updates, follow <a href="https://www.instagram.com/pedalpaloozapdx/">Pedalpalooza on Instagram</a>, and tag posts about rides <strong>@pedalpaloozapdx</strong>!</p>
       {{ end }}
 
-      {{ if eq (.Param "year") 2022 }}
+      {{ if eq (.Param "year") 2023 }}
       <div class="donate">
         <p>
           <span>Support Bike Summer</span>

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-promo-banner.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-promo-banner.html
@@ -1,5 +1,5 @@
 <div class="pp-banner">
-  <a href="/images/pp/pp2022.jpg"><img alt="Pedalpalooza" id="pedalpalooza-img" src="/images/pp/pp2022-banner.jpg"></a>
+  <a href="/images/pp/pp-general.png"><img alt="Pedalpalooza" id="pedalpalooza-img" src="/images/pp/pp-general-banner.png"></a>
   <p><strong class="pp-headline"><a href="/pages/pedalpalooza/">Pedalpalooza</a> is on! All summer &mdash; June, July, and August!</strong></p>
   <p>Go to the <a href="/pedalpalooza-calendar/">Pedalpalooza calendar</a> and <a href="https://www.pedalpalooza.org">Pedalpalooza.org</a> for more details</p>
 </div>


### PR DESCRIPTION
PP card is not yet at the front of the carousel queue; when this year's artwork is added (still to come), it can be bumped to the front.