### PR TITLE
Remove unused JS routing

### DIFF
--- a/site/themes/s2b_hugo_theme/static/js/cal/main.js
+++ b/site/themes/s2b_hugo_theme/static/js/cal/main.js
@@ -152,7 +152,6 @@ $(document).ready(function() {
                // so don't display "load more" button if PP
                container.append($('#load-more-template').html());
              }
-             checkAnchors();
              lazyLoadEventImages();
              $(document).off('click', '#load-more')
                   .on('click', '#load-more', function(e) {
@@ -164,7 +163,6 @@ $(document).ready(function() {
                           show_details: isExpanded
                       }, function(eventHTML) {
                           $('#load-more').before(eventHTML);
-                          checkAnchors();
                           lazyLoadEventImages();
                       });
                       return false;
@@ -182,7 +180,6 @@ $(document).ready(function() {
             show_details: true // always expand details for a single event
         }, function (eventHTML) {
             container.append(eventHTML);
-            checkAnchors();
             lazyLoadEventImages();
         });
     }
@@ -190,7 +187,6 @@ $(document).ready(function() {
     function viewAddEventForm(id, secret) {
         container.getAddEventForm( id, secret, function(eventHTML) {
             container.empty().append(eventHTML);
-            checkAnchors();
             if (id) {
                 $(document).off('click', '#confirm-delete')
                     .on('click', '#confirm-delete', function() {
@@ -298,61 +294,6 @@ $(document).ready(function() {
         $('html, body').animate({scrollTop: 0}, 800);
         return false;
     });
-
-    var routes = [];
-    function addRoute(test, action) {
-        routes.push({ test: test, action: action });
-    }
-    function checkRoute(frag) {
-        for (var i=0; i<routes.length; i++) {
-            var route = routes[i];
-            if (route.test.test(frag) && route.action(frag) !== false) {
-                return true;
-            }
-        }
-    }
-    function testRoute(frag) {
-        for (var i=0; i<routes.length; i++) {
-            if (routes[i].test.test(frag)) {
-                return true;
-            }
-        }
-    }
-    function visitRoute(frag) {
-        if (checkRoute(frag)) {
-            history.pushState({}, frag, frag);
-        }
-    }
-
-    var checkTimeout = null;
-    function checkAnchors() {
-        if (checkTimeout !== null) {
-            clearTimeout(checkTimeout);
-        }
-        checkTimeout = setTimeout(checkAnchorsDebounced, 500);
-    }
-    function checkAnchorsDebounced() {
-        var aList = document.querySelectorAll('a');
-        for (var i=0; i<aList.length; i++) {
-            var a = aList[i];
-            if (a.hasAttribute('route')) {
-                continue;
-            }
-            var frag = a.getAttribute('href');
-            if (frag.indexOf('//') !== -1) {
-                // don't mess with external links.
-                return;
-            }
-            if (testRoute(frag)) {
-                a.setAttribute('route', 'true');
-                a.addEventListener('click', function(ev) {
-                    ev.preventDefault();
-                    visitRoute(ev.currentTarget.getAttribute('href'));
-                    return false;
-                });
-            }
-        }
-    }
 
     // lightly adapted from
     // https://developers.google.com/web/fundamentals/performance/lazy-loading-guidance/images-and-video/


### PR DESCRIPTION
This code appears to have been used c. 2017 when the `/fun` calendar pages were functioning as a self-contained SPA within the larger site. See commented out code in this commit for context on how this was previously used: https://github.com/shift-org/shift-docs/commit/9b4243fa3fa6cf4475da1f6d0be4f4f34b76da27 We're not doing that sort of JS routing any more, so this isn't needed.