### PR TITLE
handle git pull errors

### DIFF
--- a/shift
+++ b/shift
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -e
+set -e # set exit on error; but its disabled later for sub_* commands
 
 #### DB ####
 export MYSQL_ROOT_PASSWORD=da642315cb2d390714590dad93e07c50
@@ -131,7 +131,8 @@ sub_ps() { #                      - Print service information
 
 sub_pull() { #                    - Update the codebase to HEAD of currently deployed branch from https://github.com/shift-org/shift-docs
     echo "pulling most recent commit from deployed branch of https://github.com/shift-org/shift-docs"
-    cd ${ROOT} ; git pull
+    cd ${ROOT}
+    git pull || exit 1
     # forces a recreation and restart of the containers from their images
     sub_up
 }
@@ -169,12 +170,12 @@ sub_attach() { # <service>        - Run bash on a running service
 sub_compose() { # <cmd...>        - Run a compose with associated files
     OS=`uname`
     if [ "$OS" == "Darwin" ] ; then
-	    docker compose $@
+      docker compose $@
     elif [ "$OS" == "Linux" ] ; then 
-	    docker-compose $@
+      docker-compose $@
     else
-	    echo "not sure how to handle your OS' version of docker.  One of the above should work!"
-	    exit 255
+      echo "not sure how to handle your OS' version of docker.  One of the above should work!"
+      exit 255
     fi
 }
 
@@ -209,7 +210,7 @@ case ${SUB_CMD} in
     *)
         shift
 
-        set +e
+        set +e # disables exit on error
         sub_${SUB_CMD} $@
 
         if [ $? = 127 ]; then
@@ -217,6 +218,6 @@ case ${SUB_CMD} in
             echo "       Run '${SCRIPT_NAME} --help' for a list of known subcommands." >&2
             exit 1
         fi
-        set -e
+        set -e # re-enables exit on error
         ;;
 esac


### PR DESCRIPTION
re: #705; today i learned:

by default, bash doesn't exit automatically when a command fails ( that way, it can handle a failed result and do interesting things  ). `set -e` however turns on automatic exit, and its at the top of the `./shift script`.... but then it gets disabled when any of the sub_* commands are called ( at the bottom of the script )

we actually need the no-auto-exit behavior for the "waitUntilServiceIsReady" command, and no-auto-exit _is_ the normal bash default -- so instead of turning it on for `sub_pull()`... instead i added `|| exit`.

because success is zero and error codes are non-zero, a normal shortcircuiting "or" would only evaluate the right hand expression on success -- but apparently bash has special handling of exit codes ( or maybe all numbers? ) that reverses the expected behavior. 🎉 

[ this is somewhat hard to test because you need to create a pull conflict. one way is to explicitly checkout some earlier commit, then manually overwrite your local shift script with the one from this pr, then run "./shift pull" -- it should see the detached head status and punt without launching docker. ]