### PR TITLE
WIP move last modified date on policy pages to front matter

### DIFF
--- a/site/content/pages/public-health.md
+++ b/site/content/pages/public-health.md
@@ -12,6 +12,8 @@ weight: "7"
 menu:
   main:
     parent: communitynav
+type: policy
+lastmod: 2023-05-13
 ---
 
 ## Ride safely
@@ -70,5 +72,3 @@ If a ride leader agrees to follow these specific guidelines, a special marker wi
 If you have questions or concerns about the safety policies for a ride, past or upcoming, reach out to the ride leaders or [contact us](/pages/contact/). Shift reserves the right to moderate calendar listings, and this may include removing the COVID Safety Plan designation from a ride if we are aware that it does not follow this policy.
 
 Please note: These guidelines have changed over time as conditions and public health guidelines have evolved. For past rides, refer to the [page history](https://github.com/shift-org/shift-docs/commits/main/site/content/pages/public-health.md) on GitHub to determine the version of policies in place at that time.
-
-*Last updated: May 2023*

--- a/site/content/pages/shift-code-of-conduct.md
+++ b/site/content/pages/shift-code-of-conduct.md
@@ -4,6 +4,8 @@ weight: 2
 menu:
   main:
     parent: aboutmenu
+type: policy
+lastmod: 2023-08-26
 ---
 ## 1. Purpose
 

--- a/site/themes/s2b_hugo_theme/layouts/policy/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/policy/single.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="{{ .Site.LanguageCode }}">
+
+  {{ partial "head.html" . }}
+
+  <body>
+
+    <div id="all">
+
+        <header>
+
+          {{ partial "nav.html" . }}
+
+        </header>
+
+        <main>
+
+            {{ partial "breadcrumbs.html" . }}
+
+            <div id="content">
+                {{ if isset .Params "id" }}
+
+                  {{ partial .Params.id . }}
+
+                {{ else }}
+
+                <div class="container">
+
+                    <div class="row">
+
+                        <div class="col-md-12">
+
+                            <div>
+                              {{ .Content }}
+                            </div>
+
+                            <div class="lastmod">
+                            <!-- Last updated: {{ .Lastmod | time.Format ":date_medium" }} -->
+                            Last updated: {{ .Lastmod | time.Format .Site.Params.date_format }}
+                            <!-- Last updated: {{ .Lastmod }} -->
+                            <!-- see  https://github.com/shift-org/shift-docs/pull/213 -->
+                            <!-- also https://makewithhugo.com/add-a-last-edited-date/ -->
+                            </div>
+                        </div>
+
+                    </div>
+                    <!-- /.row -->
+
+                </div>
+                <!-- /.container -->
+
+                {{ end }}
+            </div>
+            <!-- /#content -->
+
+        </main>
+
+        <footer>
+
+            {{ partial "footer.html" . }}
+
+        </footer>
+
+    </div>
+    <!-- /#all -->
+
+    {{ partial "scripts.html" . }}
+
+  </body>
+</html>

--- a/site/themes/s2b_hugo_theme/static/css/custom.css
+++ b/site/themes/s2b_hugo_theme/static/css/custom.css
@@ -94,3 +94,7 @@ main .donate a {
     forced-color-adjust: auto;
   }
 }
+
+.lastmod {
+  font-style: italic;
+}


### PR DESCRIPTION
WIP solution to #532. 

Ideally the last modified date would be set automatically, and supposedly this is possible — see https://gohugo.io/methods/page/lastmod/. (Requires `enableGitInfo` to be enabled in the site config, which it is.) However, I experimented with this for a while, and on my local at least, I was always stuck with a mod date of "January 1, 0001." See also https://makewithhugo.com/add-a-last-edited-date/.

This approach in this PR does work, but it's is a little fiddly and just as manual as adding it to the content itself. But, maybe it has the bones of the real solution.