### PR TITLE
fix for #483

### DIFF
--- a/backend/www/manage_event.php
+++ b/backend/www/manage_event.php
@@ -82,10 +82,11 @@ function upload_attached_file($event, $messages) {
         $file_message = $uploader->validate('file', TRUE);
         if ($file_message != null) {
             $messages = array('file' => $file_message);
+        } else {
+            global $IMAGEDIR;
+            $file = $uploader->move($IMAGEDIR, 'file');
+            $event->setImage($file->getName());
         }
-        global $IMAGEDIR;
-        $file = $uploader->move($IMAGEDIR, 'file');
-        $event->setImage($file->getName());
     }
     return $messages;
 }


### PR DESCRIPTION
fix for https://github.com/shift-org/shift-docs/issues/483
skips trying to move an image file if it failed to upload due to validation.
( that allows the code to properly return an error rather than raise an exception )
