### PR TITLE
Moved calendar styles to their own head partial

### DIFF
--- a/site/themes/s2b_hugo_theme/layouts/404.html
+++ b/site/themes/s2b_hugo_theme/layouts/404.html
@@ -1,48 +1,51 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.LanguageCode }}">
 
+<head>
   {{ partial "head.html" . }}
+</head>
 
-  <body>
+<body>
 
-    <div id="all">
+  <div id="all">
 
-        <header>
+    <header>
+      {{ partial "nav.html" . }}
+    </header>
 
-          {{ partial "nav.html" . }}
+    <div id="content">
+        <div class="container">
 
-        </header>
+            <div class="col-sm-6 col-sm-offset-3" id="error-page">
 
-        <div id="content">
-            <div class="container">
+                <div class="box">
 
-                <div class="col-sm-6 col-sm-offset-3" id="error-page">
+                    <p class="text-center">
+                        <a href="{{ .Site.BaseURL }}">
+                            <img src="{{ .Site.Params.logo }}" alt="{{ .Title }} logo">
+                        </a>
+                    </p>
 
-                    <div class="box">
+                    <h3>We are sorry - this page is not here anymore</h3>
+                    <h4 class="text-muted">Error 404 - Page not found</h4>
 
-                        <p class="text-center">
-                            <a href="{{ .Site.BaseURL }}">
-                                <img src="{{ .Site.Params.logo }}" alt="{{ .Title }} logo">
-                            </a>
-                        </p>
-
-                        <h3>We are sorry - this page is not here anymore</h3>
-                        <h4 class="text-muted">Error 404 - Page not found</h4>
-
-                        <p class="buttons"><a href="{{ .Site.BaseURL }}" class="btn btn-template-main"><i class="fa fa-home"></i> Go to Homepage</a>
-                        </p>
-                    </div>
-
-
+                    <p class="buttons"><a href="{{ .Site.BaseURL }}" class="btn btn-template-main"><i class="fa fa-home"></i> Go to Homepage</a>
+                    </p>
                 </div>
-                <!-- /.col-sm-6 -->
+
+
             </div>
-            <!-- /.container -->
+            <!-- /.col-sm-6 -->
         </div>
-        <!-- /#content -->
-
-        {{ partial "footer.html" . }}
-
+        <!-- /.container -->
     </div>
-  </body>
+      <!-- /#content -->
+
+    <footer>
+      {{ partial "footer.html" . }}
+    </footer>
+
+  </div>
+</body>
+
 </html>

--- a/site/themes/s2b_hugo_theme/layouts/_default/list.html
+++ b/site/themes/s2b_hugo_theme/layouts/_default/list.html
@@ -1,115 +1,119 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.LanguageCode }}">
 
+<head>
   {{ partial "head.html" . }}
+</head>
 
-  <body>
+<body>
 
-    <div id="all">
+  <div id="all">
 
-        <header>
+    <header>
+      {{ partial "nav.html" . }}
+    </header>
 
-          {{ partial "nav.html" . }}
+    <main>
+      {{ partial "breadcrumbs.html" . }}
 
-        </header>
+      <div id="content">
+        <div class="container">
+        <div class="row">
+            <!-- *** LEFT COLUMN *** -->
 
-        {{ partial "breadcrumbs.html" . }}
+            <div class="col-md-9" id="blog-listing-medium">
 
-        <div id="content">
-            <div class="container">
+              {{ $paginator := .Paginate (where .Data.Pages "Type" "blog") }}
+              {{ range $paginator.Pages }}
+              <section class="post">
                 <div class="row">
-                    <!-- *** LEFT COLUMN *** -->
+                  <div class="col-md-4">
+                  <div class="image">
+                    <a href="{{ .Permalink }}">
+                      {{ if .Params.banner }}
+                      <img src="{{ .Site.BaseURL}}{{ .Params.banner }}" class="img-responsive" alt="">
+                      {{ else }}
+                      <img src="{{ .Site.BaseURL}}img/placeholder.png" class="img-responsive" alt="">
+                      {{ end }}
+                    </a>
+                  </div>
+                  </div>
+                  <div class="col-md-8">
+                    <h2><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
+                    <div class="clearfix">
+                      <p class="author-category">
+                      {{ if isset .Params "author" }}
+                      {{ i18n "authorBy" }} <a href="#">{{ .Params.author }}</a>
+                      {{ end }}
+                      {{ if isset .Params "categories" }}
+                      {{ if gt (len .Params.categories) 0 }}
+                      in <a href="{{ $.Site.BaseURL }}categories/{{ index .Params.categories 0 | urlize | lower }}">{{ index .Params.categories 0 }}</a>
+                      {{ end }}
+                      {{ end }}
 
