### PR TITLE
speed docker restart

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,10 +111,12 @@ services:
     volumes:
       # map the shift node code and package files;
       # and attach to the volume for its modules.
+      # remaps "package-lock" to "npm-shrinkwrap"
+      # to ensure "npm i" uses a fixed set of dependencies.
       - ./app:/shift/app/
       - ./tools:/shift/tools/
-      - ./package.json:/shift/package.json:ro
-      - ./package-lock.json:/shift/package-lock.json:ro
+      - ./package.json:/shift/package.json
+      - ./package-lock.json:/shift/npm-shrinkwrap.json
       - modules:/shift/node_modules/
 
       # provide access to images:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "start": "npm -w app start",
-    "prestart": "npm ci --omit dev --audit false --fund false --ignore-scripts",
+    "prestart": "npm i --omit dev --audit false --fund false --ignore-scripts",
     "dev": "concurrently -k \"npm:dev-*\"",
     "predev": "env-cmd -f tools/dev.env node tools/setupEventImages.js",
    	"dev-app": "env-cmd -f tools/dev.env npm start -w app",


### PR DESCRIPTION
this makes the docker node image believe `package-lock.json` is `npm-shrinkwrap.json` which allows `prestart` to use "npm i"  to get a fixed set of dependencies.

normally "npm i" will automatically update `package-lock.json` and download new dependencies when they are available.  to avoid that behavior, `prestart` had been using "npm ci".  unfortunately, while ci preserves the lock file, it doesn't preserve the installed packages: it deletes and reinstalls the dependencies each time. therefore, restart times were long ( >40 seconds on production. ) using `npm-shrinkwrap.json` and "npm i" is the middle ground. it only downloads and updates dependencies when they are missing.

"ci" averaged 16 seconds on my windows box; "i" ( when nothing has changed ) is < 1 second. 

note: i also removed the read-only flags from the json files. "npm ci" was fine with them as read-only, "npm i" wants the files to be writable, even though they aren't changed. 