### PR TITLE
fix pedalp inclusive/exclusive date differences

### DIFF
--- a/site/content/archive/pedalpalooza/pedalpalooza-2020.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2020.md
@@ -7,7 +7,7 @@ type: pp-theme-cal
 pp: true
 year: 2020
 startdate: 2020-06-01
-enddate: 2020-07-06 # end date is exclusive
+enddate: 2020-07-05
 daterange: June 1–July 5, 2020
 banner-image: "/images/pp/pp2020-banner.png"
 poster-image: "/images/pp/pp2020.png"

--- a/site/content/archive/pedalpalooza/pedalpalooza-2021.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2021.md
@@ -7,7 +7,7 @@ type: calevents
 pp: true
 year: 2021
 startdate: 2021-06-01
-enddate: 2021-09-01 # end date is exclusive
+enddate: 2021-08-31
 daterange: June 1–August 31, 2021
 banner-image: "/images/pp/pp2021-banner.jpg"
 poster-image: "/images/pp/pp2021.jpg"

--- a/site/content/archive/pedalpalooza/pedalpalooza-2022.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2022.md
@@ -7,7 +7,7 @@ type: calevents
 pp: true
 year: 2022
 startdate: 2022-06-01
-enddate: 2022-09-01 # end date is exclusive
+enddate: 2022-08-31
 daterange: June 1–August 31, 2022
 banner-image: "/images/pp/pp2022-banner.jpg"
 poster-image: "/images/pp/pp2022.jpg"

--- a/site/content/archive/pedalpalooza/pedalpalooza-2023.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2023.md
@@ -7,7 +7,7 @@ type: calevents
 pp: true
 year: 2023
 startdate: 2023-06-01
-enddate: 2023-09-01 # end date is exclusive
+enddate: 2023-08-31
 daterange: June 1–August 31, 2023
 banner-image: "/images/pp/pp2023-banner.jpg"
 poster-image: "/images/pp/pp2023.jpg"

--- a/site/content/pedalpalooza-calendar.md
+++ b/site/content/pedalpalooza-calendar.md
@@ -7,7 +7,7 @@ type: calevents
 pp: true
 year: 2024
 startdate: 2024-06-01