-                    <div class="col-md-9" id="blog-listing-medium">
-
-                        {{ $paginator := .Paginate (where .Data.Pages "Type" "blog") }}
-                        {{ range $paginator.Pages }}
-                        <section class="post">
-                            <div class="row">
-                                <div class="col-md-4">
-                                  <div class="image">
-                                      <a href="{{ .Permalink }}">
-                                          {{ if .Params.banner }}
-                                          <img src="{{ .Site.BaseURL}}{{ .Params.banner }}" class="img-responsive" alt="">
-                                          {{ else }}
-                                          <img src="{{ .Site.BaseURL}}img/placeholder.png" class="img-responsive" alt="">
-                                          {{ end }}
-                                      </a>
-                                  </div>
-                                </div>
-                                <div class="col-md-8">
-                                    <h2><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
-                                    <div class="clearfix">
-                                        <p class="author-category">
-                                          {{ if isset .Params "author" }}
-                                          {{ i18n "authorBy" }} <a href="#">{{ .Params.author }}</a>
-                                          {{ end }}
-                                          {{ if isset .Params "categories" }}
-                                          {{ if gt (len .Params.categories) 0 }}
-                                          in <a href="{{ $.Site.BaseURL }}categories/{{ index .Params.categories 0 | urlize | lower }}">{{ index .Params.categories 0 }}</a>
-                                          {{ end }}
-                                          {{ end }}
-
-                                        </p>
-                                        <p class="date-comments">
-                                            <a href="{{ .Permalink }}"><i class="fa fa-calendar-o"></i> {{ .Date.Format .Site.Params.date_format }}</a>
-                                        </p>
-                                    </div>
-                                    <p class="intro">{{ .Summary }}</p>
-                                    <p class="read-more"><a href="{{ .Permalink }}" class="btn btn-template-main">{{ i18n "continueReading" }}</a>
-                                    </p>
-                                </div>
-                            </div>
-                        </section>
-                        {{ end }}
-
-                        <ul class="pager">
-                            {{ if .Paginator.HasPrev }}
-                            <li class="previous"><a href="{{ .Site.BaseURL }}{{ .Paginator.Prev.URL }}">&larr; {{ i18n "newer" }}</a></li>
-                            {{ else }}
-                            <li class="previous disabled"><a href="#">&larr; {{ i18n "newer" }}</a></li>
-                            {{ end }}
-
-                            {{ if .Paginator.HasNext }}
-                            <li class="next"><a href="{{ .Site.BaseURL }}{{ .Paginator.Next.URL }}">{{ i18n "older" }} &rarr;</a></li>
-                            {{ else }}
-                            <li class="next disabled"><a href="#">{{ i18n "older" }} &rarr;</a></li>
-                            {{ end }}
-                        </ul>
+                      </p>
+                      <p class="date-comments">
+                        <a href="{{ .Permalink }}"><i class="fa fa-calendar-o"></i> {{ .Date.Format .Site.Params.date_format }}</a>
+                      </p>
                     </div>
-                    <!-- /.col-md-9 -->
-
-                    <!-- *** LEFT COLUMN END *** -->
-
-                    <!-- *** RIGHT COLUMN ***
-       _________________________________________________________ -->
-
-                    <div class="col-md-3">
-
-                        <!-- *** MENUS AND WIDGETS *** -->
-
-                        {{ partial "sidebar.html" . }}
-
-                        <!-- *** MENUS AND FILTERS END *** -->
-
-                    </div>
-                    <!-- /.col-md-3 -->
-
-                    <!-- *** RIGHT COLUMN END *** -->
-
+                    <p class="intro">{{ .Summary }}</p>
+                    <p class="read-more"><a href="{{ .Permalink }}" class="btn btn-template-main">{{ i18n "continueReading" }}</a>
+                    </p>
+                  </div>
                 </div>
