### PR TITLE
Added pagination object to events API response when requesting a range of events

### DIFF
--- a/backend/www/events.php
+++ b/backend/www/events.php
@@ -52,6 +52,28 @@ function daysInRange($startdate, $enddate) {
     return round(($enddate / $days) - ($startdate / $days));
 }
 
+function getPagination($firstDay, $lastDay, $count) {
+    $range = daysInRange($firstDay, $lastDay);
+    $pagination = [ 
+        'start' => date("Y-m-d", $firstDay),
+        'end' => date("Y-m-d", $lastDay),
+        'range' => $range,
+        'events' => $count,
+    ];
+
+    $nextRangeStart = date('Y-m-d', strtotime("+" . $range+1 . " days", $firstDay));
+    $nextRangeEnd = date('Y-m-d', strtotime("+" . $range+1 . " days", $lastDay));
+
+    global $PROTOCOL, $HOST;
+    $data = [
+        'startdate' => $nextRangeStart,
+        'enddate' => $nextRangeEnd,
+    ];
+    $pagination['next'] = $PROTOCOL . $HOST . "/api/events.php?" . http_build_query($data); 
+
+    return $pagination;
+}
+
 if ($enddate < $startdate) {
     $message = "enddate: " . date('Y-m-d', $enddate) . " is before startdate: " . date('Y-m-d', $startdate);
     $json = text_error( $message );
@@ -68,6 +90,7 @@ if ($enddate < $startdate) {
     }
     else {
         $events = EventTime::getRangeVisible($startdate, $enddate);
+        $json['pagination'] = getPagination($startdate, $enddate, count($events));
     }
 
     foreach ($events as $eventTime) {

--- a/docs/CALENDAR_API.md
+++ b/docs/CALENDAR_API.md
@@ -48,7 +48,7 @@ Success:
 * each event object: key-value pairs of all available public fields; does not contain any private fields (use `manage_event` endpoint for those)
 * when using `id` parameter, array is expected to return 1 object; if the ID does not match a known event, you will receive a `200` response with an empty `events` array
 
-Example response:
+Example response for a single event:
 
     {
       "events": [
@@ -89,6 +89,32 @@ Example response:
           "endtime": "20:00:00"
         }
       ]
+    }
+
+Example response for a range of events: 
+
+    {
+      "events": [
+        {
+          "id": "1234",
+          ...
+        },
+        {
+          "id": "1236",
+          ...
+        },
+        {
+          "id": "2200",
+          ...
+        }
+      ], 
+      "pagination": {
+        "start": "2024-07-01",
+        "end": "2024-07-11",
+        "range": 10,
+        "events": 3,
+        "next": "https://www.shift2bikes.org/api/events.php?startdate=2024-07-12&enddate=2024-07-22"
+      }
     }
 
 Errors:


### PR DESCRIPTION
Added a `pagination` object to the `events` API response JSON alongside the `events` array. (Unless a single event is requested by `id`, in which case the `pagination` object is not needed or provided.) 

This `pagination` object is as-yet unused by the front-end, but hopefully this lays the groundwork for A) simplifying client logic for fetching more results, and B) searching by criteria other than by date.

Example output for `https://localhost:4443/api/events.php?startdate=2019-06-01&enddate=2019-06-11`: 
```
"events": [
  { ... }, 
  { ... },
  { ... }
], 
"pagination": {
  "start":"2019-06-01",
  "end":"2019-06-11",
  "range":10,
  "events":105,
  "next":"https://localhost:4443/api/events.php?startdate=2019-06-12&enddate=2019-06-22"
}
```