### PR TITLE
change the event image placeholder to a 1x1 blank image

### DIFF
--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
@@ -222,7 +222,7 @@
           <div class="eventImg">
             [[# image]]
             <a href="[[image]]">
-              <img class="lazy" src="{{ .Site.BaseURL }}img/cal/icons/image.svg" data-src="[[image]]" alt="User-uploaded image for [[title]]" />
+              <img class="lazy" src="{{ .Site.BaseURL }}img/cal/icons/blank.svg" data-src="[[image]]" alt="User-uploaded image for [[title]]" />
             </a>
             [[/ image]]
           </div>

--- a/site/themes/s2b_hugo_theme/static/img/cal/icons/blank.svg
+++ b/site/themes/s2b_hugo_theme/static/img/cal/icons/blank.svg
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"/>


### PR DESCRIPTION
updates the placeholder image so that there isn't a flash of the "sun over mountains" on load.

ex.
https://www.shift2bikes.org/calendar/event-16559
vs.
https://deploy-preview-526--shift-docs.netlify.app/calendar/event-16559

refresh on both pages, on the first one a visible placeholder will appear; while the second one has the "invisible" placeholder and to my eye feels smoother.  ( i have some local images that are smaller than this example, and especially for those, the original placeholder can create a noticeable visual jump just before the real image loads in. )