-                <!-- /.row -->
+              </section>
+              {{ end }}
+
+              <ul class="pager">
+                {{ if .Paginator.HasPrev }}
+                <li class="previous"><a href="{{ .Site.BaseURL }}{{ .Paginator.Prev.URL }}">&larr; {{ i18n "newer" }}</a></li>
+                {{ else }}
+                <li class="previous disabled"><a href="#">&larr; {{ i18n "newer" }}</a></li>
+                {{ end }}
+
+                {{ if .Paginator.HasNext }}
+                <li class="next"><a href="{{ .Site.BaseURL }}{{ .Paginator.Next.URL }}">{{ i18n "older" }} &rarr;</a></li>
+                {{ else }}
+                <li class="next disabled"><a href="#">{{ i18n "older" }} &rarr;</a></li>
+                {{ end }}
+              </ul>
             </div>
-            <!-- /.container -->
+            <!-- /.col-md-9 -->
+
+            <!-- *** LEFT COLUMN END *** -->
+
+            <!-- *** RIGHT COLUMN *** -->
+
+            <div class="col-md-3">
+
+              <!-- *** MENUS AND WIDGETS *** -->
+
+              {{ partial "sidebar.html" . }}
+
+              <!-- *** MENUS AND FILTERS END *** -->
+
+            </div>
+            <!-- /.col-md-3 -->
+
+            <!-- *** RIGHT COLUMN END *** -->
+
+          </div>
+          <!-- /.row -->
         </div>
-        <!-- /#content -->
+        <!-- /.container -->
+      </div>
+      <!-- /#content -->
+    </main>
 
-        {{ partial "footer.html" . }}
+    <footer>
+    {{ partial "footer.html" . }}
+    </footer>
 
-    </div>
-    <!-- /#all -->
+  </div>
+  <!-- /#all -->
 
-    {{ partial "scripts.html" . }}
+  {{ partial "scripts.html" . }}
 
-  </body>
+</body>
+
 </html>

--- a/site/themes/s2b_hugo_theme/layouts/_default/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/_default/single.html
@@ -1,80 +1,78 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.LanguageCode }}">
 
+<head>
   {{ partial "head.html" . }}
+</head>
 
-  <body>
+<body>
 
-    <div id="all">
+  <div id="all">
 
-        <header>
+    <header>
+      {{ partial "nav.html" . }}
+    </header>
 
-          {{ partial "nav.html" . }}
+    <main>
+      {{ partial "breadcrumbs.html" . }}
 
-        </header>
+      <div id="content">
+        <div class="container">
 
-        <main>
+          <div class="row">
 
-            {{ partial "breadcrumbs.html" . }}
+            <!-- *** LEFT COLUMN *** -->
 
-            <div id="content">
-                <div class="container">
+            <div class="col-md-9" id="blog-post">
 
-                    <div class="row">
+              <div id="post-content">
+              {{ .Content }}
+              </div>
+              <!-- /#post-content -->
+              {{ if .Site.DisqusShortname }}
+              <div id="comments">
+                {{ template "_internal/disqus.html" . }}
+              </div>
+              {{ end }}
 
-                        <!-- *** LEFT COLUMN *** -->
-
-                        <div class="col-md-9" id="blog-post">
-                        
-                            <div id="post-content">
-                              {{ .Content }}
-                            </div>
-                            <!-- /#post-content -->
-                            {{ if .Site.DisqusShortname }}
-                            <div id="comments">
-                                {{ template "_internal/disqus.html" . }}
-                            </div>
-                            {{ end }}
-
-                        </div>
-                        <!-- /#blog-post -->
-
-                        <!-- *** LEFT COLUMN END *** -->
-
-                        <!-- *** RIGHT COLUMN *** -->
-
-                        <div class="col-md-3">
-
-                            <!-- *** MENUS AND WIDGETS *** -->
-
-                            {{ partial "sidebar.html" . }}
-
-                            <!-- *** MENUS AND FILTERS END *** -->
-
-                        </div>
-                        <!-- /.col-md-3 -->
-
-                        <!-- *** RIGHT COLUMN END *** -->
-
-                    </div>
-                    <!-- /.row -->
-
-                </div>
-                <!-- /.container -->
             </div>
-            <!-- /#content -->
-        </main>
+            <!-- /#blog-post -->
 
-        <footer>
+            <!-- *** LEFT COLUMN END *** -->
 
-            {{ partial "footer.html" . }}
+            <!-- *** RIGHT COLUMN *** -->
 
-        </footer>
+            <div class="col-md-3">
 
