### PR TITLE
switch "Copy Calendar Feed URL" button to a webcal link

### DIFF
--- a/site/content/pages/calendar-faq.md
+++ b/site/content/pages/calendar-faq.md
@@ -96,12 +96,23 @@ Email the [Shift calendar crew](mailto:bikecal@shift2bikes.org) if you need help
 
 The Pedalpalooza events can be added to your computer or smart phone's calendar. As new rides are created, they will show up on your calendar automatically ( usually within 24 hours of the ride being posted by the organizer. ) This is a convenient way to stay up to date, but remember these are community driven events: any and all events will be visible when you view your calendar.
 
-In most cases, clicking this link -- <a href="webcal://www.shift2bikes.org/cal/pedalpalooza-calendar.php">webcal://www.shift2bikes.org/cal/pedalpalooza-calendar.php</a> -- will open your calendar application automatically, and it will guide you through the steps to subscribe. If that doesn't work you will have to subscribe manually; the exact steps will depend on what type of phone or calendar application you are using.  
+On many devices, clicking this link -- <a href="webcal://www.shift2bikes.org/cal/pedalpalooza-calendar.php">webcal://www.shift2bikes.org/cal/pedalpalooza-calendar.php</a> -- will open your calendar app automatically, and the app will guide you through the steps to subscribe. 
 
