### PR TITLE
Better errors for node

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,5 +17,18 @@
             ],
             "type": "node"
         },
+        {
+            "name": "Test",
+            "request": "launch",
+            "runtimeArgs": [
+                "run-script",
+                "test"
+            ],
+            "runtimeExecutable": "npm",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "node"
+        },
     ]
 }

--- a/app/endpoints/manage_event.js
+++ b/app/endpoints/manage_event.js
@@ -23,7 +23,7 @@ const dt = require("../util/dateTime");
 const config = require("../config");
 const emailer = require("../emailer");
 const nunjucks = require("../nunjucks");
-const validateEvent = require("../models/calEventValidator");
+const { validateEvent } = require("../models/calEventValidator");
 
 // read multipart (and curl) posts.
 exports.post = [ uploader.handle.single('file'), handleRequest ];

--- a/app/models/calEvent.js
+++ b/app/models/calEvent.js
@@ -1,7 +1,7 @@
 const crypto = require("crypto");
 const knex = require("../knex");
 const { CalDaily } = require("./calDaily");
-const { Area, DatesType, Review } = require("./calConst");
+const { Review } = require("./calConst");
 const dt = require("../util/dateTime");
 const config = require("../config");
 
@@ -68,56 +68,14 @@ const methods =  {
     return out;
   },
 
