### PR TITLE
Update to latest jQuery

### DIFF
--- a/docs/PACKAGES.md
+++ b/docs/PACKAGES.md
@@ -15,6 +15,6 @@
   * [Mailcheck](https://github.com/mailcheck/mailcheck/releases)
   * [w3c IntersectionObserver polyfill](https://github.com/w3c/IntersectionObserver/tree/main/polyfill) (for lazy loading images)
 
-As of February 2023, all have been updated to their latest releases within their major version.
+As of December 2023, all have been updated to their latest releases within their major version.
 
 FullCalendar, Bootstrap, and Font Awesome are behind at least one major version.

--- a/site/themes/s2b_hugo_theme/layouts/partials/scripts.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/scripts.html
@@ -1,5 +1,5 @@
 {{ template "_internal/google_analytics.html" . }}
-<script src="//code.jquery.com/jquery-3.6.3.min.js" integrity="sha256-pvPw+upLPUjgMXY0G+8O0xUf+/Im1MZjXxxgOcBQBXU=" crossorigin="anonymous"></script>
+<script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
 <script src="//stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 
 <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-cookie/1.4.1/jquery.cookie.min.js"></script>


### PR DESCRIPTION
Updated jQuery to v3.7.1 (from v3.6.3). The latest version and all in between say, "We do not expect compatibility issues when upgrading from a jQuery 3.0+ version": 
* [jQuery v3.6.4 announcement](https://blog.jquery.com/2023/03/08/jquery-3-6-4-released-selector-forgiveness/)
* [jQuery v3.7.0 announcement](https://blog.jquery.com/2023/05/11/jquery-3-7-0-released-staying-in-order/)
* [jQuery v3.7.1 announcement](https://blog.jquery.com/2023/08/28/jquery-3-7-1-released-reliable-table-row-dimensions/)

Smoke test the calendar pages, including adding, editing, and deleting events.