-    </div>
-    <!-- /#all -->
+              <!-- *** MENUS AND WIDGETS *** -->
 
-    {{ partial "scripts.html" . }}
+              {{ partial "sidebar.html" . }}
 
-  </body>
+              <!-- *** MENUS AND FILTERS END *** -->
+
+            </div>
+            <!-- /.col-md-3 -->
+
+            <!-- *** RIGHT COLUMN END *** -->
+
+          </div>
+          <!-- /.row -->
+
+        </div>
+        <!-- /.container -->
+      </div>
+      <!-- /#content -->
+    </main>
+
+    <footer>
+    {{ partial "footer.html" . }}
+    </footer>
+
+  </div>
+  <!-- /#all -->
+
+  {{ partial "scripts.html" . }}
+
+</body>
+
 </html>

--- a/site/themes/s2b_hugo_theme/layouts/caledit/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/caledit/single.html
@@ -1,12 +1,15 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.LanguageCode }}">
 
-{{ partial "head.html" . }}
+<head>
+  {{ partial "head.html" . }}
+  {{ partial "cal/head.html" . }}
+</head>
 
 <body>
-  <!-- legacycalpage/single.html -->
 
   <div id="all">
+
     <header>
       {{ partial "nav.html" . }}
     </header>
@@ -45,9 +48,7 @@
     </main>
 
     <footer>
-
-        {{ partial "footer.html" . }}
-
+      {{ partial "footer.html" . }}
     </footer>
 
   </div>
@@ -61,4 +62,5 @@
   </script>
 
 </body>
+
 </html>

--- a/site/themes/s2b_hugo_theme/layouts/calevents/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/calevents/single.html
@@ -1,12 +1,15 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.LanguageCode }}">
 
-{{ partial "head.html" . }}
+<head>
+  {{ partial "head.html" . }}
+  {{ partial "cal/head.html" . }}
+</head>
 
 <body>
-  <!-- legacycalpage/single.html -->
 
   <div id="all">
+
     <header>
       {{ partial "nav.html" . }}
     </header>
@@ -67,9 +70,7 @@
     </main>
 
     <footer>
-
-        {{ partial "footer.html" . }}
-
+      {{ partial "footer.html" . }}
     </footer>
 
   </div>
@@ -80,6 +81,7 @@
 
   <script type="text/javascript">
     window.legacycal_renderpage = "{{ .Params.id }}";
+    // TODO
   </script>
 
 </body>

--- a/site/themes/s2b_hugo_theme/layouts/calgrid/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/calgrid/single.html
@@ -1,60 +1,61 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.LanguageCode }}">
 
-{{ partial "head.html" . }}
+<head>
+  {{ partial "head.html" . }}
+  {{ partial "cal/head.html" . }}
+</head>
 
 <body>
-  <!-- legacycalpage/single.html -->
 
   <div id="all">
+
     <header>
       {{ partial "nav.html" . }}
     </header>
 
     <main>
-        {{ partial "breadcrumbs.html" . }}
+      {{ partial "breadcrumbs.html" . }}
 
-        <div id="content">
-          <div class="container">
+      <div id="content">
+        <div class="container">
 
-            <div class="row">
+          <div class="row">
 
-              <div class="col-md-12">
+            <div class="col-md-12">
 
-                <div>
-                  {{ .Content }}
-                </div>
-
-                <!-- only display when PP is coming soon or happening now -->
-                <!-- {{ partial "cal/pp-promo-banner.html" . }} -->
-
-                <!-- only display during Steptember -->
-                <!-- {{ partial "cal/promo-banner-steptember.html" . }} -->
-
-                {{ partial "cal/view-options.html" . }}
-                {{ partial "cal/fullcal.html" . }} 
-
-                <div id="fullcalendar"></div>
-
-                {{ partial "alert_banner.html" . }}
-
-                {{ partial "disclaimer.html" . }}
-
+              <div>
+                {{ .Content }}
               </div>
 
+              <!-- only display when PP is coming soon or happening now -->
+              <!-- {{ partial "cal/pp-promo-banner.html" . }} -->
+
+              <!-- only display during Steptember -->
+              <!-- {{ partial "cal/promo-banner-steptember.html" . }} -->
+
+              {{ partial "cal/view-options.html" . }}
+              {{ partial "cal/fullcal.html" . }} 
+
+              <div id="fullcalendar"></div>
+
+              {{ partial "alert_banner.html" . }}
+
+              {{ partial "disclaimer.html" . }}
+
             </div>
