### PR TITLE
restore manage_event.php to 2mb with comments

### DIFF
--- a/backend/www/manage_event.php
+++ b/backend/www/manage_event.php
@@ -78,10 +78,12 @@ function upload_attached_file($event, $messages) {
             'The file uploaded is not an image'
         );
         // re: image size - see also the nginx shift.conf and edit.html.
-        // this is larger than the nginx limit so that nginx makes the real decision 
-        // while still having some cap here "just in case".
+        // ideally this would be larger nginx's limit so to allow nginx to make the real decision.
         // ( meaning, the client only has one error to handle in practical use: http 413 )
-        $uploader->setMaxSize('3MB');
+        // however, php has a "upload-max-filesize", 
+        // and flourish gets unhappy when the value here is larger than that.
+        // https://www.php.net/manual/en/ini.core.php#ini.upload-max-filesize
+        $uploader->setMaxSize('2MB');
         $uploader->setOptional();
         $file_message = $uploader->validate('file', TRUE);
         if ($file_message != null) {


### PR DESCRIPTION
ideally manage_event's limit would be larger nginx's limit so to allow nginx to make the real decision.
( meaning, the client only has one error to handle in practical use: http 413 )

however, php has a "upload-max-filesize",  and flourish gets unhappy when the value is larger than that.
https://www.php.net/manual/en/ini.core.php#ini.upload-max-filesize

the client does have to handle two kinds of errors:
* the errors json -- which it reports as an error in the image field ( re: the recent fix to handle validation errors )
* http 413 when the image is larger than nginx's limit, which it currently reports as a generic server error to the organizer.