### PR TITLE
Database migration to UTF8

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -39,6 +39,20 @@ Migration scripts are located in `services/db/migrations/`. To apply a migration
 
 ```./shift mysql-pipe < services/db/migrations/0000-example-migration.sql```
 
+### Creating a migration
+
+Any change to the database should be done using a migration script so it can be consistently applied in any dev environment (including production). It should be safe to re-run a migration, so use SQL statements that won't error out if run a second time. (e.g. check for presence before dropping)
+
+Along with the migration, update the `setup.sql` script. This ensures that both new databases and existing databases that have been migrated will have the same structure.
+
+After you've applied your migration, run this command to dump the database structure but without the actual row data:
+
+```./shift mysqldump --no-data > setup.sql```
+
+Then:
+* Comment out each `DROP TABLE` line, e.g. `` -- DROP TABLE IF EXISTS `tablename` ``
+* Add `IF NOT EXISTS` to each `CREATE TABLE` statement, e.g. `` CREATE TABLE IF NOT EXISTS `tablename` ``
+
 
 ## Resetting tables
 

--- a/services/db/migrations/0005_char_set_and_collation.sql
+++ b/services/db/migrations/0005_char_set_and_collation.sql
@@ -2,5 +2,3 @@
 ALTER TABLE calevent CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 ALTER TABLE caldaily CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 ALTER DATABASE shift CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
--- will still need to update collation for MySQL v8 to utf8mb4_0900_ai_ci, 
--- but v5.7 doesn't recognize that collation

--- a/services/db/migrations/0005_char_set_and_collation.sql
+++ b/services/db/migrations/0005_char_set_and_collation.sql
@@ -1,0 +1,6 @@
+-- set char set and collation to UTF8
+ALTER TABLE calevent CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER TABLE caldaily CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+ALTER DATABASE shift CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+-- will still need to update collation for MySQL v8 to utf8mb4_0900_ai_ci, 
+-- but v5.7 doesn't recognize that collation

--- a/services/db/seed/setup.sql
+++ b/services/db/seed/setup.sql
@@ -1,8 +1,8 @@
--- MySQL dump 10.13  Distrib 5.7.34, for Linux (x86_64)
+-- MySQL dump 10.13  Distrib 5.7.44, for Linux (x86_64)
 --
 -- Host: db    Database: shift
 -- ------------------------------------------------------
--- Server version	5.7.34
+-- Server version	5.7.44
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
@@ -33,15 +33,6 @@ CREATE TABLE IF NOT EXISTS `caladdress` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
--- Dumping data for table `caladdress`
---
-
-LOCK TABLES `caladdress` WRITE;
-/*!40000 ALTER TABLE `caladdress` DISABLE KEYS */;
-/*!40000 ALTER TABLE `caladdress` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
 -- Table structure for table `calcount`
 --
 
@@ -57,15 +48,6 @@ CREATE TABLE IF NOT EXISTS `calcount` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
--- Dumping data for table `calcount`
---
-
-LOCK TABLES `calcount` WRITE;
-/*!40000 ALTER TABLE `calcount` DISABLE KEYS */;
-/*!40000 ALTER TABLE `calcount` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
 -- Table structure for table `caldaily`
 --
 
@@ -75,24 +57,15 @@ UNLOCK TABLES;
 CREATE TABLE IF NOT EXISTS `caldaily` (
   `modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `id` int(11) DEFAULT NULL,
-  `newsflash` text,
+  `newsflash` mediumtext,
   `eventdate` date DEFAULT NULL,
   `eventstatus` varchar(1) DEFAULT NULL,
   `exceptionid` int(11) DEFAULT NULL,
   `pkid` int(11) NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`pkid`),
   KEY `eventdate` (`eventdate`)
-) ENGINE=MyISAM AUTO_INCREMENT=13648 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=12941 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Dumping data for table `caldaily`
---
-
-LOCK TABLES `caldaily` WRITE;
-/*!40000 ALTER TABLE `caldaily` DISABLE KEYS */;
-/*!40000 ALTER TABLE `caldaily` ENABLE KEYS */;
-UNLOCK TABLES;
 
 --
 -- Table structure for table `calevent`