-            <!-- /.row -->
 
           </div>
-          <!-- /.container -->
+          <!-- /.row -->
+
         </div>
-        <!-- /#content -->
+        <!-- /.container -->
+      </div>
+      <!-- /#content -->
     </main>
 
     <footer>
-
-        {{ partial "footer.html" . }}
-
+      {{ partial "footer.html" . }}
     </footer>
 
   </div>
@@ -63,4 +64,5 @@
   {{ partial "scripts.html" . }}
 
 </body>
+
 </html>

--- a/site/themes/s2b_hugo_theme/layouts/index.html
+++ b/site/themes/s2b_hugo_theme/layouts/index.html
@@ -1,47 +1,45 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.LanguageCode }}">
 
+<head>
   {{ partial "head.html" . }}
+  {{ partial "cal/head.html" . }}
+</head>
 
-  <body>
+<body>
 
-    <div id="all">
+  <div id="all">
 
-        <header>
+    <header>
+      <!--{{ partial "top.html" . }}-->
+      {{ partial "nav.html" . }}
+    </header>
 
-          <!--{{ partial "top.html" . }}-->
+    <main>
+      {{ partial "carousel.html" . }}
 
-          {{ partial "nav.html" . }}
+      <!--{{ partial "features.html" . }}-->
+      <!--{{ partial "testimonials.html" . }}-->
+      <!--{{ partial "see_more.html" . }}-->
+      <!--{{ partial "recent_posts.html" . }}-->
 
-        </header>
+      <!-- up next showing PP themes for now -->
+      {{ partial "cal/up-next.html" . }}
 
-        <main>
+      {{ partial "alert_banner.html" . }}
 
-        {{ partial "carousel.html" . }}
+      {{ partial "sponsors.html" . }}
+    </main>
 
-        <!--{{ partial "features.html" . }}-->
+    <footer>
+      {{ partial "footer.html" . }}
+    </footer>
 
-        <!--{{ partial "testimonials.html" . }}-->
+  </div>
+  <!-- /#all -->
 
-        <!--{{ partial "see_more.html" . }}-->
+  {{ partial "scripts.html" . }}
 
-        <!--{{ partial "recent_posts.html" . }}-->
+</body>
 
-        <!-- up next showing PP themes for now -->
-        {{ partial "cal/up-next.html" . }}
-
-        {{ partial "alert_banner.html" . }}
-
-        {{ partial "sponsors.html" . }}
-
-        </main>
-
-        {{ partial "footer.html" . }}
-
-    </div>
-    <!-- /#all -->
-
-    {{ partial "scripts.html" . }}
-
-  </body>
 </html>

--- a/site/themes/s2b_hugo_theme/layouts/page/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/page/single.html
@@ -1,63 +1,61 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.LanguageCode }}">
 
+<head>
   {{ partial "head.html" . }}
+</head>
 
-  <body>
+<body>
 
-    <div id="all">
+  <div id="all">
 
-        <header>
+    <header>
+      {{ partial "nav.html" . }}
+    </header>
 
-          {{ partial "nav.html" . }}
+    <main>
+        {{ partial "breadcrumbs.html" . }}
 
-        </header>
+        <div id="content">
+            {{ if isset .Params "id" }}
 
-        <main>
+              {{ partial .Params.id . }}
 
-            {{ partial "breadcrumbs.html" . }}
+            {{ else }}
 
-            <div id="content">
-                {{ if isset .Params "id" }}
+            <div class="container">
 
-                  {{ partial .Params.id . }}
+                <div class="row">
 
-                {{ else }}
+                    <div class="col-md-12">
 
-                <div class="container">
-
-                    <div class="row">
-
-                        <div class="col-md-12">
-
-                            <div>
-                              {{ .Content }}
-                            </div>
-
+                        <div>
+                          {{ .Content }}
                         </div>
 
                     </div>
-                    <!-- /.row -->
 
                 </div>
-                <!-- /.container -->
+                <!-- /.row -->
 
-                {{ end }}
             </div>
-            <!-- /#content -->
+            <!-- /.container -->
 
-        </main>
+            {{ end }}
+        </div>
+        <!-- /#content -->
 
-        <footer>
+      </main>
 
-            {{ partial "footer.html" . }}
+      <footer>
+        {{ partial "footer.html" . }}
+      </footer>
 
