### PR TITLE
normalize usage of docker-compose

### DIFF
--- a/shift
+++ b/shift
@@ -167,15 +167,7 @@ sub_attach() { # <service>        - Run bash on a running service
 }
 
 sub_compose() { # <cmd...>        - Run a compose with associated files
-    OS=`uname`
-    if [ "$OS" == "Darwin" ] ; then
-	    docker compose $@
-    elif [ "$OS" == "Linux" ] ; then 
-	    docker-compose $@
-    else
-	    echo "not sure how to handle your OS' version of docker.  One of the above should work!"
-	    exit 255
-    fi
+    docker-compose $@
 }
 
 sub_logs() { # <service>, ...     - Show last 50 lines and attach to a service


### PR DESCRIPTION
this change makes it so that macos uses the same "dash" compose command as production.  ( `docker-compose` )

this is a "patch" until we can upgrade production. ( re: https://github.com/shift-org/shift-docs/issues/772 ) once that's done, then this should be converted to the "space" version ( `docker compose` )

(  even though the dash version is deprecated, the "dash" version works on macos with current versions of docker.  the "space" version doesn't yet exist on production  )

i've tested this on apple silicon with local Docker version 26.1.1, build 4cf5afa. and i've tested this previously on my older intel mac with ... a relatively recent version of docker. 

( eta: production is 24.0.5 - 2023-07-24 )

see also [this thread](https://github.com/shift-org/shift-docs/pull/768#discussion_r1667789141) from @carrythebanner 


> We originally did this docker compose vs docker-compose dance to work around some other failures, but that was in 2021/2022 and Docker v20.10 — see commit notes here:
> https://github.com/shift-org/shift-docs/commit/32d9bd225b357d6b45701c3ea9342c02a1bb2cb4
> https://github.com/shift-org/shift-docs/commit/7ab6a19e1a53a6015d27cb6a435f938b2710265b