### PR TITLE
cache busting

### DIFF
--- a/backend/models/Event.php
+++ b/backend/models/Event.php
@@ -234,8 +234,13 @@ class Event extends fActiveRecord {
         }
     }
 
-    // ensure that the image is stored in the right location, and 
-    // return the path to the image.
+    // ensure that the image is stored in the right location,
+    // and return url of the image.  
+    // ex. https://shift2bikes.org/eventimages/9248-5.png
+    //
+    // the url includes a "sequence" number to handle "cache-busting" for image changes.
+    // ngnix ( see `shift.conf` ) strips the sequence number to find the real file.
+    // the sequence changes whenever the event is updated ( rather than just when the image has changed ) -- not ideal, but good enough. 
     private function updateImageUrl($storeIfChanged) {
         global $IMAGEDIR;
         global $IMAGEURL;
@@ -266,8 +271,9 @@ class Event extends fActiveRecord {
                 }
             }
         }
-        // ex. https://shift2bikes.org/eventimages/9248.png
-        return "$IMAGEURL/$new_name";
+        // return the image url including the cache-busting sequence.
+        $sequence = $this->getChanges();
+        return "$IMAGEURL/$id-$sequence.$ext";
     }
 }
 

--- a/docs/TABLES.md
+++ b/docs/TABLES.md
@@ -11,6 +11,10 @@ See also:
   - **modified**, timestamp:
 
     ex. 2022-10-01 19:41:25
+    
+  - **changes** int
+  
+    sequential counter indicated the number of time the organizer has changed the event. used primarily for the calendar feed so that ical clients will notice when changes to the event have occurred. also used for event image cache busting.
 
   - **name** string
 

--- a/services/nginx/conf.d/shift.conf
+++ b/services/nginx/conf.d/shift.conf
@@ -70,6 +70,16 @@ server {
         alias /opt/legacy/cal;
     }
 
+    # handle images of the standard shift format 
+    # ex. /eventimages/9248-124.png
+    #
+    location ~ /eventimages/(\d+)(?:-\d+).(\w+) {
+        alias /opt/backend/eventimages/$1.$2;
+        expires max;
+    }
+
+    # a fallback for images that don't fit the expected format for some reason.
+    #
     location /eventimages {
         alias /opt/backend/eventimages;
     }


### PR DESCRIPTION
- uses the calevent sequence number to generate unique image urls; every published event change generates a new url ( regardless of whether the image was changed. )
- adds a regex handler to nginx to strip the sequence from url to find the real file.
- sets the lifetime for images using the sequence urls to max-age