-        </footer>
+  </div>
+  <!-- /#all -->
 
-    </div>
-    <!-- /#all -->
+  {{ partial "scripts.html" . }}
 
-    {{ partial "scripts.html" . }}
+</body>
 
-  </body>
 </html>

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/head.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/head.html
@@ -1,0 +1,15 @@
+<!-- styles for calendar pages; also needed on homepage for "up next" widget -->
+<link rel="stylesheet" type="text/css" href="/css/cal/main.css">
+
+<!-- only load grid view styles on calendar list pages; not needed on edit pages -->
+{{ if or (eq .Type "calevents") (eq .Type "calgrid") (eq .Type "pp-theme-cal") }}
+<link rel="stylesheet" type="text/css" href="/js/libs/fullcalendar/core/main.min.css">
+<link rel="stylesheet" type="text/css" href="/js/libs/fullcalendar/daygrid/main.min.css">
+<link rel="stylesheet" type="text/css" href="/js/libs/fullcalendar/timegrid/main.min.css">
+{{ end }}
+
+<!-- only load list view styles on homepage for "up next" widget and PP cal page -->
+{{ if or (eq .Type "homepage") (eq .Type "pp-theme-cal") }}
+<link rel="stylesheet" type="text/css" href="/js/libs/fullcalendar/core/main.min.css"/>
+<link rel="stylesheet" type="text/css" href="/js/libs/fullcalendar/list/main.min.css"/>
+{{ end }}

--- a/site/themes/s2b_hugo_theme/layouts/partials/head.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/head.html
@@ -1,98 +1,68 @@
-<head>
+<meta charset="utf-8">
+<meta name="robots" content="all,follow">
+<meta name="googlebot" content="index,follow,snippet,archive">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+{{ if eq .Title .Site.Title }}
+<!-- if page title and site title are equal, don't repeat it -->
+<title>{{ .Title }}</title>
+{{ else }}
+<title>{{ .Title }} - {{ .Site.Title }}</title>
+{{ end }}
+<meta name="author" content="{{ .Site.Author.name }}" />
 
-  <meta charset="utf-8">
-  <meta name="robots" content="all,follow">
-  <meta name="googlebot" content="index,follow,snippet,archive">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  {{ if eq .Title .Site.Title }}
-  <!-- if page title and site title are equal, don't repeat it -->
-  <title>{{ .Title }}</title>
-  {{ else }}
-  <title>{{ .Title }} - {{ .Site.Title }}</title>
-  {{ end }}
-  <meta name="author" content="{{ .Site.Author.name }}" />
+{{ if .Keywords }}
+<meta name="keywords" content="{{ delimit .Keywords ", " }}">
+{{ else if .Site.Params.DefaultKeywords }}
+<meta name="keywords" content="{{ delimit .Site.Params.DefaultKeywords ", " }}">
+{{ end }}
 
-  {{ if .Keywords }}
-  <meta name="keywords" content="{{ delimit .Keywords ", " }}">
-  {{ else if .Site.Params.DefaultKeywords }}
-  <meta name="keywords" content="{{ delimit .Site.Params.DefaultKeywords ", " }}">
-  {{ end }}
+{{ if .Description }}
+<meta name="description" content="{{ .Description }}">
+{{ else if .Site.Params.DefaultDescription }}
+<meta name="description" content="{{ .Site.Params.DefaultDescription }}">
+{{ end }}
 
-  {{ if .Description }}
-  <meta name="description" content="{{ .Description }}">
-  {{ else if .Site.Params.DefaultDescription }}
-  <meta name="description" content="{{ .Site.Params.DefaultDescription }}">
-  {{ end }}
+{{ hugo.Generator }}
 
-  {{ hugo.Generator }}
+<link href='//fonts.googleapis.com/css?family=Roboto:400,100,100italic,300,300italic,500,700,800' rel='stylesheet' type='text/css'>
 
-  <link href='//fonts.googleapis.com/css?family=Roboto:400,100,100italic,300,300italic,500,700,800' rel='stylesheet' type='text/css'>
+<!-- Bootstrap and Font Awesome css -->
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+<link rel="stylesheet" href="//stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
 
-  <!-- Bootstrap and Font Awesome css -->
-  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
-  <link rel="stylesheet" href="//stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
+<!-- Animation styles  -->
+<link href="{{ .Site.BaseURL }}css/animate.css" rel="stylesheet">
 
