### PR TITLE
add an ical endpoint that hides deleted events

### DIFF
--- a/services/nginx/conf.d/shift.conf
+++ b/services/nginx/conf.d/shift.conf
@@ -31,18 +31,23 @@ server {
     # ( see https://docs.docker.com/compose/networking/ )
     # -----------------------------------------------
 
-    # replace ics.php with the newer ical.php
+    # used for the per-ride "export link"
     location = /api/ics.php {
         proxy_pass http://node:3080/api/ical.php;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
-    # replace the legacy pedalp endpoint with a range
+    # used as a webcal endpoint for calendar subscriptions:
+    # ex.  webcal://www.shift2bikes.org/cal/pedalpalooza-calendar.php
     location = /api/pedalpalooza-calendar.php {
         # set to a constant range for this year's pedalp
-        # alt, could set to the blank string "" and it would return 3 month range
-        # or could customize the endpoint with a "pedalpalooza" parameter or something.
-        proxy_pass http://node:3080/api/ical.php?startdate=2024-06-01&enddate=2024-08-31&filename=pedalpalooza-2024.ics;
+        proxy_pass http://node:3080/api/ical.php?startdate=2024-06-01&enddate=2024-08-31&filename=pedalpalooza-2024.ics&all=true;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location = /api/pedalpalooza-test.php {
+        # set to a constant range for this year's pedalp
+        proxy_pass http://node:3080/api/ical.php?startdate=2024-06-01&enddate=2024-08-31&filename=pedalpalooza-2024.ics&all=false;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 


### PR DESCRIPTION
instead of just "webcal://www.shift2bikes.org/cal/pedalpalooza-calendar.php"
there is also a "webcal://www.shift2bikes.org/cal/pedalpalooza-test.php" 
so we can see how google/apple behave when we summarily drop deleted events ( currently we list them as cancelled )
if it works okay ( and it probably will ) then we could swap dropping them by default.