-enddate: 2024-09-01 # end date is exclusive
+enddate: 2024-08-31
 daterange: June 1–August 31, 2024
 banner-image: "/images/pp/pp2024-banner.png"
 poster-image: "/images/pp/pp2024.png"

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
@@ -20,14 +20,15 @@
   if ({{ .Param "pp" }} && ( {{ .Param "year" }} >= 2008 ) ) {
 
     document.addEventListener('DOMContentLoaded', function() {
-    	// the values are pulled from the .md page file
+      // the values are pulled from the .md page file
       // all PP pages require start and enddates
-      const today = dayjs();
+      const today = dayjs().startOf('day');
       const range = { 
-          start: dayjs( {{ .Param "startdate" }} ),
-          end : dayjs( {{ .Param "enddate" }} ),
-        };
-      // is today in range? then use today; otherwise use the range start
+        start: dayjs( {{ .Params.startdate }} ),
+        end : dayjs( {{ .Params.enddate }} ),
+      };
+      // use today as the initially focused day, if its within the range;
+      // otherwise use the start of the range.
       const initialDate = (today >= range.start && today <= range.end) ?
                           today : range.start;  
 
@@ -40,10 +41,10 @@
           center: 'title',
           right: 'dayGridMonth,timeGridWeek,timeGridDay'
         },
-        defaultDate: initialDate,
+        defaultDate: initialDate.toDate(),
         validRange: {
           start: range.start.toDate(),
-          // fullcal ranges are exclusive.
+          // warning: fullcal enddate is exclusive.
           end: range.end.add(1, 'day').toDate(),
         },
         nowIndicator: true,

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
@@ -20,15 +20,19 @@
   if ({{ .Param "pp" }} && ( {{ .Param "year" }} >= 2008 ) ) {
 
     document.addEventListener('DOMContentLoaded', function() {
-      var calendarEl = document.getElementById('fullcalendar');
+    	// the values are pulled from the .md page file
+      // all PP pages require start and enddates
+      const today = dayjs();
+      const range = { 
+          start: dayjs( {{ .Param "startdate" }} ),
+          end : dayjs( {{ .Param "enddate" }} ),
+        };
+      // is today in range? then use today; otherwise use the range start
+      const initialDate = (today >= range.start && today <= range.end) ?
+                          today : range.start;  
 
-      var today = new Date;
-      default_start_date = {{ .Param "startdate" }};
-      if ( new Date({{ .Param "startdate" }}) <= today && new Date({{ .Param "enddate" }}) >= today) {
-        default_start_date = today;
-      }
-
-      var calendar = new FullCalendar.Calendar(calendarEl, {
+      const calendarEl = document.getElementById('fullcalendar');
+      const calendar = new FullCalendar.Calendar(calendarEl, {
         plugins: [ 'dayGrid', 'timeGrid' ],
         defaultView: 'dayGridMonth',
         header: {
@@ -36,10 +40,11 @@
           center: 'title',
           right: 'dayGridMonth,timeGridWeek,timeGridDay'
         },
-        defaultDate: default_start_date,
+        defaultDate: initialDate,
         validRange: {
-          start: {{ .Param "startdate" }},
-          end: {{ .Param "enddate" }}
+          start: range.start.toDate(),
+          // fullcal ranges are exclusive.
+          end: range.end.add(1, 'day').toDate(),
         },
         nowIndicator: true,
         eventLimit: true,

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/fullcal.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/fullcal.html
@@ -5,6 +5,11 @@
 {{ partial "cal/scripts.html" . }}
 
 <script type="text/javascript">
+  {{/*
+    this partial is used by the calgrid and pp-landing layouts.
+    pp-landing is used only if pedalpalooza _isnt_ happening.
+    calgrid is used by the calgrid page ( /calendar and the "Grid" option )
+  */}}
   document.addEventListener('DOMContentLoaded', function() {
     var calendarEl = document.getElementById('fullcalendar');
     var params = parseURL();

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-2020-cal.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-2020-cal.html
@@ -8,6 +8,15 @@
 <script type="text/javascript">
   document.addEventListener('DOMContentLoaded', function() {
     var calendarEl = document.getElementById('fullcalendar');
+    const range = {
+      // warning: fullcal dates are exclusive.
+      start : {{ .Params.startdate }},
+      end : function() {
+        const d = new Date( {{ .Params.enddate }} );
+        d.setDate( d.getDate() + 1);
+        return d;
+      }(), 
+    };
   
     var calendar = new FullCalendar.Calendar(calendarEl, {
       plugins: [ 'dayGrid', 'timeGrid', 'list' ],
@@ -42,11 +51,8 @@
         right: 'dayGridSixWeeks,listDaySixWeeks,listDay'
       },
       noEventsMessage: "Open day — submit a theme at Pedalpalooza.org!",
-      defaultDate: {{ .Param "startdate" }},
-      validRange: {
-        start: {{ .Param "startdate" }},
-        end: {{ .Param "enddate" }}
-      },
+      defaultDate: range.start,
+      validRange: range,
       nowIndicator: true,
       eventLimit: true,
       navLinks: true,

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/up-next.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/up-next.html
@@ -2,6 +2,11 @@
 <script src="{{ .Site.BaseURL }}js/libs/fullcalendar/list/main.min.js"></script>
 
 <script type="text/javascript">
+  {{/* 
+    up-next is used by the homepage to display a list of upcoming events.
+    the list view here is different than the /calendar and /pedalp pages.
+    this uses FullCalendar; those use custom code and a mustache template.
+  */}}
   document.addEventListener('DOMContentLoaded', function() {
     var calendarEl = document.getElementById('fullcalendar');
 


### PR DESCRIPTION
first pass of turning inclusive dates in to exclusive dates for fullcal, re: https://github.com/shift-org/shift-docs/issues/739

setting this as draft until i ( and we all ) have more time to think about whether this might affect anything else. ( ex. FullCalendar is used in 4 partials )

`/layouts/partials/cal/events.html` 
`/layouts/partials/cal/fullcal.html`
`/layouts/partials/cal/pp-2020-cal.html`
`/layouts/partials/cal/up-next.html`

and, it'd be good to verify the behavior of some of the archive pages in years before 2021