### PR TITLE
Event range request improvements

### DIFF
--- a/app/endpoints/events.js
+++ b/app/endpoints/events.js
@@ -28,6 +28,8 @@ const config = require("../config");
 const { fromYMDString, to24HourString, toYMDString } = require("../util/dateTime");
 const { CalEvent } = require("../models/calEvent");
 const { CalDaily } = require("../models/calDaily");
+const { EventsRange } = require("../models/calConst");
+
 
 // the events endpoint:
 exports.get = function(req, res, next) {
@@ -58,11 +60,12 @@ exports.get = function(req, res, next) {
     if (!start.isValid() || !end.isValid()) {
       res.textError("need valid start and end times");
     } else {
-      const range = end.diff(start, 'day');
+      // add 1 so days in range is inclusive
+      const range = end.diff(start, 'day') + 1;
       if (range < 0) {
         res.textError("start date should be before end date");
-      } else if (range > 100) {
-        res.textError(`event range too large: ${range} days requested; max 100 days`);
+      } else if (range > EventsRange.MaxDays) {
+        res.textError(`event range too large: ${range} days requested; max ${EventsRange.MaxDays} days`);
       } else {
         return CalDaily.getRangeVisible(start, end, includeAllEvents).then((dailies) => {
           return getSummaries(dailies).then((events) => {
@@ -113,9 +116,15 @@ function specialSummary(evt) {
 // expects days are dayjs objects
 // and count is the number of events between the two
 function getPagination(firstDay, lastDay, count) {
-  const range = lastDay.diff(firstDay, 'day');
-  const nextRangeStart = firstDay.add(range + 1, 'day');
-  const nextRangeEnd = lastDay.add(range + 1, 'day');
+  // add 1 so days in range is inclusive
+  const range = lastDay.diff(firstDay, 'day') + 1;
+
+  const prevRangeStart = firstDay.subtract(range, 'day');
+  const prevRangeEnd = lastDay.subtract(range, 'day');
+  const prev = getEventRangeUrl(prevRangeStart, prevRangeEnd);
+
+  const nextRangeStart = firstDay.add(range, 'day');
+  const nextRangeEnd = lastDay.add(range, 'day');
   const next = getEventRangeUrl(nextRangeStart, nextRangeEnd);
 
   return {
@@ -123,6 +132,7 @@ function getPagination(firstDay, lastDay, count) {
     end: toYMDString(lastDay),
     range, // tbd: do we need to send this? can client determine from start, end?
     events: count,
+    prev,
     next,
   };
 }

--- a/app/endpoints/events.js
+++ b/app/endpoints/events.js
@@ -61,9 +61,10 @@ exports.get = function(req, res, next) {
       res.textError("need valid start and end times");
     } else {
       // add 1 so days in range is inclusive
+      // e.g. (2025-06-10 - 2025-06-01 = 9 days difference) + 1 day = 10 day range
       const range = end.diff(start, 'day') + 1;
-      if (range <= 0) {
-        res.textError("start date must be before end date");
+      if (range < 1) {
+        res.textError("end date cannot be before start date");
       } else if (range > EventsRange.MaxDays) {
         res.textError(`event range too large: ${range} days requested; max ${EventsRange.MaxDays} days`);
       } else {

--- a/app/endpoints/events.js
+++ b/app/endpoints/events.js
@@ -62,8 +62,8 @@ exports.get = function(req, res, next) {
     } else {
       // add 1 so days in range is inclusive
       const range = end.diff(start, 'day') + 1;
-      if (range < 0) {
-        res.textError("start date should be before end date");
+      if (range <= 0) {
+        res.textError("start date must be before end date");
       } else if (range > EventsRange.MaxDays) {
         res.textError(`event range too large: ${range} days requested; max ${EventsRange.MaxDays} days`);
       } else {

--- a/app/models/calConst.js
+++ b/app/models/calConst.js
@@ -42,5 +42,9 @@ const Review = Object.freeze({
   Revised   : 'R',
 });
 
+const EventsRange = Object.freeze({
+  MaxDays : 100,
+});
+
 //
-module.exports = { Area, Audience, DatesType, EventStatus, Review };
+module.exports = { Area, Audience, DatesType, EventStatus, Review, EventsRange };

--- a/site/themes/s2b_hugo_theme/assets/js/cal/helpers.js
+++ b/site/themes/s2b_hugo_theme/assets/js/cal/helpers.js
@@ -31,6 +31,10 @@ const DEFAULT_AREA = 'P';
 const DEFAULT_AUDIENCE = 'G';
 const DEFAULT_LENGTH = '--';
 
+const EVENTS_RANGE = Object.freeze({
+  DEFAULT_DAYS : 10,
+});
+
 const SITE_TITLE = "Shift";
 
 const API_VERSION = '3';

--- a/site/themes/s2b_hugo_theme/assets/js/cal/helpers.js
+++ b/site/themes/s2b_hugo_theme/assets/js/cal/helpers.js
@@ -31,9 +31,9 @@ const DEFAULT_AREA = 'P';
 const DEFAULT_AUDIENCE = 'G';
 const DEFAULT_LENGTH = '--';
 
-const EVENTS_RANGE = Object.freeze({
-  DEFAULT_DAYS : 10,
-});
+// total number of days to fetch, inclusive of start and end dates;
+// minimum of 1, maximum set by server
+const DEFAULT_DAYS_TO_FETCH = 10;
 
 const SITE_TITLE = "Shift";
 

--- a/site/themes/s2b_hugo_theme/assets/js/cal/main.js
+++ b/site/themes/s2b_hugo_theme/assets/js/cal/main.js
@@ -131,9 +131,13 @@ $(document).ready(function() {
              lazyLoadEventImages();
              $(document).off('click', '#load-more')
                   .on('click', '#load-more', function(e) {
+                      // if there is a user-provided enddate, use that to set the day range (and add 1 so date range is inclusive);
+                      // otherwise, use the default range
+                      range = options.enddate ? view.enddate.diff(view.startdate, 'day') + 1 : dayRange;
+
                       // the next day to view is one day after the previous last
                       view.startdate = view.enddate.add(1, 'day');
-                      view.enddate = view.startdate.add(dayRange - 1, 'day');
+                      view.enddate = view.startdate.add(range - 1, 'day');
                       // add new events to the end of those we've already added.
                       getEventHTML(view, function(eventHTML) {
                           $('#load-more').before(eventHTML);

--- a/site/themes/s2b_hugo_theme/assets/js/cal/main.js
+++ b/site/themes/s2b_hugo_theme/assets/js/cal/main.js
@@ -101,7 +101,7 @@ $(document).ready(function() {
           startdate: from,
           // if there was an enddate, use it; otherwise use a fixed number of days.
           // subtract 1 so range is inclusive
-          enddate: options.enddate ? end : from.add(EVENTS_RANGE.DEFAULT_DAYS - 1, 'day'),
+          enddate: options.enddate ? end : from.add( (DEFAULT_DAYS_TO_FETCH - 1), 'day'),
           // pass this on to the events listing.
           show_details: options.show_details,
         };
@@ -130,7 +130,7 @@ $(document).ready(function() {
                   .on('click', '#load-more', function(e) {
                       // if there is a user-provided enddate, use that to set the day range (and add 1 so date range is inclusive);
                       // otherwise, use the default range
-                      range = options.enddate ? view.enddate.diff(view.startdate, 'day') + 1 : EVENTS_RANGE.DEFAULT_DAYS;
+                      range = options.enddate ? (view.enddate.diff(view.startdate, 'day') + 1) : DEFAULT_DAYS_TO_FETCH;
 
                       // the next day to view is one day after the previous last
                       view.startdate = view.enddate.add(1, 'day');

--- a/site/themes/s2b_hugo_theme/assets/js/cal/main.js
+++ b/site/themes/s2b_hugo_theme/assets/js/cal/main.js
@@ -82,9 +82,6 @@ $(document).ready(function() {
         });
     }
 
-    // default range of days to show.
-    const dayRange = 10;
-
     // compute range and details settings from the url options.
     // the returned object gets passed to getEventHTML().
     function getInitialView(options) {
@@ -104,7 +101,7 @@ $(document).ready(function() {
           startdate: from,
           // if there was an enddate, use it; otherwise use a fixed number of days.
           // subtract 1 so range is inclusive
-          enddate: options.enddate ? end : from.add(dayRange - 1, 'day'),
+          enddate: options.enddate ? end : from.add(EVENTS_RANGE.DEFAULT_DAYS - 1, 'day'),
           // pass this on to the events listing.
           show_details: options.show_details,
         };
@@ -133,7 +130,7 @@ $(document).ready(function() {
                   .on('click', '#load-more', function(e) {
                       // if there is a user-provided enddate, use that to set the day range (and add 1 so date range is inclusive);
                       // otherwise, use the default range
-                      range = options.enddate ? view.enddate.diff(view.startdate, 'day') + 1 : dayRange;
+                      range = options.enddate ? view.enddate.diff(view.startdate, 'day') + 1 : EVENTS_RANGE.DEFAULT_DAYS;
 
                       // the next day to view is one day after the previous last
                       view.startdate = view.enddate.add(1, 'day');

--- a/site/themes/s2b_hugo_theme/assets/js/cal/main.js
+++ b/site/themes/s2b_hugo_theme/assets/js/cal/main.js
@@ -103,7 +103,8 @@ $(document).ready(function() {
           // 'from' is today; for other PP pages it's options startdate.
           startdate: from,
           // if there was an enddate, use it; otherwise use a fixed number of days.
-          enddate: options.enddate ? end : from.add(dayRange, 'day'),
+          // subtract 1 so range is inclusive
+          enddate: options.enddate ? end : from.add(dayRange - 1, 'day'),
           // pass this on to the events listing.
           show_details: options.show_details,
         };
@@ -132,7 +133,7 @@ $(document).ready(function() {
                   .on('click', '#load-more', function(e) {
                       // the next day to view is one day after the previous last
                       view.startdate = view.enddate.add(1, 'day');
-                      view.enddate = view.startdate.add(dayRange, 'day');
+                      view.enddate = view.startdate.add(dayRange - 1, 'day');
                       // add new events to the end of those we've already added.
                       getEventHTML(view, function(eventHTML) {
                           $('#load-more').before(eventHTML);


### PR DESCRIPTION
Updated how event ranges are handled: 
* Moved max day range value to config
* Made day range requests inclusive of start & end dates
* Front end now fetches the expected number of events with the "show more" button, if both `startdate` & `enddate` were provided by the user; fixes #760
* Moved front end default days range to config (helpers.js)

So now: 
* Events endpoint `pagination.range` returns 1 as expected when `startdate` and `enddate` are the same date; fixes #567
* Front end now defaults to 10 day range request as originally intended (previously fetched start date + 10, i.e. 11 days)

Also: 
* Added `prev` to Events endpoint `pagination` object, alongside `next`