### PR TITLE
Deleted events query

### DIFF
--- a/app/endpoints/events.js
+++ b/app/endpoints/events.js
@@ -34,7 +34,7 @@ exports.get = function(req, res, next) {
   let id = req.query.id;
   let start = req.query.startdate;
   let end = req.query.enddate;
-  const includeDeleted = (req.query.all === "true") || (req.query.all === "1");
+  const includeAllEvents = (req.query.all === "true") || (req.query.all === "1");
   if (id && start && end) {
     res.textError("expected only an id or date range"); // fix, i think its supposed be sending a json error.
   } else if (id) {
@@ -64,7 +64,7 @@ exports.get = function(req, res, next) {
       } else if (range > 100) {
         res.textError(`event range too large: ${range} days requested; max 100 days`);
       } else {
-        return CalDaily.getRangeVisible(start, end, includeDeleted).then((dailies) => {
+        return CalDaily.getRangeVisible(start, end, includeAllEvents).then((dailies) => {
           return getSummaries(dailies).then((events) => {
             const pagination = getPagination(start, end, events.length);
             res.set(config.api.header, config.api.version);

--- a/app/endpoints/events.js
+++ b/app/endpoints/events.js
@@ -5,6 +5,7 @@
  * This endpoint supports two different queries:
  *   id=caldaily_id ( the time id )
  *   startdate=YYYY-MM-DD & enddate=YYYY-MM-DD
+ *   &all=true ( to include soft deleted rides )
  *
  * For example:
  *   http://localhost:3080/api/events.php?id=1893
@@ -33,6 +34,7 @@ exports.get = function(req, res, next) {
   let id = req.query.id;
   let start = req.query.startdate;
   let end = req.query.enddate;
+  const includeDeleted = (req.query.all === "true") || (req.query.all === "1");
   if (id && start && end) {
     res.textError("expected only an id or date range"); // fix, i think its supposed be sending a json error.
   } else if (id) {
@@ -62,7 +64,7 @@ exports.get = function(req, res, next) {
       } else if (range > 100) {
         res.textError(`event range too large: ${range} days requested; max 100 days`);
       } else {
-        return CalDaily.getRangeVisible(start, end).then((dailies) => {
+        return CalDaily.getRangeVisible(start, end, includeDeleted).then((dailies) => {
           return getSummaries(dailies).then((events) => {
             const pagination = getPagination(start, end, events.length);
             res.set(config.api.header, config.api.version);

--- a/app/models/calDaily.js
+++ b/app/models/calDaily.js
@@ -103,7 +103,10 @@ const methods =  {
       caldaily_id: this.pkid.toString(),
       shareable: this.getShareable(),
       cancelled: this.isUnscheduled(), // better would have been "scheduled:true"
-      newsflash: this.newsflash,
+      // dont send newsflash when delisted:
+      // its not scheduled and may be deleted
+      // either way, its not info we want to show.
+      newsflash: !this.isDelisted() ? this.newsflash : null,
       status: this.eventstatus,
     };
     // see notes in CalEvent.getJSON()

--- a/app/models/calDaily.js
+++ b/app/models/calDaily.js
@@ -104,10 +104,8 @@ const methods =  {
       shareable: this.getShareable(),
       cancelled: this.isUnscheduled(), // better would have been "scheduled:true"
       newsflash: this.newsflash,
+      status: this.eventstatus,
     };
-    if (this.eventstatus === EventStatus.Cancelled) {
-      data.explicit_cancel = true;
-    }
     // see notes in CalEvent.getJSON()
     if (endtime !== undefined) {
       data.endtime = endtime;

--- a/app/models/calDaily.js
+++ b/app/models/calDaily.js
@@ -213,12 +213,16 @@ class CalDaily {
       .query('caldaily')
       .join('calevent', 'caldaily.id', 'calevent.id')
       .whereRaw('not coalesce(hidden, 0)')           // calevent: zero when published; null for legacy events.
-      .modify(function(q) {
+      .where(function(q) {
         if (!includeDeleted) {
           // calevent: a legacy code; reused for soft-delete
           q.whereNot('review', Review.Excluded)
           // caldaily: for deselected days; soft-deleted days are also deselected.
           q.whereNot('eventstatus', EventStatus.Delisted)
+        } else {
+          q.whereNot('eventstatus', EventStatus.Delisted)
+           .orWhere('eventstatus', EventStatus.Delisted)
+           .andWhere('review', Review.Excluded)
         }
       })
       .whereNot('eventstatus', EventStatus.Skipped)  // caldaily: a legacy status code.

--- a/app/models/calEvent.js
+++ b/app/models/calEvent.js
@@ -14,8 +14,10 @@ const methods =  {
     if (duration <= 0) {
       duration = null;
     }
-
-    let out = {
+    return this.isDeleted() ? {
+      id        : this.id.toString(),
+      deleted   : true,
+    } : {
       id        : this.id.toString(),
       title     : this.title,
       venue     : this.locname,
@@ -64,7 +66,7 @@ const methods =  {
       // for now, therefore this is in CalDaily
       // endtime: getEndTime()
     };
-    return out;
+
   },
 
   // similar to "fromArray" in php

--- a/tools/makeFakeEvents.js
+++ b/tools/makeFakeEvents.js
@@ -104,7 +104,7 @@ function makeCalDailies(eventId, start, numDays) {
     }
     out.push({
       id          : eventId,
-      eventdate   : knex.toDate(start),
+      eventdate   : start.toDate(),
       eventstatus : active? EventStatus.Active : EventStatus.Cancelled,
       newsflash   : msg,
     });


### PR DESCRIPTION
there's a new events query parameter, `&all=true`, ( ex.  http://localhost:3080/api/events.php?startdate=2024-06-02&enddate=2024-06-12&all=true )

when `all` is `true` or `1`, and an event has been deleted, all of the previously scheduled days for that event will be returned as with a special `"deleted": true` property and limited other information.
for example:
```
 {
      "id": "4",
      "deleted": true,
      "date": "2024-06-05",
      "caldaily_id": "5",
      "shareable": "http://localhost:3080/calendar/event-5",
      "cancelled": true,
      "status": "D",    // CHANGED -> the updated pr always sends the status of each day;
                        //  it will be "D" delisted for all "deleted events".
                        //  it might be "D"-delisted or "C"-cancelled  or "A" active for normal events
      "endtime": "19:45:00"
}
```
this isn't a completely satisfying solution because there will be repeated entries for every caldaily used by the calevent. but -- this _is_ a range based request... so it does ultimately need to talk in terms of days.

---

i also set this mode to return "delisted" days when querying all -- that is, days that were deselected by an organizer but never explicitly cancelled, because it sounded like that was probably needed as well. 

unfortunately, the "cancelled" flag for event queries is true for both explicitly cancelled days and for delisted days -- rather than attempt to fix that, i added an additional "explicit_cancel" flag for meaning no, it wasn't delisted it was actually cancelled.
```
 {
      "id": "2",
      "title": "Under the Bridge",
      "time": "16:15:00",
      ... 
      "date": "2024-06-07",
      "caldaily_id": "2",
      "shareable": "http://localhost:3080/calendar/event-2",
      "cancelled": true, // --> really means "unscheduled", might be status C or D.
      "status": "C"  // CHANGED --> the updated pr sends the "status"; "C" for explicitly canceled, "D" for delisted, "A" for active.
    }
```
 ( just to really break everyone's brain: generally delisted days aren't returned by queries, so technically most of the time when a client can see the "cancelled" flag is does actually mean "cancelled".  but that "most of the time" worries me, so leaving "cancelled" to mean "unscheduled" like it has been doing seems best. ) 