### PR TITLE
update to the new ical feed

### DIFF
--- a/services/nginx/conf.d/shift.conf
+++ b/services/nginx/conf.d/shift.conf
@@ -41,13 +41,7 @@ server {
     # ex.  webcal://www.shift2bikes.org/cal/pedalpalooza-calendar.php
     location = /api/pedalpalooza-calendar.php {
         # set to a constant range for this year's pedalp
-        proxy_pass http://node:3080/api/ical.php?startdate=2024-06-01&enddate=2024-08-31&filename=pedalpalooza-2024.ics&all=true;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    }
-
-    location = /api/pedalpalooza-test.php {
-        # set to a constant range for this year's pedalp
-        proxy_pass http://node:3080/api/ical.php?startdate=2024-06-01&enddate=2024-08-31&filename=pedalpalooza-2024.ics&all=false;
+        proxy_pass http://node:3080/api/ical.php?startdate=2024-06-01&enddate=2024-08-31&filename=pedalpalooza-2024.ics;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 


### PR DESCRIPTION
this switches the main ical feed so that it no longer shows "delisted" events ( by changing the nginx configuration ):
- removes "&all=true" from the ical feed to hide the delisted events.
- removes the feed used for testing.

the Derry Girls Ride (event listing id 11259) is a great test. it has one active, one cancelled, and one delisted day.
```
	D	2024-06-01	18622
	C	2024-06-02	18625 
	A	2024-06-23	19403
```

the test feed correctly hides the D entry, while still showing the C listing. 
https://api.shift2bikes.org/api/pedalpalooza-test.php vs. https://api.shift2bikes.org/api/pedalpalooza-calendar.php

to test an event "vanishing" while already subscribed, i used mac's desktop calendar app:
* subscribed to the test feed ( setting the refresh to 5 minutes )
* created a test event and published it
* verified i could see it in calendar
* delisted the day ( and edited the html to activate the "save" button to update with zero days )
* waited 5 minutes, and saw the event disappear from calendar

interestingly, google changed calendar at some point so it *never* shows cancelled events. so there was nothing to test for it.