### PR TITLE
Handle hidden and print fields without needing direct access to the hide/print flag fields

### DIFF
--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
@@ -249,21 +249,17 @@
 
           <p class="description">[[details]]</p>
 
-          [[^hideemail]]
           [[#email]]
           <p class="contactInfo">
             <a href="mailto:[[email]]"><svg class="icon" role="img" aria-label="Email"><use href="#icon-email" /><title>Email</title></svg> [[email]]</a>
           </p>
           [[/email]]
-          [[/hideemail]]
 
-          [[^hidephone]]
           [[#phone]]
           <p class="contactInfo">
             <a href="tel:[[phone]]"><svg class="icon" role="img" aria-label="Phone"><use href="#icon-phone" /><title>Phone</title></svg> [[phone]]</a>
           </p>
           [[/phone]]
-          [[/hidephone]]
 
           [[ #weburl ]]
           <p class="contactInfo">
@@ -275,7 +271,6 @@
           </p>
           [[ /weburl ]]
 
-          [[^hidecontact]]
           [[#contact]]
 
           [[#contactLink]]
@@ -294,7 +289,6 @@
           [[/contactLink]]
 
           [[/contact]]
-          [[/hidecontact]]
 
           <div class="eventlink">
             <p class="facebook-share">
@@ -328,14 +322,14 @@
           <ul>
             <li>title: [[tinytitle]]</li>
             <li>description: [[printdescr]]</li>
-            <li>contact info:</li>
-            <ul>
-              <li>[[organizer]]</li>
-              [[# printemail]]<li>[[email]]</li>[[/ printemail]]
-              [[# printphone]]<li>[[phone]]</li>[[/ printphone]]
-              [[# printweburl]]<li>[[weburl]]</li>[[/ printweburl]]
-              [[# printcontact]]<li>[[contact]]</li>[[/ printcontact]]
-            </ul>
+            <li>contact info:
+              <ul>
+                <li>[[organizer]]</li>
+                [[# printpreviewemail]]<li>[[printpreviewemail]]</li>[[/ printpreviewemail]]
+                [[# printpreviewphone]]<li>[[printpreviewphone]]</li>[[/ printpreviewphone]]
+                [[# printpreviewweburl]]<li>[[printpreviewweburl]]</li>[[/ printpreviewweburl]]
+                [[# printpreviewcontact]]<li>[[printpreviewcontact]]</li>[[/ printpreviewcontact]]
+              </ul>
             </li>
           </ul>
           [[/preview]]

--- a/site/themes/s2b_hugo_theme/static/js/cal/addevent.js
+++ b/site/themes/s2b_hugo_theme/static/js/cal/addevent.js
@@ -303,6 +303,18 @@
             previewEvent['displayEndTime'] = moment(endTime, 'HH:mm').format('h:mm A'); // e.g. 6:00 PM
         }
 
+        // set values for print contact fields if enabled
+        var printContactFields = [ 'email', 'phone', 'contact', 'weburl' ];
+        printContactFields.forEach((field) => {
+            previewEvent[`printpreview${field}`] = $(`#print${field}`).is(":checked") ? $(`#${field}`).val() : null;
+        });
+
+        // clear private fields if hidden
+        var privateContactFields = [ 'email', 'phone', 'contact' ];
+        privateContactFields.forEach((field) => {
+            previewEvent[`${field}`] = $(`#hide${field}`).is(":checked") ? null : $(`#${field}`).val();
+        });
+
         previewEvent['audienceLabel'] = $form.getAudienceLabel(previewEvent['audience']);
         previewEvent['length'] += ' miles';
         previewEvent['mapLink'] = $form.getMapLink(previewEvent['address']);


### PR DESCRIPTION
See comment on #555 regarding the "hide" boolean fields. The "print" boolean fields are similar, though they operate independently (e.g. you can hide your email online, but opt to include it in print). 

----

We currently use the "hide" booleans in the event list view, but only to manage the preview mode when editing (see #380). Otherwise, they're redundant because the backend properly provides or nulls private fields if they're supposed to be hidden. 

This change alters the handling of those fields so that the preview function pulls the "hide" boolean values directly from the current state of the edit form. It also checks the "print" boolean fields, and if they're enabled, sets a special "print preview" field with the appropriate value.

After this change, the `events` endpoint should no longer need either the "hide" or "print" boolean fields, and we could consider removing them from that API response. (They would still be needed for the `manage_event` and `retrieve_event` endpoint.)