### PR TITLE
Hugo update

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,17 @@ The purpose of the Shift/Pedalpalooza Calendar is to empower citizens to create 
 
 # Software
 
-built using:
-- php
-- docker
-- [hugo v0.37.1](https://gohugo.io) 
-- && the theme ["Universal"](https://themes.gohugo.io/hugo-universal-theme/)
-- && the content from [the legacy shift website](https://old.shift2bikes.org)
-- && [Netlify web hosting](https://www.netlify.com) to serve the content
-- && [the Netlify CMS](https://www.netlifycms.org)
+Built using:
+- [MySQL](https://www.mysql.com/)
+- [PHP](https://www.php.net/)
+- [Docker](https://www.docker.com/)
+- [Hugo](https://gohugo.io), using:
+  - the theme "s2b_hugo_theme", ported from the ["Universal"](https://themes.gohugo.io/hugo-universal-theme/) theme
+  - the content from the [legacy Shift website](https://old.shift2bikes.org)
+  - [Netlify web hosting](https://www.netlify.com) to serve the content
+  - the [Netlify CMS](https://www.netlifycms.org) for editing static pages in Markdown
 
-You can see the live site here:  https://www.shift2bikes.org
+You can see the live site here: [https://www.shift2bikes.org](https://www.shift2bikes.org)
 
 ## Contributing
 
@@ -31,7 +32,7 @@ Following the below steps you'll have a copy of the site running, including 3 do
 5. If you're standing up the site for the first time, add database tables with the setup script: `./shift mysql-pipe < services/db/seed/setup.sql`.
 6. Visit `https://localhost:4443/` . If this leads to an SSL error in chrome, you may try flipping this flag:  chrome://flags/#allow-insecure-localhost
 
-Note that no changes to the filesystems INSIDE the container should ever be needed;  they read from your LOCAL filesystem so updating the local FS will show up in the container (perhaps after a restart).  Updating, changing branches, etc can be done with git commands OUTSIDE of the container (`git checkout otherbranch` or `git pull`).
+Note that no changes to the filesystems **inside** the container should ever be needed;  they read from your **local** filesystem so updating the local FS will show up in the container (perhaps after a restart).  Updating, changing branches, etc can be done with git commands **outside** of the container (`git checkout otherbranch` or `git pull`).
 
 So - now you can hopefully access the site.  But a real end-to-end test of yoursetup, would be creating an event:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - 3306
 
   hugo:
-    image: jojomi/hugo:0.37
+    image: jojomi/hugo:0.84
     volumes:
       - ./site/:/src/
       - ./site/public/:/output/

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,7 @@
   publish = "site/public/"
 
 [build.environment]
-  HUGO_VERSION = "0.37.1"
+  HUGO_VERSION = "0.84.4"
 
 [context.deploy-preview]
   # this command builds draft content for deploy previews

--- a/site/config.toml
+++ b/site/config.toml
@@ -207,6 +207,10 @@ paginate = 10
     title = "From our blog"
     subtitle = "Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo."
 
+# allows HTML in Markdown (e.g. Pedalpalooza archive pages from 2007 and earlier)
+[markup.goldmark.renderer]
+    unsafe= true
+
 # For search functionality
 
 [outputs]

--- a/site/config.toml
+++ b/site/config.toml
@@ -214,5 +214,5 @@ paginate = 10
 # For search functionality
 
 [outputs]
-# JSON enables lunr.js search functionnality
-home = [ "HTML", "RSS", "JSON"]
+# add "JSON" to enable lunr.js search functionality
+home = [ "HTML", "RSS"]

--- a/site/content/pages/mcbf.md
+++ b/site/content/pages/mcbf.md
@@ -6,9 +6,9 @@ menu:
   main:
     parent: featuredevents
 ---
-<center>![mcbf header banner](/images/mcbf_entry_banner.jpg?classes=shadow&align=center)</center>
+![mcbf header banner](/images/mcbf_entry_banner.jpg?classes=shadow&align=center)
 
-The Multnomah County Bike Fair (aka *Bike Fair*) is an **almost** annual event held as part of [Pedalpalooza](/pages/pedalpalooza) since 2007 in beautiful Portland, Oregon. 
+The Multnomah County Bike Fair (aka *Bike Fair*) is an **almost** annual event held as part of [Pedalpalooza](/pages/pedalpalooza/) since 2007 in beautiful Portland, Oregon. 
 
 It's a family-friendly bike event open to the public, featuring games (slow races, bike jousting), entertainment (live music, casual competitions), arts + crafts, and general silly fun. 
 

--- a/site/layouts/partials/header.html
+++ b/site/layouts/partials/header.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-    {{ .Hugo.Generator }}
+    {{ hugo.Generator }}
     {{ partial "meta.html" . }}
     {{ partial "favicon.html" . }}
     <title>{{ .Title }} :: {{ .Site.Title }}</title>

--- a/site/themes/s2b_hugo_theme/layouts/partials/head.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/head.html
@@ -24,7 +24,7 @@
   <meta name="description" content="{{ .Site.Params.DefaultDescription }}">
   {{ end }}
 
-  {{ .Hugo.Generator }}
+  {{ hugo.Generator }}
 
   <link href='//fonts.googleapis.com/css?family=Roboto:400,100,100italic,300,300italic,500,700,800' rel='stylesheet' type='text/css'>
 


### PR DESCRIPTION
Updates to the latest Hugo Docker image available from the source we're currently using. Partially fixes #571 — jumps forward a bunch of versions, but still behind the latest.

Probably a good idea to backup and remove the `public` folder and rebuild it with this version to ensure the build output is exactly as expected.