### PR TITLE
Revert "Remove empty, unused db tables"

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -47,7 +47,7 @@ Along with the migration, update the `setup.sql` script. This ensures that both 
 
 After you've applied your migration, run this command to dump the database structure but without the actual row data:
 
-```./shift mysqldump --no-data > services/db/tmp/setup.sql```
+```./shift mysqldump --no-data > setup.sql```
 
 Then:
 * Comment out each `DROP TABLE` line, e.g. `` -- DROP TABLE IF EXISTS `tablename` ``

--- a/docs/TABLES.md
+++ b/docs/TABLES.md
@@ -249,6 +249,11 @@ calshare:
 mugDialog:
 - dialog_id primary key
 - chatter string 
+ 
+
+mugdialog:
+- dialog_id primary key
+- chatter string 
   
 
 pp20apr2006:
@@ -298,6 +303,14 @@ ppforum:
  
 
 rideIdea:
+- id primary key
+- ride string 
+- contact string(26) 
+- IP string(15) 
+- datePosted timestamp  
+
+
+rideidea:
 - id primary key
 - ride string 
 - contact string(26) 

--- a/services/db/migrations/0006_remove_unused_tables.sql
+++ b/services/db/migrations/0006_remove_unused_tables.sql
@@ -1,3 +1,0 @@
--- drop unused tables
-DROP TABLE IF EXISTS `mugdialog`;
-DROP TABLE IF EXISTS `rideidea`;


### PR DESCRIPTION
Reverts shift-org/shift-docs#611

More trouble than it’s worth — there are some funky Flourish behaviors that these lowercase tables were papering over. We can just clean these tables out later along with the rest of the unused tables. 