### PR TITLE
Remove empty, unused db tables

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -47,7 +47,7 @@ Along with the migration, update the `setup.sql` script. This ensures that both 
 
 After you've applied your migration, run this command to dump the database structure but without the actual row data:
 
-```./shift mysqldump --no-data > setup.sql```
+```./shift mysqldump --no-data > services/db/tmp/setup.sql```
 
 Then:
 * Comment out each `DROP TABLE` line, e.g. `` -- DROP TABLE IF EXISTS `tablename` ``

--- a/docs/TABLES.md
+++ b/docs/TABLES.md
@@ -249,11 +249,6 @@ calshare:
 mugDialog:
 - dialog_id primary key
 - chatter string 
- 
-
-mugdialog:
-- dialog_id primary key
-- chatter string 
   
 
 pp20apr2006:
@@ -303,14 +298,6 @@ ppforum:
  
 
 rideIdea:
-- id primary key
-- ride string 
-- contact string(26) 
-- IP string(15) 
-- datePosted timestamp  
-
-
-rideidea:
 - id primary key
 - ride string 
 - contact string(26) 

--- a/services/db/migrations/0006_remove_unused_tables.sql
+++ b/services/db/migrations/0006_remove_unused_tables.sql
@@ -1,0 +1,3 @@
+-- drop unused tables
+DROP TABLE IF EXISTS `mugdialog`;
+DROP TABLE IF EXISTS `rideidea`;


### PR DESCRIPTION
(redux with merge conflicts etc worked out)

There are 2 database tables which are both unused and empty: `mugdialog` and `rideidea`. Note the capitalization — there are 2 similar tables, `mugDialog` and `rideIdea`, which *do* have data (though both are also unused by the current application).

This change drops the entirely-empty tables, to clear the way for archiving any tables that may have something useful in them (see #602).