### PR TITLE
Only show / validate Terms fields on initial submission

### DIFF
--- a/app/models/calEventValidator.js
+++ b/app/models/calEventValidator.js
@@ -182,8 +182,8 @@ function validateEvent(input) {
   const errors = new ErrorCollector();
   const v = makeValidator(input, errors);
   // these don't get stored; but are still required
-  v.requireTrue('code_of_conduct', "You must have read the Ride Leading Comic");
-  v.requireTrue('read_comic', "You must agree to the Code of Conduct");
+  v.requireTrue('code_of_conduct', "You must agree to the Code of Conduct");
+  v.requireTrue('read_comic', "You must have read the Ride Leading Comic");
   const title = v.requireString('title', 'Title missing');
   let values = {
     title: title,

--- a/app/models/calEventValidator.js
+++ b/app/models/calEventValidator.js
@@ -181,9 +181,11 @@ function makeValidator(input, errors) {
 function validateEvent(input) {
   const errors = new ErrorCollector();
   const v = makeValidator(input, errors);
-  // these don't get stored; but are still required
-  v.requireTrue('code_of_conduct', "You must agree to the Code of Conduct");
-  v.requireTrue('read_comic', "You must have read the Ride Leading Comic");
+  // these don't get stored; but are still required on initial submission for a new event
+  if (!input.id) {
+    v.requireTrue('code_of_conduct', "You must agree to the Code of Conduct");
+    v.requireTrue('read_comic', "You must have read the Ride Leading Comic");
+  }
   const title = v.requireString('title', 'Title missing');
   let values = {
     title: title,

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
@@ -439,6 +439,8 @@
         </div>
       </div>
 
+      [[^ id ]]
+      <!-- only show Terms section for initial submission -->
       <div class="panel panel-default">
         <div class="panel-heading">
           <h2>
@@ -454,7 +456,6 @@
           <div class="panel-body">
             <p class="input-help">Rides posted to the Shift calendar must abide by the <a href="/pages/shift-code-of-conduct/" target="_blank" title="opens in a new window">Code of Conduct</a>.</p>
             <div class="checkbox">
-              <input type="hidden" name="code_of_conduct" value="0" />
               <label class="control-label" for="code_of_conduct">
                 <input type="checkbox" name="code_of_conduct" id="code_of_conduct" value="1" [[# codeOfConduct ]]checked[[/ codeOfConduct ]] />
                 I agree to the Code of Conduct
@@ -462,7 +463,6 @@
             </div>
             <p class="input-help">For tips on making your ride successful, we ask that you read the <a href="/images/rideleadingcomiccolor.jpg" target="_blank" title="opens in a new window">Ride Leading Comic</a> at least once before submitting an event.</p>
             <div class="checkbox">
-              <input type="hidden" name="read_comic" value="0" />
               <label class="control-label" for="read_comic">
                 <input type="checkbox" name="read_comic" id="read_comic" value="1" [[# readComic ]]checked[[/ readComic ]] />
                 I have read the Ride Leading Comic
@@ -472,6 +472,12 @@
           </div>
         </div>
       </div>
+      [[/ id ]]
+
+      [[# id ]]
+      <input type="hidden" name="code_of_conduct" value="[[# codeOfConduct ]]1[[/ codeOfConduct ]]" />
+      <input type="hidden" name="read_comic" value="[[# readComic]]1[[/ readComic ]]" />
+      [[/ id ]]
 
       [[# id ]]
       <div class="panel panel-default">

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
@@ -475,11 +475,6 @@
       [[/ id ]]
 
       [[# id ]]
-      <input type="hidden" name="code_of_conduct" value="[[# codeOfConduct ]]1[[/ codeOfConduct ]]" />
-      <input type="hidden" name="read_comic" value="[[# readComic]]1[[/ readComic ]]" />
-      [[/ id ]]
-
-      [[# id ]]
       <div class="panel panel-default">
         <div class="panel-heading">
           <h2>


### PR DESCRIPTION
When you create an event listing, the organizer must agree to the code of conduct and affirm that they've read the ride leader comic. On subsequent requests those terms checkboxes are still shown on the front end, but an organizer can't un-read the comic or revoke their acceptance of the terms.

This changes the add/edit form to only show the Terms section for initial submission. After that (if an `id` is present, i.e. the event exists), the Terms section is hidden. The fields are still present under the hood as hidden inputs (similar to `id` and `secret` fields) so that backend validation can stay the same.

Also, the error messages for the two terms fields were swapped; fixed those as well.