-  <!-- Animation styles  -->
-  <link href="{{ .Site.BaseURL }}css/animate.css" rel="stylesheet">
+<!-- Theme stylesheet, if possible do not edit this stylesheet -->
+{{ if and (isset .Site.Params "style") .Site.Params.style }}
+  <link href="{{ .Site.BaseURL }}css/style.{{ .Site.Params.style }}.css" rel="stylesheet" id="theme-stylesheet">
+{{ else }}
+  <link href="{{ .Site.BaseURL }}css/style.default.css" rel="stylesheet" id="theme-stylesheet">
+{{ end }}
 
-  <!-- Theme stylesheet, if possible do not edit this stylesheet -->
-  {{ if and (isset .Site.Params "style") .Site.Params.style }}
-    <link href="{{ .Site.BaseURL }}css/style.{{ .Site.Params.style }}.css" rel="stylesheet" id="theme-stylesheet">
-  {{ else }}
-    <link href="{{ .Site.BaseURL }}css/style.default.css" rel="stylesheet" id="theme-stylesheet">
-  {{ end }}
+<!-- Custom stylesheet - for your changes -->
+<link href="{{ .Site.BaseURL }}css/custom.css" rel="stylesheet">
 
-  <!-- Custom stylesheet - for your changes -->
-  <link href="{{ .Site.BaseURL }}css/custom.css" rel="stylesheet">
+<!-- Favicon and apple touch icons-->
+<link rel="icon" href="{{ .Site.BaseURL }}img/favicon.ico">
+<link rel="icon" href="{{ .Site.BaseURL }}img/favicon.png" type="image/png">
+<link rel="apple-touch-icon" href="{{ .Site.BaseURL }}img/apple-touch-icon.png">
 
-  <!-- Responsivity for older IE -->
-  {{ `
-    <!--[if lt IE 9]>
-        <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
-        <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
-    <![endif]-->
-  ` | safeHTML }}
+<!-- owl carousel; only load styles on homepage -->
+{{ if (eq .Type "homepage") }}
+<link href="{{ .Site.BaseURL }}css/owl.carousel.css" rel="stylesheet">
+<link href="{{ .Site.BaseURL }}css/owl.theme.css" rel="stylesheet">
+{{ end }}
 
-  <!-- Favicon and apple touch icons-->
-  <link rel="icon" href="{{ .Site.BaseURL }}img/favicon.ico">
-  <link rel="icon" href="{{ .Site.BaseURL }}img/favicon.png" type="image/png">
-  <link rel="apple-touch-icon" href="{{ .Site.BaseURL }}img/apple-touch-icon.png">
+<link rel="alternate" href="{{ "/index.xml" | absURL }}" type="application/rss+xml" title="{{ .Site.Title }}">
 
-  <!-- owl carousel; only load styles on homepage -->
-  {{ if (eq .Type "homepage") }}
-  <link href="{{ .Site.BaseURL }}css/owl.carousel.css" rel="stylesheet">
-  <link href="{{ .Site.BaseURL }}css/owl.theme.css" rel="stylesheet">
-  {{ end }}
+<!-- Facebook OpenGraph tags -->
+<meta property="og:title" content="{{ .Title }}" />
+<meta property="og:description" content="{{ .Description }}" />
+<meta property="og:type" content="website" />
+<meta property="og:image" content="https://www.shift2bikes.org/{{ .Site.Params.logo }}" />
+<meta property="og:image:height" content="1200" />
+<meta property="og:image:width" content="1200" />
 