@@ -104,7 +77,7 @@ UNLOCK TABLES;
 CREATE TABLE IF NOT EXISTS `calevent` (
   `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `modified` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  `changes` int(11),
+  `changes` int(11) DEFAULT '0',
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) DEFAULT NULL,
   `email` varchar(255) DEFAULT NULL,
@@ -123,8 +96,8 @@ CREATE TABLE IF NOT EXISTS `calevent` (
   `title` varchar(255) DEFAULT NULL,
   `tinytitle` varchar(255) NOT NULL,
   `audience` char(1) DEFAULT NULL,
-  `descr` text,
-  `printdescr` text,
+  `descr` mediumtext,
+  `printdescr` mediumtext,
   `image` varchar(255) DEFAULT NULL,
   `imageheight` int(11) DEFAULT NULL,
   `imagewidth` int(11) DEFAULT NULL,
@@ -151,17 +124,8 @@ CREATE TABLE IF NOT EXISTS `calevent` (
   `ridelength` varchar(255) DEFAULT NULL,
   `safetyplan` int(1) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=MyISAM AUTO_INCREMENT=8246 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=8029 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Dumping data for table `calevent`
---
-
-LOCK TABLES `calevent` WRITE;
-/*!40000 ALTER TABLE `calevent` DISABLE KEYS */;
-/*!40000 ALTER TABLE `calevent` ENABLE KEYS */;
-UNLOCK TABLES;
 
 --
 -- Table structure for table `calforum`
@@ -183,15 +147,6 @@ CREATE TABLE IF NOT EXISTS `calforum` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
--- Dumping data for table `calforum`
---
-
-LOCK TABLES `calforum` WRITE;
-/*!40000 ALTER TABLE `calforum` DISABLE KEYS */;
-/*!40000 ALTER TABLE `calforum` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
 -- Table structure for table `calshare`
 --
 
@@ -203,15 +158,6 @@ CREATE TABLE IF NOT EXISTS `calshare` (
   `shareevents` varchar(255) DEFAULT NULL
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Dumping data for table `calshare`
---
-
-LOCK TABLES `calshare` WRITE;
-/*!40000 ALTER TABLE `calshare` DISABLE KEYS */;
-/*!40000 ALTER TABLE `calshare` ENABLE KEYS */;
-UNLOCK TABLES;
 
 --
 -- Table structure for table `mugDialog`
@@ -228,15 +174,6 @@ CREATE TABLE IF NOT EXISTS `mugDialog` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
--- Dumping data for table `mugDialog`
---
-
-LOCK TABLES `mugDialog` WRITE;
-/*!40000 ALTER TABLE `mugDialog` DISABLE KEYS */;
-/*!40000 ALTER TABLE `mugDialog` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
 -- Table structure for table `mugdialog`
 --
 
@@ -249,15 +186,6 @@ CREATE TABLE IF NOT EXISTS `mugdialog` (
   PRIMARY KEY (`dialog_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Dumping data for table `mugdialog`
---
-
-LOCK TABLES `mugdialog` WRITE;
-/*!40000 ALTER TABLE `mugdialog` DISABLE KEYS */;
-/*!40000 ALTER TABLE `mugdialog` ENABLE KEYS */;
-UNLOCK TABLES;
 
 --
 -- Table structure for table `pp20apr2006`
@@ -299,15 +227,6 @@ CREATE TABLE IF NOT EXISTS `pp20apr2006` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
--- Dumping data for table `pp20apr2006`
---
-
-LOCK TABLES `pp20apr2006` WRITE;
-/*!40000 ALTER TABLE `pp20apr2006` DISABLE KEYS */;
-/*!40000 ALTER TABLE `pp20apr2006` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
 -- Table structure for table `ppdistro`
 --
 
@@ -321,15 +240,6 @@ CREATE TABLE IF NOT EXISTS `ppdistro` (
   PRIMARY KEY (`id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=56 DEFAULT CHARSET=latin1 COMMENT='Tracks locations of PP calendars and posters';
 /*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Dumping data for table `ppdistro`
---
-
-LOCK TABLES `ppdistro` WRITE;
-/*!40000 ALTER TABLE `ppdistro` DISABLE KEYS */;
-/*!40000 ALTER TABLE `ppdistro` ENABLE KEYS */;
-UNLOCK TABLES;
 
 --
 -- Table structure for table `ppforum`
@@ -351,15 +261,6 @@ CREATE TABLE IF NOT EXISTS `ppforum` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
--- Dumping data for table `ppforum`
---
-
-LOCK TABLES `ppforum` WRITE;
-/*!40000 ALTER TABLE `ppforum` DISABLE KEYS */;
-/*!40000 ALTER TABLE `ppforum` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
 -- Table structure for table `rideIdea`
 --
 
@@ -377,15 +278,6 @@ CREATE TABLE IF NOT EXISTS `rideIdea` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
--- Dumping data for table `rideIdea`
---
-
-LOCK TABLES `rideIdea` WRITE;
-/*!40000 ALTER TABLE `rideIdea` DISABLE KEYS */;
-/*!40000 ALTER TABLE `rideIdea` ENABLE KEYS */;
-UNLOCK TABLES;
-
---
 -- Table structure for table `rideidea`
 --
 
@@ -401,15 +293,6 @@ CREATE TABLE IF NOT EXISTS `rideidea` (
   PRIMARY KEY (`id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Dumping data for table `rideidea`
---
-
-LOCK TABLES `rideidea` WRITE;
-/*!40000 ALTER TABLE `rideidea` DISABLE KEYS */;
-/*!40000 ALTER TABLE `rideidea` ENABLE KEYS */;
-UNLOCK TABLES;
 
 --
 -- Table structure for table `sched`
@@ -460,15 +343,6 @@ CREATE TABLE IF NOT EXISTS `sched` (
   PRIMARY KEY (`id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=156 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Dumping data for table `sched`
---
-
-LOCK TABLES `sched` WRITE;
-/*!40000 ALTER TABLE `sched` DISABLE KEYS */;
-/*!40000 ALTER TABLE `sched` ENABLE KEYS */;
-UNLOCK TABLES;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
@@ -479,4 +353,4 @@ UNLOCK TABLES;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2021-10-05  1:30:32
+-- Dump completed on 2024-02-21  3:35:13


### PR DESCRIPTION
Mostly addresses #332. 

As detailed in that issue, you may see `?` for extended characters in the terminal, but the database itself will be saving and recalling the real characters.