### PR TITLE
PP 2024 promo banner + merch sale link

### DIFF
--- a/site/themes/s2b_hugo_theme/layouts/calevents/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/calevents/single.html
@@ -31,7 +31,7 @@
                   {{ else }}
                     <!-- on other cal pages, display smaller banner that links to PP cal page -->
                     <!-- only display when PP is coming soon or happening now -->
-                    <!-- {{ partial "cal/pp-promo-banner.html" . }} -->
+                    {{ partial "cal/pp-promo-banner.html" . }}
 
                     <!-- only display during Steptember -->
                     <!-- {{ partial "cal/promo-banner-steptember.html" . }} -->

--- a/site/themes/s2b_hugo_theme/layouts/calgrid/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/calgrid/single.html
@@ -29,7 +29,7 @@
               </div>
 
               <!-- only display when PP is coming soon or happening now -->
-              <!-- {{ partial "cal/pp-promo-banner.html" . }} -->
+              {{ partial "cal/pp-promo-banner.html" . }}
 
               <!-- only display during Steptember -->
               <!-- {{ partial "cal/promo-banner-steptember.html" . }} -->

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-header.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-header.html
@@ -23,7 +23,7 @@
 <p>Check <a href="https://www.pedalpalooza.org/">Pedalpalooza.org</a> for updates, follow <a href="https://www.instagram.com/pedalpaloozapdx/">Pedalpalooza on Instagram</a>, and tag posts about rides <strong>@pedalpaloozapdx</strong>!</p>
       {{ end }}
 
-      {{ if eq (.Param "year") 2023 }}
+      {{ if eq (.Param "year") 2024 }}
       <div class="donate">
         <p>
           <span>Support Bike Summer</span>
@@ -35,7 +35,7 @@
         </p>
       </div>
 
-<!--       {{ partial "cal/pp-merch.html" . }} -->
+      {{ partial "cal/pp-merch.html" . }}
 
       {{ end }}
 

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-merch.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-merch.html
@@ -1,4 +1,4 @@
 <div class="donate" style="margin: 1em auto;">
-  <p><strong>Limited time</strong> &mdash; buy 2023 Pedalpalooza pennants and merch now! 2nd pre-sale ends June 5th at 11:59pm.</p>
+  <p><strong>Limited time</strong> &mdash; buy 2024 Pedalpalooza pennants and merch now! Pre-sale ends May 9th at 11:59pm.</p>
   <p><a href="https://www.shop.rendered.co/pedalpalooza" target="_blank" rel="noopener">Buy merch</a></p>
 </div>

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-promo-banner.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-promo-banner.html
@@ -1,7 +1,11 @@
 <div class="pp-banner">
-  <a href="/images/pp/pp2024.png"><img alt="Pedalpalooza" id="pedalpalooza-img" src="/images/pp/pp2024-banner.png"></a>
-  <p><strong class="pp-headline"><a href="/pages/pedalpalooza/">Pedalpalooza</a> is on! All summer &mdash; June, July, and August!</strong></p>
-  <p>Go to the <a href="/pedalpalooza-calendar/">Pedalpalooza calendar</a> and <a href="https://www.pedalpalooza.org">Pedalpalooza.org</a> for more details</p>
+  <div class="promo-wrapper">
+    <a href="/pedalpalooza-calendar/"><img alt="Pedalpalooza" id="pedalpalooza-img" src="/images/pp/pp2024-banner.png" style="width: 160px; height: 90px;"></a>
+    <div style="margin: 0 1rem;">
+      <p><strong class="pp-headline">Pedalpalooza is coming! Bike Summer is June, July, and August!</strong></p>
+      <p>Go to the <a href="/pedalpalooza-calendar/">Pedalpalooza calendar</a> and <a href="https://www.pedalpalooza.org">Pedalpalooza.org</a> for more details</p>
+    </div>
+  </div>
 
-<!--   {{ partial "cal/pp-merch.html" . }} -->
+  {{ partial "cal/pp-merch.html" . }}
 </div>

--- a/site/themes/s2b_hugo_theme/static/css/cal/main.css
+++ b/site/themes/s2b_hugo_theme/static/css/cal/main.css
@@ -394,6 +394,18 @@ a.expand-details {
     margin-bottom: 2em;
 }
 
+.pp-banner .promo-wrapper {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+}
+
+@media screen and (width <= 600px) {
+    .pp-banner .promo-wrapper {
+        flex-direction: column;
+    }
+}
+
 .pp-banner .pp-headline,
 .promo-banner .pp-headline {
     font-weight: bold;


### PR DESCRIPTION
* Added promo banner to regular list & grid view events pages
* Tweaked promo banner layout so that it doesn't dominate the list/grid view pages quite so much (still room to improve, though)
* Added merch link to promo banner and the header of the PP calendar page