-  <link rel="alternate" href="{{ "/index.xml" | absURL }}" type="application/rss+xml" title="{{ .Site.Title }}">
-
-  <!-- Facebook OpenGraph tags -->
-  <meta property="og:title" content="{{ .Title }}" />
-  <meta property="og:description" content="{{ .Description }}" />
-  <meta property="og:type" content="website" />
-  <meta property="og:image" content="https://www.shift2bikes.org/{{ .Site.Params.logo }}" />
-  <meta property="og:image:height" content="1200" />
-  <meta property="og:image:width" content="1200" />
-
-  <!-- Verification metadata for Mastodon -->
-  <link href="https://pdx.social/@shift2bikes" rel="me">
-
-  <!-- load calendar styles on calendar list, edit, or grid pages, or on homepage for "up next" widget -->
-  {{ if or (eq .Type "calevents") (eq .Type "caledit") (eq .Type "calgrid") (eq .Type "pp-landing") (eq .Type "pp-theme-cal") (eq .Type "homepage") }}
-  <link rel="stylesheet" type="text/css" href="/css/cal/main.css">
-  {{ end }}
-
-  <!-- only load grid view styles on calendar list pages; not needed on edit pages -->
-  {{ if or (eq .Type "calevents") (eq .Type "calgrid") (eq .Type "pp-theme-cal") }}
-  <link rel="stylesheet" type="text/css" href="/js/libs/fullcalendar/core/main.min.css">
-  <link rel="stylesheet" type="text/css" href="/js/libs/fullcalendar/daygrid/main.min.css">
-  <link rel="stylesheet" type="text/css" href="/js/libs/fullcalendar/timegrid/main.min.css">
-  {{ end }}
-
-  <!-- only load list view styles on homepage for "up next" widget and PP cal page -->
-  {{ if or (eq .Type "homepage") (eq .Type "pp-theme-cal") }}
-  <link rel="stylesheet" type="text/css" href="/js/libs/fullcalendar/core/main.min.css"/>
-  <link rel="stylesheet" type="text/css" href="/js/libs/fullcalendar/list/main.min.css"/>
-  {{ end }}
-
-</head>
+<!-- Verification metadata for Mastodon -->
+<link href="https://pdx.social/@shift2bikes" rel="me">

--- a/site/themes/s2b_hugo_theme/layouts/pp-landing/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/pp-landing/single.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.LanguageCode }}">
 
-{{ partial "head.html" . }}
+<head>
+  {{ partial "head.html" . }}
+  {{ partial "cal/head.html" . }}
+</head>
 
 <body>
-  <!-- legacycalpage/single.html -->
 
   <div id="all">
     <header>
@@ -27,7 +29,7 @@
                     <a href="{{ .Param "poster-image" }}"><img alt="Pedalpalooza" id="pedalpalooza-img" src="{{ .Param "banner-image" }}"></a>
                     <div>
                       <span class="pp-headline">Pedalpalooza!</span>
-<!--                       <span class="pp-daterange">{{ .Param "daterange" }}</span> -->
+                      <!-- <span class="pp-daterange">{{ .Param "daterange" }}</span> -->
                     </div>
 
                   {{ .Content }}
@@ -36,7 +38,7 @@
                   
                 </div>
 
-<!-- 
+                <!-- 
                 {{ partial "alert_banner.html" . }}
 
                 {{ partial "cal/view-options.html" . }}
@@ -45,7 +47,7 @@
                 <div id="fullcalendar"></div>
 
                 {{ partial "disclaimer.html" . }}
- -->
+                -->
 
               </div>
 
@@ -59,9 +61,7 @@
     </main>
 
     <footer>
-
-        {{ partial "footer.html" . }}
-
+      {{ partial "footer.html" . }}
     </footer>
 
   </div>
@@ -70,4 +70,5 @@
   {{ partial "scripts.html" . }}
 
 </body>
+
 </html>

--- a/site/themes/s2b_hugo_theme/layouts/pp-theme-cal/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/pp-theme-cal/single.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
 <html lang="{{ .Site.LanguageCode }}">
 
-{{ partial "head.html" . }}
+<head>
+  {{ partial "head.html" . }}
+  {{ partial "cal/head.html" . }}
+</head>
 
 <body>
-  <!-- legacycalpage/single.html -->
 
   <div id="all">
     <header>
@@ -21,7 +23,7 @@
 
               <div class="col-md-12">
 
-<!--                 {{ partial "alert_banner.html" . }} -->
+                   <!-- {{ partial "alert_banner.html" . }} -->
 
                   <!-- modified pp_heading partial -->
                   <div class="pp-banner">
@@ -45,9 +47,7 @@
     </main>
 
     <footer>
-
-        {{ partial "footer.html" . }}
-
+      {{ partial "footer.html" . }}
     </footer>
 
   </div>
@@ -56,4 +56,5 @@
   {{ partial "scripts.html" . }}
 
 </body>
+
 </html>


### PR DESCRIPTION
Also normalized a bunch of indentation and added a missing `<main>` element to one layout.

End result should be that calendar styles continue to load where needed, and don't load when not. (Note that the homepage needs calendar styles for the "up next" widget.)