### PR TITLE
fix: calendar "view more events"

### DIFF
--- a/site/themes/s2b_hugo_theme/static/js/cal/main.js
+++ b/site/themes/s2b_hugo_theme/static/js/cal/main.js
@@ -129,8 +129,8 @@ $(document).ready(function() {
              $(document).off('click', '#load-more')
                   .on('click', '#load-more', function(e) {
                       // the next day to view is one day after the previous last
-                      view.startdate = view.startdate.add(1, 'day');
-                      view.enddate = view.enddate.add(dayRange, 'day');
+                      view.startdate = view.enddate.add(1, 'day');
+                      view.enddate = view.startdate.add(dayRange, 'day');
                       // add new events to the end of those we've already added.
                       getEventHTML(view, function(eventHTML) {
                           $('#load-more').before(eventHTML);


### PR DESCRIPTION
the comment was accurate, but the code was wrong:
```
// the next day to view is one day after the previous last
view.startdate = view.startdate.add(1, 'day');
view.startdate = view.enddate.add(1, 'day');
```

introduced with: https://github.com/shift-org/shift-docs/commit/9f7d7207f87644ce805f3e3dc35be600a9966ef5

the original code was:
```
firstDayOfRange = daysAfter(lastDayOfRange, nextDay);
lastDayOfRange = daysAfter(firstDayOfRange, dayRange);
```

to match, the code should be:
```
view.startdate = view.enddate.add(1, 'day');
view.enddate = view.startdate.add(dayRange, 'day');
```