### PR TITLE
Ride area tag + additional values: Westside, East Portland, Clackamas

### DIFF
--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
@@ -251,6 +251,15 @@
           <div class="panel-body">
 
             <div class="form-group">
+              <label class="control-label" for="area">Area</label>
+              <select name="area" class="form-control" id="area">
+                [[# areaOptions ]]
+                <option value="[[code]]" [[# isSelected ]]selected[[/ isSelected ]]>[[text]]</option>
+                [[/ areaOptions ]]
+              </select>
+            </div>
+
+            <div class="form-group">
               <label class="control-label req-label" for="venue">Location name</label>
               <input type="text" class="form-control" name="venue" id="venue" value="[[venue]]" required="true" aria-invalid="false" />
             </div>
@@ -279,15 +288,6 @@
               <label class="control-label optional-label" for="locend">End location details</label>
               <input type="text" class="form-control" name="locend" id="locend" value="[[locend]]" aria-describedby="locend-help" />
               <p class="input-help" id="locend-help">Your event's end location, if known.</p>
-            </div>
-
-            <div class="form-group">
-              <label class="control-label" for="area">Area</label>
-              <select name="area" class="form-control" id="area">
-                [[# areaOptions ]]
-                <option value="[[code]]" [[# isSelected ]]selected[[/ isSelected ]]>[[text]]</option>
-                [[/ areaOptions ]]
-              </select>
             </div>
 
             <div class="form-group">

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
@@ -190,6 +190,7 @@
                   <div class="location">
                     [[#areaLabel]]
                     <p class="area">
+                      <svg class="icon" role="img" aria-label="Area"><use href="#icon-map" /><title>Area</title></svg>
                       [[areaLabel]]
                     </p>
                     [[/areaLabel]]

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
@@ -188,6 +188,11 @@
                   [[#cancelled]]<del>[[/cancelled]]
 
                   <div class="location">
+                    [[#areaLabel]]
+                    <p class="area">
+                      [[areaLabel]]
+                    </p>
+                    [[/areaLabel]]
                     <p>
                       [[#mapLink]]
                       <a href="[[mapLink]]" target="_blank" rel="noopener" title="Opens in a new window">

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/icons.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/icons.html
@@ -61,4 +61,12 @@
     <path d="M40.0001 22V58" stroke-width="13.2467" stroke-linecap="square"/>
     <path d="M58 40H22" stroke-width="13.2467" stroke-linecap="square"/>
   </symbol>
+
+  <symbol id="icon-map" viewBox="0 0 80 80">
+    <path d="M26.9091 64.6816V11.7309V8.71748L8 13.0224V72L26.9091 67.6951V64.6816Z" fill="currentColor"/>
+    <path d="M72 8L53.0909 12.3049V15.3184V68.2691V71.2825L72 66.9776V8Z" fill="currentColor"/>
+    <path d="M50.1818 68.4126V15.3184V12.4484L29.8182 8.71748V11.5874V64.6816V67.5516L50.1818 71.2825V68.4126Z" fill="currentColor"/>
+    <!-- Map by widphic from <a href="https://thenounproject.com/browse/icons/term/map/" target="_blank" title="Map Icons">Noun Project</a> (CC BY 3.0) -->
+  </symbol>
+
 </svg>

--- a/site/themes/s2b_hugo_theme/static/css/cal/main.css
+++ b/site/themes/s2b_hugo_theme/static/css/cal/main.css
@@ -291,10 +291,10 @@ h3 {
     text-decoration: underline;
 }
 
-.location .area {
+.area {
     background: #FCFAF2;
     color: #663300;
-    padding: 2px 4px;
+    padding: 2px 4px 2px 0;
     border: 1px solid #FFDD66;
     border-radius: 2px;
     display: inline-block;

--- a/site/themes/s2b_hugo_theme/static/css/cal/main.css
+++ b/site/themes/s2b_hugo_theme/static/css/cal/main.css
@@ -292,11 +292,7 @@ h3 {
 }
 
 .area {
-    background: #FCFAF2;
-    color: #663300;
     padding: 2px 4px 2px 0;
-    border: 1px solid #FFDD66;
-    border-radius: 2px;
     display: inline-block;
     width: auto;
     margin: 0.25em 0;

--- a/site/themes/s2b_hugo_theme/static/css/cal/main.css
+++ b/site/themes/s2b_hugo_theme/static/css/cal/main.css
@@ -291,6 +291,17 @@ h3 {
     text-decoration: underline;
 }
 
+.location .area {
+    background: #FCFAF2;
+    color: #663300;
+    padding: 2px 4px;
+    border: 1px solid #FFDD66;
+    border-radius: 2px;
+    display: inline-block;
+    width: auto;
+    margin: 0.25em 0;
+}
+
 .summary {
     padding-left: 10px;
     border-left: 1px solid grey;

--- a/site/themes/s2b_hugo_theme/static/img/cal/icons/map.svg
+++ b/site/themes/s2b_hugo_theme/static/img/cal/icons/map.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80">
+  <path d="M26.9091 64.6816V11.7309V8.71748L8 13.0224V72L26.9091 67.6951V64.6816Z" fill="currentColor"/>
+  <path d="M72 8L53.0909 12.3049V15.3184V68.2691V71.2825L72 66.9776V8Z" fill="currentColor"/>
+  <path d="M50.1818 68.4126V15.3184V12.4484L29.8182 8.71748V11.5874V64.6816V67.5516L50.1818 71.2825V68.4126Z" fill="currentColor"/>
+  <!-- Map by widphic from <a href="https://thenounproject.com/browse/icons/term/map/" target="_blank" title="Map Icons">Noun Project</a> (CC BY 3.0) -->
+</svg>

--- a/site/themes/s2b_hugo_theme/static/js/cal/addevent.js
+++ b/site/themes/s2b_hugo_theme/static/js/cal/addevent.js
@@ -36,7 +36,10 @@
                          {code: 'G', text: 'General. For adults, but kids welcome.'},
                          {code: 'A', text: '21+ only.'}],
             areas = [{code: 'P', text: 'Portland'},
-                {code: 'V', text: 'Vancouver'}];
+                     {code: 'V', text: 'Vancouver'},
+                     {code: 'W', text: 'Westside'},
+                     {code: 'E', text: 'Outer East'},
+                     {code: 'C', text: 'Clackamas'}];
 
         shiftEvent.lengthOptions = [];
         for ( i = 0; i < lengths.length; i++ ) {

--- a/site/themes/s2b_hugo_theme/static/js/cal/addevent.js
+++ b/site/themes/s2b_hugo_theme/static/js/cal/addevent.js
@@ -38,7 +38,7 @@
             areas = [{code: 'P', text: 'Portland'},
                      {code: 'V', text: 'Vancouver'},
                      {code: 'W', text: 'Westside'},
-                     {code: 'E', text: 'Outer East'},
+                     {code: 'E', text: 'East Portland'},
                      {code: 'C', text: 'Clackamas'}];
 
         shiftEvent.lengthOptions = [];

--- a/site/themes/s2b_hugo_theme/static/js/cal/helpers.js
+++ b/site/themes/s2b_hugo_theme/static/js/cal/helpers.js
@@ -1,18 +1,44 @@
 (function($) {
 
     $.fn.getAudienceLabel = function(audience) {
-         if (audience == null) {
-             return null;
-         }
-
-         if (audience == "A") {
-             return "21+ Only";
-         } else if (audience == "F") {
-             return "Family Friendly";
-         } else {
-           //no label needed for general (G) or any other value
-           return null;
+        if (audience == null) {
+            return null;
         }
+
+        if (audience == "A") {
+            return "21+ Only";
+        } else if (audience == "F") {
+            return "Family Friendly";
+        } else {
+            //no label needed for general (G) or any other value
+            return null;
+        }
+    };
+
+    $.fn.getAreaLabel = function(area) {
+        if (area == null) {
+            return null;
+        }
+
+        switch (area) {
+          case 'V':
+              return "Vancouver";
+              break;
+          case 'W':
+              return "Westside";
+              break;
+          case 'E':
+              return "Outer East";
+              break;
+          case 'C':
+              return "Clackamas";
+              break;
+          case 'P':
+              // no label needed for Portland (P)
+          default:
+              return null;
+        }
+
     };
 
     $.fn.getMapLink = function(address) {

--- a/site/themes/s2b_hugo_theme/static/js/cal/helpers.js
+++ b/site/themes/s2b_hugo_theme/static/js/cal/helpers.js
@@ -28,7 +28,7 @@
               return "Westside";
               break;
           case 'E':
-              return "Outer East";
+              return "East Portland";
               break;
           case 'C':
               return "Clackamas";

--- a/site/themes/s2b_hugo_theme/static/js/cal/main.js
+++ b/site/themes/s2b_hugo_theme/static/js/cal/main.js
@@ -33,6 +33,7 @@ $(document).ready(function() {
                 }
 
                 value.audienceLabel = container.getAudienceLabel(value.audience);
+                value.areaLabel = container.getAreaLabel(value.area);
                 value.mapLink = container.getMapLink(value.address);
 
                 if ( 'show_details' in options && options['show_details'] == true ) {


### PR DESCRIPTION
In additional to the existing Portland (`P`) and Vancouver (`V`) values for the `area` field, this adds 3 more values: Westside (`W`), East Portland (`E`), and Clackamas (`C`).

This also reintroduces a display tag on rides indicating the area (unless it's Portland, in which case no tag is displayed).

[Map icon by widphic](https://thenounproject.com/browse/icons/term/map/), via the [Noun Project](https://thenounproject.com/)

Fixes #530.