### PR TITLE
ngnix doesnt like the decimal point

### DIFF
--- a/services/nginx/conf.d/shift.conf
+++ b/services/nginx/conf.d/shift.conf
@@ -22,7 +22,7 @@ server {
     # and edit.html which describes the limit; 
     # this is slightly larger than the described limit to account for the json
     # and to be a little forgiving generally.
-    client_max_body_size 2.25m;
+    client_max_body_size 2250k;
 
     # replace ics.php with the newer ical.php
     location ^~ /api/ics.php {


### PR DESCRIPTION
well, that was terrible. 
i had fully tested the 2mb limit, then nudged it up a bit ... but apparently didnt properly restart nginx;
it doesn't like the decimal point and won't boot properly with it.
i converted to kb and its happier again.