### PR TITLE
improved email handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ app/eventimages/*
 !app/eventimages/
 !app/eventimages/README.md
 !app/eventimages/bike.jpg
+bin
+.vscode
+node_modules

--- a/app/config.js
+++ b/app/config.js
@@ -23,13 +23,8 @@ const config = {
     name: env_default('MYSQL_DATABASE', 'shift'),
     type: "mysql2", // name of driver, installed by npm
   },
-  smtp: {
-    host: env_default('SMTP_HOST'),
-    user: env_default('SMTP_USER'),
-    pass: env_default('SMTP_PASS'),
-    logfile: env_default('SHIFT_EMAIL_LOG',
-       path.join(appPath, "../services/node/shift-mail.log")),
-  },
+  // a nodemailer friendly config, or false if smtp is not configured.
+  smtp: getSmtpSettings(),
   site: {
     name: "SHIFT to Bikes",
     listen,
@@ -55,6 +50,10 @@ const config = {
     support: "bikecal@shift2bikes.org",
     // the confirmation emailer blind copies this address
     moderator: "shift-event-email-archives@googlegroups.com",
+    logfile: function() {
+      const logfile = env_default('SHIFT_EMAIL_LOG');
+      return logfile ? path.resolve(appPath, logfile) : false;
+    }()
   },
   image: {
     // storage location for event images
@@ -99,4 +98,22 @@ function siteUrl(proxyPort) {
   const protocol = serverPort ? "https://" : "http://";
   const portstr  = (serverPort === '443') ? '' : ':' + (serverPort ?? proxyPort);
   return protocol + hostname + portstr;
+}
+
+// returns a nodemailer friendly config, or false if smtp is not configured.
+// https://nodemailer.com/smtp/
+function getSmtpSettings() {
+  // assumes that if SMTP_HOST is set, the rest is okay.
+  const host = env_default('SMTP_HOST');
+  return host && {
+    host: host,
+    port:  587,
+    // secure should be true for 465;
+    // false for everything else; and everyone seems to want 587.
+    secure: false,
+    auth: {
+      user: env_default('SMTP_USER'),
+      pass: env_default('SMTP_PASS'),
+    }
+  };
 }

--- a/app/config.js
+++ b/app/config.js
@@ -101,19 +101,23 @@ function siteUrl(proxyPort) {
 }
 
 // returns a nodemailer friendly config, or false if smtp is not configured.
-// https://nodemailer.com/smtp/
 function getSmtpSettings() {
-  // assumes that if SMTP_HOST is set, the rest is okay.
   const host = env_default('SMTP_HOST');
-  return host && {
-    host: host,
-    port:  587,
-    // secure should be true for 465;
-    // false for everything else; and everyone seems to want 587.
-    secure: false,
-    auth: {
-      user: env_default('SMTP_USER'),
-      pass: env_default('SMTP_PASS'),
-    }
-  };
+  if (!host) {
+    return false;
+  } else {
+    // assumes that if SMTP_HOST is set, the rest is okay;
+    // ( and returns a nodemailer config: https://nodemailer.com/smtp/ )
+    return {
+      host: host,
+      port:  587,
+      // secure should be true for 465;
+      // false for everything else; and everyone seems to want 587.
+      secure: false,
+      auth: {
+        user: env_default('SMTP_USER'),
+        pass: env_default('SMTP_PASS'),
+      }
+    };
+  }
 }

--- a/app/endpoints/manage_event.js
+++ b/app/endpoints/manage_event.js
@@ -133,6 +133,7 @@ function updateEvent(evt, data) {
 function sendConfirmationEmail(evt) {
   const url = config.site.url('addevent', `edit-${evt.id}-${evt.password}`);
   const subject = `Shift2Bikes Secret URL for ${evt.title}`;
+  console.debug("sending confirmation for", url);
 
   const support= config.email.support;
   const body = nunjucks.render('email.njk', {
@@ -154,7 +155,7 @@ function sendConfirmationEmail(evt) {
     bcc: config.email.moderator, // backup copy for debugging and/or moderating
     // html
     // attachments
-  });
+  }, evt.name, evt.email, evt.title, url);
 }
 
 /**


### PR DESCRIPTION
when node starts, this uses "nodemailer.verify transport" to test / log the state of smtp connection at startup.
i've verified with the old docker that given correct and incorrect ethereal email settings, decent notification will be provided.

ex. with a bad settings, at startup:
```
 failed smtp verification: Error: getaddrinfo ENOTFOUND xxxxsmtp.ethereal.email
```
when sending, the client gets an http 500 with `Server error saving event!` and the server logs:
```
sending confirmation for http://localhost:3080/addevent/edit-15-ea09520cdedd4d37ad2736f5d2b1b83e
Error: getaddrinfo ENOTFOUND xxxxsmtp.ethereal.email
at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:118:26)
```

with good settings, at startup:
```
okay: verified email host smtp.ethereal.email
```
and when sending:
``` 
sending confirmation for https://localhost:4443/addevent/edit-1-8c6680b9679e44499169abee0049b81e
Sent email Fri, 22 Mar 2024 22:14:49 GMT:
[
"Tester",
"somebody@somewhere.email",
"Test Event",
"https://localhost:4443/addevent/edit-1-8c6680b9679e44499169abee0049b81e"
] 
```