-  // aka "fromArray" in php
-  // assumes that the fields have been validated
-  // and doesnt try to re-validate them.
-  updateFromJSON(input) {
-    // note: this is different from || ( also ?? ) because of null vs. undefined.
-    // and, also, in floush -- an empty string is converted to null(!)
-    // https://flourishlib.com/docs/fActiveRecord.html#ColumnOperations
-    function get (field, def) {
-      const val = (field in input) ? input[field] : def;
-      return val === '' ? null : val;
-    };
-    // These are marked as required
-    this.title = get('title', 'Title missing');
-    this.locname = get('venue', 'Venue missing');
-    this.address = get('address', 'Address missing');
-    this.name = get('organizer', 'Organizer missing');
-    this.email = get('email', 'Email missing');
+  // similar to "fromArray" in php
+  updateFromJSON(data) {
+    // ugly: assumes the data is validated and adjusted already.
+    Object.assign(this, data);
 
-    // these are optional
-    this.hideemail = get('hideemail', 0);
-    this.phone = get('phone', '');
-    this.hidephone = get('hidephone', 0);
-    this.contact = get('contact', '');
-    this.hidecontact = get('hidecontact', 0);
-    this.descr = get('details', '');
-    // note: this node version considers this time required.
-    // and manage_event.validateRequest() tries to ensure the time is good.
-    this.eventtime = get('time', '');
-    this.timedetails = get('timedetails', '');
-    this.locdetails = get('locdetails', '');
-    this.loopride = get('loopride', 0);
-    this.locend = get('locend', '');
-    this.eventduration = get('eventduration', 0);
-    this.weburl = get('weburl', '');
-    this.webname = get('webname', '');
-    this.audience = get('audience', '');
-    this.tinytitle = get('tinytitle', '');
-    this.printdescr = get('printdescr', '');
-    this.dates = get('datestring', ''); // string field 'dates' needed for legacy admin calendar
-    this.datestype = get('datestype', DatesType.OneDay);
-    this.area = get('area', Area.Portland);
-    this.printemail = get('printemail', 0);
-    this.printphone = get('printphone', 0);
-    this.printweburl = get('printweburl', 0);
-    this.printcontact = get('printcontact', 0);
-    this.safetyplan = get('safetyplan', 0);
-
-    // default highlight to off = (zero); but if it's already set, leave it as-is
+    // default highlight to zero; but if it's already set, leave as-is
     // fix: add a default to mysql? could there be db entries with null in there already
-    // and why is this happening in "fromJSON"?
+    // and why is this happening in "updateFromJSON"?
     this.highlight = this.highlight ?? 0;
   },
 

--- a/app/models/calEventValidator.js
+++ b/app/models/calEventValidator.js
@@ -1,0 +1,227 @@
+const dt = require("../util/dateTime");
+const validator = require('validator');
+const { Area, DatesType } = require("./calConst");
+
+class ErrorCollector {
+  constructor() {
+    this.errors = {};
+    this.count = 0;
+  }
+  addError(field, msg) {
+    this.errors[field] = msg ?? `Please enter a value for <span class=\"field-name\">${field}</span>`;
+    this.count++;
+  }
+  getErrors() {
+    return this.errors;
+  }
+}
+
+// ensure the email, title, etc. submitted by the organizer seem valid.
+// input is json, errors is of type ErrorCollector
+function makeValidator(input, errors) {
+  // the validator package requires strings and only strings
+  // the various functions below convert strings to the desired output types.
+  function getString(field) {
+    // coalecese nulls and undefined into a blank string
+    // ensure all numbers and booleans are strings
+    // trim all strings
+    return ((input[field] ?? '') + '').trim();
+  }
+  return {
+    requireString(field, msg) {
+      const str = getString(field);
+      if (validator.isEmpty(str)) {
+        errors.addError(field, msg);
+      } else {
+        return str;
+      }
+    },
+    requireEmail(field, msg) {
+      const str = getString(field);
+      if (!validator.isEmail(str)) {
+        errors.addError('email', msg);
+      } else {
+        return str; // write the trimmed value.
+      }
+    },
+    // only checks the value; doesnt return anything
+    requireTrue(field, msg) {
+      const str = getString(field);
+      // is the boolean value missing?
+      if (!validator.isBoolean(str)) {
+        errors.addError(field, msg);
+      } else {
+        // is the boolean value false?
+        if (!validator.toBoolean(str)) {
+          errors.addError(field, msg);
+        }
+      }
+    },
+    // validate the event time
+    // the php doesnt do this, but it feels like a good idea.
+    // ( and CalEvent.updateFromJSON() relies on it. )
+    requiredTime(field) {
+      // interestingly: the upload is in AM/PM style
+      // but the server stores and reports in 24 hour style.
+      // and flourish stores communicates 'time' fields as an fTime
+      // while mysql stores as a 'hh:mm:ss' with no meridian
+      // so flourish must automatically transform to 24 time.
+      // https://dev.mysql.com/doc/refman/8.0/en/time.html
+      // https://flourishlib.com/docs/fTime.html
+      const str = getString(field);
+      if (validator.isEmpty(str)) {
+        errors.addError('time');
+      } else {
+        let t = dt.from12HourString(str);
+        if (!t.isValid()) {
+          t = dt.from24HourString(str);
+        }
+        if (!t.isValid()) {
+          errors.addError('time');
+        } else {
+          return dt.to24HourString(t);
+        }
+      }
+    },
+    // to mimic php/flourish empty strings are converted to null.
+    // https://flourishlib.com/docs/fActiveRecord.html#ColumnOperations
+    nullString(field) {
+      const str = getString(field);
+      return validator.isEmpty(str) ? null : str;
+    },
+    // if not specified, returns 0
+    // otherwise expects 0, 1, true, or false
+    // then returns a 0 or 1 value
+    optionalFlag(field) {
+      const str = getString(field);
+      if (validator.isEmpty(str)) {
+        return 0;
+      } else if (!validator.isBoolean(str)) {
+        errors.addError(field);
+      } else {
+        return validator.toBoolean(str) ? 1 : 0;
+      }
+    },
+    // if not specified, returns 0
+    // otherwise expects an int-like value
+    zeroInt(field) {
+      const str = getString(field);
+      if (validator.isEmpty(str)) {
+        return 0;
+      } else {
+        // validator returns NaN, if the str isn't an int.
+        const val = validator.toInt(str);
+        if (isNaN(val)) {
+          errors.addError(field);
+        } else {
+          return val;
+        }
+      }
+    },
+    // if not specified, returns the defaultVal
+    // otherwise must be a single letter
+    optionalChar(field, defaultVal) {
+      const str = getString(field);
+      if (validator.isEmpty(str)) {
+        return defaultVal;
+      } else if (!validator.matches(str, /^[A-Z]$/)) {
+        errors.addError(field);
+      } else {
+        return str;
+      }
+    },
+    // munge print title:
+    // if print title (aka tinytitle) isn't set,
+    // use the first 24 chars of the regular title
+    mungeTinyTitle(title) {
+      const str = getString('tinytitle');
+      // fix? cut at words? ( could use the wordwrapjs )
+      return (validator.isEmpty(str) && title) ? title.substring(0, 24) : str;
+    },
+
+    /**
+     * Ensures that the 'datestatuses' in 'data' (if any) are valid.
+     * Allows an empty list ( which cancels all existing occurrences. )
+     *
+     * @param statusList:A list of data status objects sent by the organizer.
+     *        [{ id, date, status, newsflash }, ...]
+     */
+    validateStatus(statusList) {
+      const invalidDateStrings = [];
+      const validStatus = [];
+      if (statusList) {
+        if (!Array.isArray(statusList)) {
+          invalidDateStrings.push("expected an array");
+        } else {
+          statusList.forEach(status => {
+            const validDate = status.date && dt.fromYMDString(status.date).isValid();
+            if (!validDate) {
+              invalidDateStrings.push(status.date);
+            } else {
+              validStatus.push(status);
+            }
+          });
+        }
+      }
+      if (invalidDateStrings.length) {
+        const msg = "Invalid dates: " + invalidDateStrings.join(', ');
+        errors.addError('dates', msg);
+      }
+      return validStatus;
+    },
+  };
+}
+
+
+// fix? required only from March to June, during Pedalpalooza
+// tinytitle', 'printdescr'
+function validateEvent(input) {
+  const errors = new ErrorCollector();
+  const v = makeValidator(input, errors);
+  // these don't get stored; but are still required
+  v.requireTrue('code_of_conduct', "You must have read the Ride Leading Comic");
+  v.requireTrue('read_comic', "You must agree to the Code of Conduct");
+  const title = v.requireString('title', 'Title missing');
+  let values = {
+    title: title,
+    locname: v.requireString('venue', 'Venue missing'),
+    address: v.requireString('address', 'Address missing'),
+    name: v.requireString('organizer', 'Organizer missing'),
+    email: v.requireEmail('email', 'Email missing'),
+    hideemail: v.optionalFlag('hideemail'),
+    phone: v.nullString('phone'),
+    hidephone: v.optionalFlag('hidephone'),
+    contact: v.nullString('contact'),
+    hidecontact: v.optionalFlag('hidecontact'),
+    descr: v.requireString('details', 'Details missing'),
+    eventtime: v.requiredTime('time'),
+    timedetails: v.nullString('timedetails'),
+    locdetails: v.nullString('locdetails'),
+    loopride: v.optionalFlag('loopride'),
+    locend: v.nullString('locend'),
+    eventduration: v.zeroInt('eventduration'),
+    weburl: v.nullString('weburl'), // fix? validate this is a url>
+    webname: v.nullString('webname'),
+    audience: v.nullString('audience'),
+    tinytitle: v.mungeTinyTitle(title),
+    printdescr: v.nullString('printdescr'),
+    dates: v.nullString('datestring'), // string field 'dates' needed for legacy admin calendar
+    datestype: v.optionalChar('datestype', DatesType.OneDay),
+    area: v.optionalChar('area', Area.Portland),
+    printemail: v.optionalFlag('printemail'),
+    printphone: v.optionalFlag('printphone'),
+    printweburl: v.optionalFlag('printweburl'),
+    printcontact: v.optionalFlag('printcontact'),
+    safetyplan: v.optionalFlag('safetyplan'),
+  };
+  const statusList = v.validateStatus(input.datestatuses);
+  return {
+    id: input.id,
+    secret: input.secret,
+    values,
+    statusList,
+    errors,
+  };
+}
+
+module.exports = validateEvent;

--- a/app/models/calEventValidator.js
+++ b/app/models/calEventValidator.js
@@ -104,14 +104,17 @@ function makeValidator(input, errors) {
     },
     // if not specified, returns 0
     // otherwise expects an int-like value
+    // greater than or equal to 0
     zeroInt(field) {
       const str = getString(field);
       if (validator.isEmpty(str)) {
         return 0;
+      } else if (!validator.isInt(str)) {
+        errors.addError(field);
       } else {
-        // validator returns NaN, if the str isn't an int.
+        // validator returns NaN if it cant convert
         const val = validator.toInt(str);
-        if (isNaN(val)) {
+        if (isNaN(val) || val < 0) {
           errors.addError(field);
         } else {
           return val;
@@ -224,4 +227,9 @@ function validateEvent(input) {
   };
 }
 
-module.exports = validateEvent;
+module.exports = {
+  validateEvent,
+  // exported for testing:
+  makeValidator,
+  ErrorCollector
+}

--- a/app/test/manage_test.js
+++ b/app/test/manage_test.js
@@ -74,7 +74,7 @@ describe("managing events", () => {
 
   it("fail creation when missing required fields", function(){
     // each time substitute a field value that should fail
-    let pairs = [
+    const pairs = [
       "title", "",
       "details", null,
       "venue", "    ",
@@ -105,9 +105,15 @@ describe("managing events", () => {
     }
     return seq;
   });
+
   it("fails creation when fields have invalid values", function(){
-    let pairs = [
+    const pairs = [
       "eventduration", "i am not a number, i am a man!",
+      // converting directly toInt will ignore trailing text
+      // so verify that this fails as expected.
+      "eventduration", "42beep",
+      "eventduration", "-12",
+      "eventduration", -12,
       "hideemail", "wants bool",
       "hidephone", 42,
       "loopride", "wants bool",
@@ -132,7 +138,6 @@ describe("managing events", () => {
     }
     return seq;
   });
-
   it("publishes an event", function() {
     // id three is unpublished
     return CalEvent.getByID(3).then(evt => {

--- a/app/test/validator_test.js
+++ b/app/test/validator_test.js
@@ -1,0 +1,52 @@
+const chai = require('chai');
+const expect = chai.expect;
+const { ErrorCollector, makeValidator } = require("../models/calEventValidator");
+
+describe('event field validation', () => {
+  it('int validator should succeed', () => {
+    const pairs = [
+      // value, expectation
+      12, 12,
+      "12", 12,
+      null, 0,
+      0, 0,
+    ];
+    for (let i = 0; i < pairs.length; i += 2) {
+      const key = "key";
+      const value = pairs[i + 0];
+      const want  = pairs[i + 1];
+      const errors = new ErrorCollector();
+      const v = makeValidator({ key: value }, errors);
+      const got = v.zeroInt(key);
+      expect(got, `test ${i / 2}`).to.equal(want);
+      expect(errors.count).to.equal(0);
+    }
+  });
+  it('int validator should fail', () => {
+    const list = [  // all of these should fail.
+      -12,
+      "-12",
+      NaN,
+      "i am not a number",
+      "42a",
+      "a42",
+      "3.5",
+    ];
+    // collect all of the errors
+    const errors = new ErrorCollector();
+    for (let i = 0; i < list.length; i++) {
+      const key = "key";
+      const v = makeValidator({ key: list[i] }, errors);
+      const got = v.zeroInt(key);
+      expect(got, `test ${i / 2}`).to.be.undefined;
+      expect(errors.count, `count ${i}`).to.equal(i+1);
+    }
+    expect(errors.count, "final length").to.equal(list.length);
+    const msg = errors.getErrors();
+    // all of the fields had the same name "key"
+    // there should be one error in ther e
+    expect(msg.key).to.exist;
+    expect(msg.key).to.equal(`Please enter a value for <span class="field-name">key</span>`);
+  });
+
+});


### PR DESCRIPTION
php had two different times of validation: first it would do some required field validation ( manage_event.php:163->37), and then it would build the object and then call flourish validate for the db ( manage_event.php:204 )

node only had the first validation; and there is no knex/db validate function available. so this change adds code to validate each field as the database object is built and builds that object *before* trying to create or update the event. all of the validation is in the new calEventValidator.js 

( and adds various unit tests for field validation. )
