### PR TITLE
raise the permitted nginx body size to handle the image size told to users in edit.html

### DIFF
--- a/backend/www/manage_event.php
+++ b/backend/www/manage_event.php
@@ -77,7 +77,11 @@ function upload_attached_file($event, $messages) {
             ),
             'The file uploaded is not an image'
         );
-        $uploader->setMaxSize('2MB');
+        // re: image size - see also the nginx shift.conf and edit.html.
+        // this is larger than the nginx limit so that nginx makes the real decision 
+        // while still having some cap here "just in case".
+        // ( meaning, the client only has one error to handle in practical use: http 413 )
+        $uploader->setMaxSize('3MB');
         $uploader->setOptional();
         $file_message = $uploader->validate('file', TRUE);
         if ($file_message != null) {

--- a/services/nginx/conf.d/shift.conf
+++ b/services/nginx/conf.d/shift.conf
@@ -18,6 +18,11 @@ server {
     error_log  /var/log/nginx/error.log debug;
     access_log /var/log/nginx/access.log;
 
+    # see also manage_event.php which has its own limits
+    # and edit.html which describes the limit; 
+    # this is slightly larger than the described limit to account for the json
+    # and to be a little forgiving generally.
+    client_max_body_size 2.25m;
 
     # replace ics.php with the newer ical.php
     location ^~ /api/ics.php {


### PR DESCRIPTION
see issue #12 for details;
this isn't a complete fix for that issue.
the client javascript still needs to communicate the 413 errors to the user,
but at least this means that organizers should be able upload images of up to 2megs as expected.