### PR TITLE
Consolidate enum labels and default values for front-end

### DIFF
--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
@@ -303,9 +303,8 @@
             <div class="form-group">
               <label class="control-label optional-label" for="length">Length of route</label>
               <select name="length" class="form-control" id="length">
-                <option value="--" [[# isSelected ]]selected[[/ isSelected ]]>--</option>
                 [[# lengthOptions ]]
-                <option value="[[range]]" [[# isSelected ]]selected[[/ isSelected ]]>[[range]] miles</option>
+                <option value="[[code]]" [[# isSelected ]]selected[[/ isSelected ]]>[[text]]</option>
                 [[/ lengthOptions ]]
               </select>
             </div>

--- a/site/themes/s2b_hugo_theme/static/js/cal/addevent.js
+++ b/site/themes/s2b_hugo_theme/static/js/cal/addevent.js
@@ -75,43 +75,46 @@
         if (!shiftEvent.audience) {
             shiftEvent.audience = DEFAULT_AUDIENCE;
         }
-        shiftEvent.audienceOptions = Object.keys(AUDIENCE).map( (audience) => {
+        shiftEvent.audienceOptions = [];
+        for (let [key, value] of Object.entries(AUDIENCE_DESCRIPTION)) {
             option = {
-                'code': audience,
-                'text': AUDIENCE_DESCRIPTION[audience],
+                'code': key,
+                'text': value,
             };
             if (option.code == shiftEvent.audience) {
                 option.isSelected = true;
             }
-            return option;
+            shiftEvent.audienceOptions.push(option);
         });
 
         if (!shiftEvent.area) {
             shiftEvent.area = DEFAULT_AREA; // Portland
         }
-        shiftEvent.areaOptions = Object.keys(AREA).map( (area) => {
+        shiftEvent.areaOptions = [];
+        for (let [key, value] of Object.entries(AREA)) {
             option = {
-                'code': area,
-                'text': AREA[area],
+                'code': key,
+                'text': value,
             };
             if (option.code == shiftEvent.area) {
                 option.isSelected = true;
             }
-            return option;
-        });
+            shiftEvent.areaOptions.push(option);
+        }
 
         if (!shiftEvent.length) {
             shiftEvent.length = DEFAULT_LENGTH;
         }
-        shiftEvent.lengthOptions = Object.keys(LENGTH).map( (range) => {
+        shiftEvent.lengthOptions = [];
+        for (let [key, value] of Object.entries(LENGTH)) {
             option = {
-                'code': range,
-                'text': LENGTH[range],
+                'code': key,
+                'text': value,
             };
             if (option.code == shiftEvent.length) {
                 option.isSelected = true;
             }
-            return option;
+            shiftEvent.lengthOptions.push(option);
         });
 
         template = $('#mustache-edit').html();

--- a/site/themes/s2b_hugo_theme/static/js/cal/addevent.js
+++ b/site/themes/s2b_hugo_theme/static/js/cal/addevent.js
@@ -1,5 +1,7 @@
 (function($) {
 
+    // uses CONSTANTS from helpers.js
+
     var _isFormDirty = false;
 
     $.fn.cleanFormDirt = function() {
@@ -30,25 +32,7 @@
     function populateEditForm(shiftEvent, callback) {
         var i, h, m, meridian,
             displayHour, displayMinute, timeChoice,
-            template, rendered, item,
-            lengths = [ '0-3', '3-8', '8-15', '15+'],
-            audiences = [{code: 'F', text: 'Family friendly. Adults bring children.'},
-                         {code: 'G', text: 'General. For adults, but kids welcome.'},
-                         {code: 'A', text: '21+ only.'}],
-            areas = [{code: 'P', text: 'Portland'},
-                     {code: 'V', text: 'Vancouver'},
-                     {code: 'W', text: 'Westside'},
-                     {code: 'E', text: 'East Portland'},
-                     {code: 'C', text: 'Clackamas'}];
-
-        shiftEvent.lengthOptions = [];
-        for ( i = 0; i < lengths.length; i++ ) {
-            item = {range: lengths[i]};
-            if (shiftEvent.length == lengths[i]) {
-                item.isSelected = true;
-            }
-            shiftEvent.lengthOptions.push(item);
-        }
+            template, rendered, item;
 
         shiftEvent.timeOptions = [];
         meridian = 'AM';
@@ -89,26 +73,46 @@
         }
 
         if (!shiftEvent.audience) {
-            shiftEvent.audience = 'G';
+            shiftEvent.audience = DEFAULT_AUDIENCE;
         }
-        shiftEvent.audienceOptions = [];
-        for ( i = 0; i < audiences.length; i++ ) {
-            if (shiftEvent.audience == audiences[i].code) {
-                audiences[i].isSelected = true;
+        shiftEvent.audienceOptions = Object.keys(AUDIENCE).map( (audience) => {
+            option = {
+                'code': audience,
+                'text': AUDIENCE_DESCRIPTION[audience],
+            };
+            if (option.code == shiftEvent.audience) {
+                option.isSelected = true;
             }
-            shiftEvent.audienceOptions.push(audiences[i]);
-        }
+            return option;
+        });
 
         if (!shiftEvent.area) {
-            shiftEvent.area = 'P';
+            shiftEvent.area = DEFAULT_AREA; // Portland
         }
-        shiftEvent.areaOptions = [];
-        for ( i = 0; i < areas.length; i++ ) {
-            if (shiftEvent.area == areas[i].code) {
-                areas[i].isSelected = true;
+        shiftEvent.areaOptions = Object.keys(AREA).map( (area) => {
+            option = {
+                'code': area,
+                'text': AREA[area],
+            };
+            if (option.code == shiftEvent.area) {
+                option.isSelected = true;
             }
-            shiftEvent.areaOptions.push(areas[i]);
+            return option;
+        });
+
+        if (!shiftEvent.length) {
+            shiftEvent.length = DEFAULT_LENGTH;
         }
+        shiftEvent.lengthOptions = Object.keys(LENGTH).map( (range) => {
+            option = {
+                'code': range,
+                'text': LENGTH[range],
+            };
+            if (option.code == shiftEvent.length) {
+                option.isSelected = true;
+            }
+            return option;
+        });
 
         template = $('#mustache-edit').html();
         rendered = Mustache.render(template, shiftEvent);

--- a/site/themes/s2b_hugo_theme/static/js/cal/addevent.js
+++ b/site/themes/s2b_hugo_theme/static/js/cal/addevent.js
@@ -88,7 +88,7 @@
         });
 
         if (!shiftEvent.area) {
-            shiftEvent.area = DEFAULT_AREA; // Portland
+            shiftEvent.area = DEFAULT_AREA;
         }
         shiftEvent.areaOptions = [];
         for (let [key, value] of Object.entries(AREA)) {

--- a/site/themes/s2b_hugo_theme/static/js/cal/helpers.js
+++ b/site/themes/s2b_hugo_theme/static/js/cal/helpers.js
@@ -15,7 +15,7 @@ const AUDIENCE = Object.freeze({
 const AUDIENCE_DESCRIPTION = Object.freeze({
     'G' : 'General — For adults, but kids welcome',
     'F' : 'Family Friendly — Adults bring children',
-    'A' : '21+ — Adults only',
+    'A' : '21+ Only — Adults only',
 });
 
 const LENGTH = Object.freeze({

--- a/site/themes/s2b_hugo_theme/static/js/cal/helpers.js
+++ b/site/themes/s2b_hugo_theme/static/js/cal/helpers.js
@@ -1,50 +1,57 @@
+const AREA = Object.freeze({
+    'P' : 'Portland',
+    'V' : 'Vancouver',
+    'W' : 'Westside',
+    'E' : 'East Portland',
+    'C' : 'Clackamas',
+});
+
+const AUDIENCE = Object.freeze({
+    'G' : 'General',
+    'F' : 'Family Friendly',
+    'A' : '21+ Only',
+});
+
+const AUDIENCE_DESCRIPTION = Object.freeze({
+    'G' : 'General — For adults, but kids welcome',
+    'F' : 'Family Friendly — Adults bring children',
+    'A' : '21+ — Adults only',
+});
+
+const LENGTH = Object.freeze({
+    '--'   : '--',
+    '0-3'  : '0-3 miles',
+    '3-8'  : '3-8 miles',
+    '8-15' : '8-15 miles',
+    '15+'  : '15+ miles',
+});
+
+const DEFAULT_AREA = 'P';
+const DEFAULT_AUDIENCE = 'G';
+const DEFAULT_LENGTH = '--';
+
 (function($) {
 
     $.fn.getAudienceLabel = function(audience) {
-        if (audience == null) {
-            return null;
-        }
-
-        if (audience == "A") {
-            return "21+ Only";
-        } else if (audience == "F") {
-            return "Family Friendly";
+        if (!audience || audience == DEFAULT_AUDIENCE) {
+            return null; // no label if unspecified, or for default value
         } else {
-            //no label needed for general (G) or any other value
-            return null;
+            return AUDIENCE[audience];
         }
     };
 
     $.fn.getAreaLabel = function(area) {
-        if (area == null) {
-            return null;
+        if (!area || area == DEFAULT_AREA) {
+            return null; // no label if unspecified, or for default value
+        } else {
+            return AREA[area];
         }
-
-        switch (area) {
-          case 'V':
-              return "Vancouver";
-              break;
-          case 'W':
-              return "Westside";
-              break;
-          case 'E':
-              return "East Portland";
-              break;
-          case 'C':
-              return "Clackamas";
-              break;
-          case 'P':
-              // no label needed for Portland (P)
-          default:
-              return null;
-        }
-
     };
 
     $.fn.getMapLink = function(address) {
         if (!address || address == 'TBA' || address == 'TBD') {
             // if address is null or not available yet, don't try to map it
-            return;
+            return null;
         }
 
         var urlPattern = /^https*:\/\//;
@@ -62,7 +69,7 @@
     $.fn.getWebLink = function(url) {
         if (!url) {
             // if url is not set, return nothing
-            return;
+            return null;
         }
 
         var urlPattern = /^https*:\/\//;
@@ -78,7 +85,7 @@
     $.fn.getContactLink = function(contactInfo) {
         if (!contactInfo) {
             // if no add'l contact info is set, return nothing
-            return;
+            return null;
         }
 
         var urlPattern = /^https*:\/\//;


### PR DESCRIPTION
The front-end was defining enum values & labels in multiple places (e.g. area 'P' = 'Portland'). This consolidates those in one place, and separates the UI-building logic from the specific values.