### PR TITLE
client-side search prototype

### DIFF
--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
@@ -1,6 +1,6 @@
 <script src="{{ .Site.BaseURL }}js/cal/helpers.js"></script>
 <script src="{{ .Site.BaseURL }}js/cal/main.js"></script>
-
+<script src="https://cdn.jsdelivr.net/npm/minisearch@6.3.0/dist/umd/index.min.js"></script>
 <script src="{{ .Site.BaseURL }}js/libs/mustache/mustache.min.js"></script>
 
 <script src="{{ .Site.BaseURL }}js/libs/dayjs/dayjs.min.js"></script>
@@ -14,6 +14,7 @@
 <script src="{{ .Site.BaseURL }}js/libs/fullcalendar/core/main.min.js"></script>
 <script src="{{ .Site.BaseURL }}js/libs/fullcalendar/daygrid/main.min.js"></script>
 <script src="{{ .Site.BaseURL }}js/libs/fullcalendar/timegrid/main.min.js"></script>
+
 
 <script type="text/javascript">
   //only show grid view for PP pages, 2008 or later
@@ -133,7 +134,7 @@
     <ul class="events-list">
       [[#events]]
 
-      <li class="event row [[#cancelled]]cancelled[[/cancelled]] [[#featured]]featured[[/featured]]" data-event-id="[[id]]">
+      <li class="event row [[#cancelled]]cancelled[[/cancelled]] [[#featured]]featured[[/featured]]" data-event-id="[[caldaily_id]]">
         [[#featured]]<p class="featured-text" id="featured[[caldaily_id]]"><span aria-hidden="true">★ </span>Featured Event<span aria-hidden="true"> ★</span></p>[[/featured]]
         <div class="time col-xs-2">
           [[#cancelled]]<del>[[/cancelled]]
@@ -381,6 +382,10 @@
   <div class="event-list-options">
     <div class="show-details">
       <button type="button" id="show-details" class="btn">Toggle details</button>
+    </div>
+    <div class="event-search">
+      <label for="event-search-field">Search</label>
+      <input type="text" id="event-search-field">
     </div>
     <div class="go-to-date">
       <label for="go-to-date-field">Go to date</label>


### PR DESCRIPTION
a prototype of client side searching ( really filtering ).

in the  /calendar page's section for goto date and toggle details, adds a simple text input field that "on change" shows/hides `<li>` items based on their `data-event-id` attribute 

- uses [minisearch](https://github.com/lucaong/minisearch ) (10.51 kb minimized) for client side filtering of existing event data 
- tweaks mustache generated html so that the "data-event-id" is "caldaily_id" ( was event listing id )
- tweaks the mustache getEventHTML() , moving  "set page title for specific id" to the caller that needed it.

![image](https://github.com/shift-org/shift-docs/assets/335250/63cd26a2-8de7-4ada-b9b3-b0ca8ce8f3ca)

i don't think its usable as is -- but might be a starting point for discussion.