### PR TITLE
improvements for soft delete

### DIFF
--- a/backend/models/Event.php
+++ b/backend/models/Event.php
@@ -135,6 +135,8 @@ class Event extends fActiveRecord {
         foreach ($eventTimes as $eventTime) {
             $eventTime->cancelOccurrence();
         }
+        // setting 'E' excludes the event from getRangeVisible()
+        $this->setReview('E');
         $this->setPassword(""); 
         $this->storeChange();
     }
@@ -201,6 +203,12 @@ class Event extends fActiveRecord {
         if ($this->getHidden() != 0) {
             $this->setHidden(0);
         }
+    }
+
+    // deleted events are marked as 'E' which makes them inaccessible to the front-end
+    // while still showing them on the ical feed ( as canceled. )
+    public function isDeleted() {
+        return $this->getReview() == 'E';
     }
 
     // prefer this instead of "store" in most cases.

--- a/backend/models/Event.php
+++ b/backend/models/Event.php
@@ -130,10 +130,10 @@ class Event extends fActiveRecord {
     }
 
     // cancel all occurrences of this event, and make it inaccessible to the organizer.
-    public function cancelEvent() {
+    public function deleteEvent() {
         $eventTimes = $this->buildEventTimes('id');
         foreach ($eventTimes as $eventTime) {
-            $eventTime->cancelOccurrence();
+            $eventTime->deleteOccurrence();
         }
         // setting 'E' excludes the event from getRangeVisible()
         $this->setReview('E');
@@ -145,7 +145,11 @@ class Event extends fActiveRecord {
         $eventDateStatuses = array();
         $eventTimes = $this->buildEventTimes('id');
         foreach ($eventTimes as $eventTime) {
-            $eventDateStatuses []= $eventTime->getFormattedDateStatus();
+            // dont send soft deleted events to the client.
+            // tdb: is there someway to filter this via buildEventTimes()?
+            if (!$eventTime->getDeleted()) {
+                $eventDateStatuses []= $eventTime->getFormattedDateStatus();
+            }
         }
         return $eventDateStatuses;
     }

--- a/backend/models/EventTime.php
+++ b/backend/models/EventTime.php
@@ -71,6 +71,19 @@ class EventTime extends fActiveRecord {
         );
     }
 
+    // get all published events, even the excluded ones
+    public static function getFullRange($firstDay, $lastDay) {
+        return fRecordSet::build(
+            'EventTime', // class
+            array(
+                'eventdate>=' => $firstDay,
+                'eventdate<=' => $lastDay,
+                'calevent{id}.hidden!' => 1  // hidden is 0 once published
+            ), // where
+            array('eventdate' => 'asc')  // order by
+        );
+    }
+
     // Find all occurrences of any EventTime within the specified date range.
     // Dates are in the "YYYY-MM-DD" format. ( ex. 2006-01-02 )
     public static function getRangeVisible($firstDay, $lastDay) {
@@ -81,7 +94,7 @@ class EventTime extends fActiveRecord {
                 'eventdate<=' => $lastDay,
                 'calevent{id}.hidden!' => 1,  // hidden is 0 once published
                 'eventstatus!' => 'S',        // 'S', skipped, a legacy status code.
-                'calevent{id}.review!' => 'E' // 'E', excluded, a legacy status code.
+                'calevent{id}.review!' => 'E' // 'E', excluded, a legacy status code; reused for soft-deletion.
             ), // where
             array('eventdate' => 'asc')  // order by
         );

--- a/backend/models/EventTime.php
+++ b/backend/models/EventTime.php
@@ -70,6 +70,7 @@ class EventTime extends fActiveRecord {
             array(
                 'pkid=' => $id,
                 'calevent{id}.hidden!' => 1,  // hidden is 0 once published
+                'eventstatus!' => 'D',        // 'D', deleted, for soft deletion
             )
         );
     }

--- a/backend/www/delete_event.php
+++ b/backend/www/delete_event.php
@@ -56,7 +56,7 @@ function build_json_response() {
         }
     } else {
         try{
-            $event->cancelEvent();
+            $event->deleteEvent();
         } catch(Exception $ex) {
             error_log("couldn't cancel event " . $ex->getMessage());
             return text_error('Server error');

--- a/backend/www/ical.php
+++ b/backend/www/ical.php
@@ -78,7 +78,7 @@ function exportCurrent($cfg) {
     $now = new DateTimeImmutable(); // now.
     $start = $now->sub(new DateInterval('P1M'))->format('Y-m-d');
     $end = $now->add(new DateInterval('P3M'))->format('Y-m-d');
-    $eventTimes = EventTime::getRangeVisible($start, $end);
+    $eventTimes = EventTime::getFullRange($start, $end);
     return buildCalendar($cfg, $eventTimes);
 }
 
@@ -96,7 +96,7 @@ function exportStringRange($cfg, $start, $end) {
         if ($range < 0 || $range > 100) {
             throw new Exception("bad date range $range days");
         }
-        $eventTimes = EventTime::getRangeVisible($start, $end);
+        $eventTimes = EventTime::getFullRange($start, $end);
         return buildCalendar($cfg, $eventTimes);
     }
 }

--- a/backend/www/retrieve_event.php
+++ b/backend/www/retrieve_event.php
@@ -21,6 +21,8 @@ if (!isset($_GET['id'])) {
     $event = Event::getByID($_GET['id']);
     if (!$event) {
         $response = text_error('Event not found');
+    } else if ($event->isDeleted()) {
+        $response = text_error('Event was deleted');
     } else {
         $secret_valid = $event->secretValid($_GET['secret']);
         $response = $event->toDetailArray($secret_valid);


### PR DESCRIPTION
one possible way of differentiating between canceled events and deleted events.

- reuses the legacy calevent review value of 'E'  which excludes events from EventTime::getRangeVisible()
- adds an "EventTime::getFullRange" so ical can still report those events
- adds an error to retrieve event for deleted events

setting as "draft" because still needs local testing.