### PR TITLE
Temp directory for importing or exporting db files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ shift.overrides
 *.sql
 !services/db/*.sql
 !services/db/*/*.sql
+services/db/tmp/*.sql
 *.today
 *.DS_Store
 backend/eventimages/


### PR DESCRIPTION
Convenience tmp folder that is ignored by source control (and can be excluded from file searches on your local) for importing and exporting SQL files, e.g. 

```
./shift mysqldump > services/db/tmp/backup.sql
./shift mysql-pipe < services/db/tmp/backup.sql
```