### PR TITLE
Update API version number

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -20,7 +20,7 @@ const config = {
   appPath,
   api: {
     header: 'Api-Version',
-    version: "24.04.08",
+    version: "3.50.0",
   },
   db: {
     host: env_default('MYSQL_HOST', 'db'),

--- a/docs/CALENDAR_API.md
+++ b/docs/CALENDAR_API.md
@@ -516,3 +516,4 @@ As with v1, there were probably revisions to v2 during this time, but changelog 
 * 3.12.0: (2024-01-22) New values for Area field (Westside, East Portland, Clackamas); added pagination object to Events endpoint response when requesting a range of events
 * 3.12.1: (2024-02-12) Manage Event (create/update) endpoint documentation
 * 3.13.0: (2024-03-04) Event info now accepts UTF-8 characters (previously limited to latin1 ASCII)
+* 3.50.0: (2024-04-22) Backend now running on Node instead of PHP; no (planned) breaking changes


### PR DESCRIPTION
Bumped minor version forward to 50, aka API v3.5 since the Node port was a logically major (albeit semantically minor) update.