### PR TITLE
Adding Netlify identity widget script only to pages that need it 

### DIFF
--- a/site/static/admin/index.html
+++ b/site/static/admin/index.html
@@ -1,5 +1,6 @@
-<!doctype html>
-<html>
+<!DOCTYPE html>
+<html lang="en">
+
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -8,9 +9,26 @@
   <!-- Include the styles for the Netlify CMS UI, after your own styles -->
   <link rel="stylesheet" href="https://unpkg.com/netlify-cms@^2.2.0/dist/cms.css" />
 
+  <!-- Include the Netlify identity widget -->
+  <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
 </head>
+
 <body>
   <!-- Include the script that builds the page and powers Netlify CMS -->
   <script src="https://unpkg.com/netlify-cms@^2.2.0/dist/cms.js"></script>
+
+  <!-- Include the Netlify identity widget -->
+  <script>
+    if (window.netlifyIdentity) {
+      window.netlifyIdentity.on("init", user => {
+        if (!user) {
+          window.netlifyIdentity.on("login", () => {
+            document.location.href = "/admin/";
+          });
+        }
+      });
+    }
+  </script>
 </body>
+
 </html>

--- a/site/themes/s2b_hugo_theme/layouts/partials/scripts.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/scripts.html
@@ -5,4 +5,16 @@
 {{/* owl carousel: only used on the homepage */}}
 {{ if (eq .Type "homepage") }}
 <script src="{{ .Site.BaseURL }}js/owl.carousel.min.js"></script>
+<script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
+<script>
+  if (window.netlifyIdentity) {
+    window.netlifyIdentity.on("init", user => {
+      if (!user) {
+        window.netlifyIdentity.on("login", () => {
+          document.location.href = "/admin/";
+        });
+      }
+    });
+  }
+</script>
 {{ end }}


### PR DESCRIPTION
… so that it won't need to be injected on every page.

Once this is pushed, we can remove these snippets from the Netlify config (Site configuration > Post-processing > Snippet injection).

Fixes #618. 