### PR TITLE
Bump API version and update docs for event and ics endpoint updates

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -20,7 +20,7 @@ const config = {
   appPath,
   api: {
     header: 'Api-Version',
-    version: "3.51.0",
+    version: "3.52.0",
   },
   db: {
     host: env_default('MYSQL_HOST', 'db'),

--- a/app/models/calDaily.js
+++ b/app/models/calDaily.js
@@ -101,9 +101,7 @@ const methods =  {
     let data = {
       date: this.getFormattedDate(),
       caldaily_id: this.pkid.toString(),
-      // don't send shareable when delisted:
-      // url is no longer valid
-      shareable: !this.isDelisted() ? this.getShareable() : null,
+      shareable: this.getShareable(),
       cancelled: this.isUnscheduled(), // better would have been "scheduled:true"
       // don't send newsflash when delisted:
       // it's not scheduled and may be deleted

--- a/app/models/calDaily.js
+++ b/app/models/calDaily.js
@@ -101,10 +101,12 @@ const methods =  {
     let data = {
       date: this.getFormattedDate(),
       caldaily_id: this.pkid.toString(),
-      shareable: this.getShareable(),
+      // don't send shareable when delisted:
+      // url is no longer valid
+      shareable: !this.isDelisted() ? this.getShareable() : null,
       cancelled: this.isUnscheduled(), // better would have been "scheduled:true"
-      // dont send newsflash when delisted:
-      // its not scheduled and may be deleted
+      // don't send newsflash when delisted:
+      // it's not scheduled and may be deleted
       // either way, its not info we want to show.
       newsflash: !this.isDelisted() ? this.newsflash : null,
       status: this.eventstatus,

--- a/docs/TABLES.md
+++ b/docs/TABLES.md
@@ -204,6 +204,7 @@ That pairing is, in a sense, its true identity.
   
     * A=as scheduled
     * C=canceled
+    * D=delisted - just removed, not explicitly canceled
     * S=skipped   - legacy
     * E=exception - legacy
     


### PR DESCRIPTION
Bumped API version and updated documentation for `events` and `ics` endpoints.

Also addresses #565.