### PR TITLE
Moved safety plan checkbox up near audience checkbox

### DIFF
--- a/site/themes/s2b_hugo_theme/layouts/partials/alert_banner.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/alert_banner.html
@@ -1,5 +1,5 @@
 <div id="alert-banner" class="promo-banner">
   <div>
-    <p>Support your community — see how you can <a href="/pages/public-health/">help make bike fun safe for all</a>.</p>
+    <p>Support your community — see how you can <a href="/pages/public-health/"{{ if (eq .Type "caledit") }} target="_blank" title="opens in a new window"{{ end }}> help make bike fun safe for all</a>.</p>
   </div>
 </div>

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
@@ -124,6 +124,16 @@
             </div>
 
             <div class="form-group">
+              <div>
+                <label class="control-label optional-label" for="safetyplan">
+                  <input type="checkbox" name="safetyplan" id="safetyplan" value="1" [[# safetyplan ]]checked[[/ safetyplan ]] />
+                  My ride follows the COVID safety plan
+                </label>
+                <p class="input-help">We need your help to keep bike fun safe for all! If you follow this <a href="/pages/public-health/#safety-plan" target="_blank" title="opens in a new window">COVID safety plan</a>, we'll put a special marker next to your ride on the calendar so people know what to expect.</p>
+              </div>
+            </div>
+
+            <div class="form-group">
               <label class="control-label optional-label" for="image">Image</label>
 
               <div class="image-form">
@@ -463,16 +473,6 @@
                 <input type="checkbox" name="read_comic" id="read_comic" value="1" [[# readComic ]]checked[[/ readComic ]] />
                 I have read the Ride Leading Comic
               </label>
-            </div>
-
-			<div class="pp-banner" style="text-align: left;">
-			<p class="input-help">We need your help to keep bike fun safe for all! If you follow this <a href="/pages/public-health/#safety-plan" target="_blank" title="opens in a new window">COVID safety plan</a>, we'll put a special marker next to your ride on the calendar so people know what to expect.</p>
-            <div class="checkbox">
-              <label class="control-label" for="safetyplan">
-                <input type="checkbox" name="safetyplan" id="safetyplan" value="1" [[# safetyplan ]]checked[[/ safetyplan ]] />
-                My ride follows the COVID safety plan
-              </label>
-            </div>
             </div>
 
           </div>


### PR DESCRIPTION
Having the safety plan next to the required terms checkboxes resulted in a bunch of people checking it because they thought they had to, not because they were actually following it. Making it clearer that the safety plan is an optional thing.