### PR TITLE
More visible focus styles for sponsors list

### DIFF
--- a/site/themes/s2b_hugo_theme/static/css/custom.css
+++ b/site/themes/s2b_hugo_theme/static/css/custom.css
@@ -72,8 +72,8 @@ main .donate a {
 }
 
 .customers .item {
-  margin-top: 2px;
-  margin-bottom: 2px;
+  margin-top: 4px;
+  margin-bottom: 4px;
 }
 
 .customers .item:focus-within {

--- a/site/themes/s2b_hugo_theme/static/css/custom.css
+++ b/site/themes/s2b_hugo_theme/static/css/custom.css
@@ -71,6 +71,22 @@ main .donate a {
   }
 }
 
+.customers .item {
+  margin-top: 2px;
+  margin-bottom: 2px;
+}
+
+.customers .item:focus-within {
+  outline: 2px solid #337AB7;
+  outline-offset: 2px;
+}
+
+.customers .item a:focus img {
+  max-width: auto;
+  filter: none;
+  -webkit-filter: none;
+}
+
 /* see https://github.com/shift-org/shift-docs/issues/326 */
 @media (-ms-high-contrast: active), (forced-colors: active) {
   svg.icon, svg.logo {


### PR DESCRIPTION
To demonstrate, Tab through the homepage. When you reach the sponsor logos (Umbrella, etc.), the focused sponsor will have an outline around the entire block and the image will be full color. The greyscale-to-full color transform was already happening on hover, but not focus.