### PR TITLE
fix pedalp event list jumping ahead

### DIFF
--- a/site/themes/s2b_hugo_theme/static/js/cal/main.js
+++ b/site/themes/s2b_hugo_theme/static/js/cal/main.js
@@ -75,12 +75,12 @@ $(document).ready(function() {
     // default range of days to show.
     const dayRange = 10;
 
-    // compute range and details settings from options.
+    // compute range and details settings from the url options.
     // the returned object gets passed to getEventHTML().
     function getInitialView(options) {
-        const today = dayjs().utc();
-        const start = dayjs(options.startdate).utc(); // if start or end are missing,
-        const end   = dayjs(options.enddate).utc();   // dayjs returns today.
+        const today = dayjs().startOf('day');
+        const start = dayjs(options.startdate); // if start or end are missing ( from the url )
+        const end   = dayjs(options.enddate);   // dayjs returns today.
         const inRange = today >= start && today <= end;
         const from = (inRange && options.pp) ? today : start;
         return {


### PR DESCRIPTION
the server expects that the start/end range YYYY-MM-DD queries are local time;
so remove the utc offsets from the requested range.

to match the main page and the /calendar page, this also changes "today" in `getInitialView()` to actually mean "start of day" rather than "the current time"  