### PR TITLE
fix handling of legacy nulls for "hidden"

### DIFF
--- a/app/endpoints/retrieve_event.js
+++ b/app/endpoints/retrieve_event.js
@@ -34,11 +34,17 @@ exports.get = function get(req, res, next) {
         // the php version didnt error on invalid secret;
         // so this doesnt either ( private data is only returned with a valid secret )
         const includePrivate = evt.isSecretValid(secret);
-        const statuses = CalDaily.getStatusesByEventId(evt.id);
-        evt.getDetails(statuses, {includePrivate}).then(details => {
-          res.set(config.api.header, config.api.version);
-          res.json(details);
-        });
+        if (!evt.isPublished() && !includePrivate) {
+          // act exactly as if unpublished events don't exist
+          // ( unless you know the secret )
+          res.textError("Event not found");
+        } else {
+          const statuses = CalDaily.getStatusesByEventId(evt.id);
+          evt.getDetails(statuses, {includePrivate}).then(details => {
+            res.set(config.api.header, config.api.version);
+            res.json(details);
+          });
+        }
       }
     }).catch(next);
   }

--- a/app/models/calDaily.js
+++ b/app/models/calDaily.js
@@ -161,7 +161,7 @@ class CalDaily {
       .query('caldaily')
       .join('calevent', 'caldaily.id', 'calevent.id') // join for hidden test.
       .where('pkid', pkid)
-      .whereNot('hidden', 1) // calevent.hidden is 0 once published
+      .whereRaw('not coalesce(hidden, 0)') // zero when published; null for legacy events.
       .whereNot('eventstatus', EventStatus.Delisted)
       .first()
       .then(function(at) {
@@ -197,7 +197,7 @@ class CalDaily {
     return knex
       .query('caldaily')
       .join('calevent', 'caldaily.id', 'calevent.id')
-      .whereNot('hidden', 1)         // hidden is 0 once published
+      .whereRaw('not coalesce(hidden, 0)')         // zero when published; null for legacy events.
       .where('eventdate', '>=', firstDay.toDate())
       .where('eventdate', '<=', lastDay.toDate())
       .orderBy('eventdate')
@@ -212,7 +212,7 @@ class CalDaily {
    return knex
       .query('caldaily')
       .join('calevent', 'caldaily.id', 'calevent.id')
-      .whereNot('hidden', 1)                         // calevent: hidden is 0 once published
+      .whereRaw('not coalesce(hidden, 0)')           // calevent: zero when published; null for legacy events.
       .whereNot('review', Review.Excluded)           // calevent: a legacy status code.
       .whereNot('eventstatus', EventStatus.Skipped)  // caldaily: a legacy status code.
       .whereNot('eventstatus', EventStatus.Delisted) // caldaily: for soft deletion.

--- a/app/models/calEvent.js
+++ b/app/models/calEvent.js
@@ -162,7 +162,9 @@ const methods =  {
 
   // can people looking for rides see this event?
   isPublished() {
-    return this.hidden === 0;
+    // note: legacy events have null for the hidden field
+    // zero and null are considered published.
+    return !this.hidden;
   },
 
   // make this event visible to all

--- a/app/test/delete_test.js
+++ b/app/test/delete_test.js
@@ -56,7 +56,7 @@ describe("event cancellation using a form", () => {
         done();
       });
   });
-  it("succeeds with a valid id and secret", async function() {
+  it("deletes with a valid id and secret", async function() {
     const e0 = await CalEvent.getByID(2);
     const d1 = await CalDaily.getForTesting(201);
     const d2 = await CalDaily.getForTesting(202);
@@ -146,6 +146,22 @@ describe("event cancellation using json", () => {
       .post(delete_api)
       .send({
         id: 3,
+        secret: testData.secret,
+      })
+      .end(function (err, res) {
+        expect(err).to.be.null;
+        expect(res).to.have.status(200);
+        expect(res).to.be.json;
+        expect(res).to.have.header('Api-Version');
+        expect(data.eventErasures.callCount).to.equal(1);
+        done();
+      });
+  });
+  it("deletes a legacy event", function(done) {
+    chai.request( app )
+      .post(delete_api)
+      .send({
+        id: 1, // id 1 is hidden null
         secret: testData.secret,
       })
       .end(function (err, res) {

--- a/app/test/retrieve_test.js
+++ b/app/test/retrieve_test.js
@@ -50,7 +50,7 @@ describe("retrieving event data for editing", () => {
         done();
       });
   });
-  it("succeeds with a valid id and secret", function(done) {
+  it("retrieves with a valid id and secret", function(done) {
     chai.request( app )
       .get('/api/retrieve_event.php')
       .query({
@@ -88,4 +88,30 @@ describe("retrieving event data for editing", () => {
         done();
       });
   });
+  it("errors on a hidden event", function(done) {
+    chai.request( app )
+      .get('/api/retrieve_event.php')
+      .query({
+        id: 3
+      })
+      .end(function (err, res) {
+        expect(err).to.be.null;
+        testData.expectError(expect, res);
+        done();
+      });
+  });
+  it("errors on a hidden event, unless given the secret", function(done) {
+    chai.request( app )
+      .get('/api/retrieve_event.php')
+      .query({
+        id: 3,
+        secret: testData.secret,
+      })
+      .end(function (err, res) {
+        expect(err).to.be.null;
+        expect(res).to.have.status(200);
+        done();
+      });
+  });
 });
+

--- a/app/test/testdb.js
+++ b/app/test/testdb.js
@@ -91,10 +91,23 @@ function fakeCalEvent(eventId) {
     loopride : 1,
     area: Area.Portland,
     highlight: 0,
-    hidden: eventId !== 3 ? 0 : 1,  // #3 is unpublished.
+    hidden: hidden(eventId),
     password: testData.secret,
     safetyplan : 1,
   };
+}
+
+function hidden(eventId) {
+  switch (eventId) {
+  case 3:
+    return 1; // #3 is hidden/unpublished.
+  case 2:
+    return 0;
+  case 1:
+    return null; // use a legacy hidden code.
+  default:
+    throw new Error("unexpected event id", eventId);
+  }
 }
 
 // https://stackoverflow.com/questions/521295/seeding-the-random-number-generator-in-javascript


### PR DESCRIPTION
- explicitly handle null in the hidden queries ( ex. coalesce )
- report "isPublished" correctly
- tweak retrieve event so that hidden events are only returned if the secret has been provided ( discovered that issue when fixing broken tests )

new tests:
- generates test data which includes a legacy null ( for event 1 )
- add test for deleting a legacy event
- add test to ensure unpublished events aren't retrievable without the secret