-Here are some links for common cases:
+For Android devices ( or for google calendar on iOS devices ) you will have to subscribe manually.
+
+### Android and Google Calendar:
+
+1. Copy the pedalpalooza calendar link above ( on Android, by pressing and holding the link until the "Copy link address" menu appears, and then selecting that option. ) 
+2. Visit [Google Calendar](https://calendar.google.com/calendar/u/0/r/settings/addbyurl) and if asked log into your Google account.
+3. On that Google Calendar page, paste the link you copied into the "URL of Calendar" box ( press on that box and hold until the "Paste" menu appears, then choose that option. )
+4. Finally, click the "Add calendar" button. 
+5. 🎉 ( Now find a ride you like, and bike on over! )
+
+For additional help with Android and Google Calendar, please see this [Google support page](https://support.google.com/calendar/answer/37100) under "Use a link to add a public calendar."
+
+### Other common cases:
 
 1. [iPhone Calendar App](https://support.apple.com/guide/iphone/use-multiple-calendars-iph3d1110d4/ios) - use the instructions under "Set up a calendar: _Subscribe to an external, read-only calendar._"
-2. [Google Calendar](https://support.google.com/calendar/answer/37100) - scroll down on that page and follow the instructions for "Use a link to add a public calendar". Note: regardless of whether you're using google calendar on your ios, android device, or computer; you will have subscribe using your web browser.
-3. [Mac Mail](https://support.apple.com/guide/calendar/subscribe-to-calendars-icl1022/mac) - follow the instructions for "Subscribe to a calendar."
-4. [Outlook](https://support.microsoft.com/en-us/office/import-or-subscribe-to-a-calendar-in-outlook-on-the-web-503ffaf6-7b86-44fe-8dd6-8099d95f38df) - follow the instructions for "Subscribing to a calendar."
-5. [Thunderbird](https://support.mozilla.org/en-US/kb/adding-a-holiday-calendar) - follow the instructions for subscribing to an "internet holiday calendar", but use the pedalpalooza calendar link from above.  ( Pedalpalooza is basically a holiday anyway, right? 😊 )
+1. [Mac Mail](https://support.apple.com/guide/calendar/subscribe-to-calendars-icl1022/mac) - follow the instructions for "Subscribe to a calendar."
+1. [Outlook](https://support.microsoft.com/en-us/office/import-or-subscribe-to-a-calendar-in-outlook-on-the-web-503ffaf6-7b86-44fe-8dd6-8099d95f38df) - follow the instructions for "Subscribing to a calendar."
+1. [Thunderbird](https://support.mozilla.org/en-US/kb/adding-a-holiday-calendar) - follow the instructions for subscribing to an "internet holiday calendar", but use the pedalpalooza calendar link from above.  ( Pedalpalooza is basically a holiday anyway, right? 😊 )

--- a/site/content/pages/calendar-faq.md
+++ b/site/content/pages/calendar-faq.md
@@ -91,3 +91,17 @@ Yes, but we ask that you clearly indicate that the event isn't a ride, or you ma
 ### I'm having trouble posting a ride or making changes. Who do I contact?
 
 Email the [Shift calendar crew](mailto:bikecal@shift2bikes.org) if you need help.
+
+## Subscribing to the calendar
+
+The Pedalpalooza events can be added to your computer or smart phone's calendar. As new rides are created, they will show up on your calendar automatically ( usually within 24 hours of the ride being posted by the organizer. ) This is a convenient way to stay up to date, but remember these are community driven events: any and all events will be visible when you view your calendar.
+
+In most cases, clicking this link -- <a href="webcal://www.shift2bikes.org/cal/pedalpalooza-calendar.php">webcal://www.shift2bikes.org/cal/pedalpalooza-calendar.php</a> -- will open your calendar application automatically, and it will guide you through the steps to subscribe. If that doesn't work you will have to subscribe manually; the exact steps will depend on what type of phone or calendar application you are using.  
+
+Here are some links for common cases:
+
+1. [iPhone Calendar App](https://support.apple.com/guide/iphone/use-multiple-calendars-iph3d1110d4/ios) - use the instructions under "Set up a calendar: _Subscribe to an external, read-only calendar._"
+2. [Google Calendar](https://support.google.com/calendar/answer/37100) - scroll down on that page and follow the instructions for "Use a link to add a public calendar". Note: regardless of whether you're using google calendar on your ios, android device, or computer; you will have subscribe using your web browser.
+3. [Mac Mail](https://support.apple.com/guide/calendar/subscribe-to-calendars-icl1022/mac) - follow the instructions for "Subscribe to a calendar."
+4. [Outlook](https://support.microsoft.com/en-us/office/import-or-subscribe-to-a-calendar-in-outlook-on-the-web-503ffaf6-7b86-44fe-8dd6-8099d95f38df) - follow the instructions for "Subscribing to a calendar."
+5. [Thunderbird](https://support.mozilla.org/en-US/kb/adding-a-holiday-calendar) - follow the instructions for subscribing to an "internet holiday calendar", but use the pedalpalooza calendar link from above.  ( Pedalpalooza is basically a holiday anyway, right? 😊 )

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-feed.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-feed.html
@@ -1,5 +1,5 @@
 <div id="pp-calendar-feed" class="pp-banner" style="text-align: center; padding-top: 1rem; margin-top: 1rem;">
-  <p>Want to see rides in your own calendar? Subscribe to the calendar feed in the calendar app on your phone or computer!</p>
-  <p><button type="button" id="feed-sub" class="btn">Copy calendar feed URL</button></p>
-  <p><input type="text" id="feed-url" readonly value="https://www.shift2bikes.org/cal/pedalpalooza-calendar.php"></p>
+  <p>Want to see rides using your computer or phone's calendar app? 
+  <p><a href="webcal://www.shift2bikes.org/cal/pedalpalooza-calendar.php">Subscribe to the calendar feed</a>!
+  <p>If clicking the subscribe link doesn't work, please see the <a href="/pages/calendar-faq/">FAQ</a> for more info.
 </div>

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-feed.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-feed.html
@@ -1,5 +1,4 @@
 <div id="pp-calendar-feed" class="pp-banner" style="text-align: center; padding-top: 1rem; margin-top: 1rem;">
   <p>Want to see rides using your computer or phone's calendar app? 
-  <p><a href="webcal://www.shift2bikes.org/cal/pedalpalooza-calendar.php">Subscribe to the calendar feed</a>!
-  <p>If clicking the subscribe link doesn't work, please see the <a href="/pages/calendar-faq/">FAQ</a> for more info.
+  <p><a href="/pages/calendar-faq/#subscribing-to-the-calendar">Subscribe to the calendar feed!</a>
 </div>

--- a/site/themes/s2b_hugo_theme/static/js/cal/main.js
+++ b/site/themes/s2b_hugo_theme/static/js/cal/main.js
@@ -228,12 +228,6 @@ $(document).ready(function() {
       }
     });
 
-    $(document).on('click', '#feed-sub', function() {
-      var textBox = document.getElementById("feed-url");
-      textBox.select();
-      document.execCommand("copy");
-    });
-
     $(document).on('click', '#date-picker-prev-month', function(ev) {
       var currentPosition = $("#date-select").scrollTop();
       $("#date-select").scrollTop(currentPosition - 112);


### PR DESCRIPTION
for issue #434 - switch the pedalp's "Copy Calendar Feed URL" button to an inline webcal link.
( which should automatically activate the user's calendar app )
- adds instructions for a few different calendar apps to the faq
- removes the "on click: copy feed url" handler from main.js