### PR TITLE
Extra metadata for ride permalinks and external links

### DIFF
--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
@@ -190,7 +190,7 @@
                   <div class="location">
                     <p>
                       [[#mapLink]]
-                      <a href="[[mapLink]]" target="_blank" rel="noopener" title="Opens in a new window">
+                      <a href="[[mapLink]]" target="_blank" rel="noopener nofollow external"  title="Opens in a new window">
                       [[/mapLink]]
                       <svg class="icon" role="img" aria-label="Location"><use href="#icon-location" /><title>Location</title></svg>
 
@@ -267,7 +267,7 @@
 
           [[ #weburl ]]
           <p class="contactInfo">
-            <a href="[[webLink]]" target="_blank" rel="noopener" title="Opens in a new window">
+            <a href="[[webLink]]" target="_blank" rel="noopener nofollow external" title="Opens in a new window">
               <svg class="icon" role="img" aria-label="Website"><use href="#icon-website" /><title>Website</title></svg>
               [[#webname]][[webname]][[/webname]]
               [[^webname]][[weburl]][[/webname]]
@@ -280,7 +280,7 @@
 
           [[#contactLink]]
           <p class="contactInfo">
-            <a href="[[contactLink]]" target="_blank" rel="noopener" title="Opens in a new window">
+            <a href="[[contactLink]]" target="_blank" rel="noopener nofollow external" title="Opens in a new window">
               <svg class="icon" role="img" aria-label="Additional contact info"><use href="#icon-website" /><title>Additional contact info</title></svg>
               [[contact]]
             </a>
@@ -307,7 +307,8 @@
                   [[^preview]]
                       href="[[shareLink]]"
                   [[/preview]]
-                  class="share-link">
+                  class="share-link"
+                  rel="bookmark">
                   Sharable link</a>
               </li>
               <li>

--- a/site/themes/s2b_hugo_theme/layouts/partials/scripts.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/scripts.html
@@ -27,7 +27,7 @@
 <script type="text/javascript">
   $(document).ready(function() {
     $(".s2b-external-link").attr("target", "_blank");
-    $(".s2b-external-link").attr("rel", "noopener");
+    $(".s2b-external-link").attr("rel", "noopener nofollow external");
     $(".s2b-external-link").attr("title", "Opens in a new window");
     $(".s2b-external-link").prepend($("<i class='glyphicon glyphicon-new-window' aria-hidden='true'></i>"));
   });


### PR DESCRIPTION
Adds `rel` attribute for ride permalinks (`rel="bookmark"`) and external links (`rel="noopener nofollow external"`). No functional changes because of this, just adds a bit of metadata which may or may not be used by web crawlers or other clients. Also provides a easy-to-understand CSS hooks for styling, if needed (e.g.`a[rel~="external"]`).