### PR TITLE
add env vars for images

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -57,13 +57,12 @@ const config = {
     moderator: "shift-event-email-archives@googlegroups.com",
   },
   image: {
-    // storage location for images:
-    // testing for SHIFT_DOMAIN here is a simple way to check for docker.
-    dir: env_default('SHIFT_DOMAIN') ?
-       "/opt/backend/eventimages" :
-       path.join(appPath, "eventimages"),
-    // image link directory
-    path: "/eventimages/",
+    // storage location for event images
+    dir: env_default('SHIFT_IMAGE_DIR',
+      path.join(appPath, "eventimages")),
+    // used for generated event image links
+    // ( see also the ngnix config )
+    path: env_default('SHIFT_IMAGE_PATH', "/eventimages/"),
     // used for event image links
     // ex. https://shift2bikes.org/eventimages/9248.png
     url(name) {


### PR DESCRIPTION
* **SHIFT_IMAGE_DIR**: the actual location of the images; defaults to the app's image directory; to load the old images set the var to `/opt/backend/eventimages`
* **SHIFT_IMAGE_PATH**: the sub path used by image url generation; defaults to "/eventimages/". ( shouldn't need to be changed. it matches what nginx expects. )