### PR TITLE
fix bug when creating mysql/docker from scratch

### DIFF
--- a/app/models/tables.js
+++ b/app/models/tables.js
@@ -171,7 +171,7 @@ function setDefaults(column, hasDefaultValue) {
     column.defaultTo(null);
   } else {
     column.notNullable();
-    if (hasDefaultValue !== false) {
+    if (hasDefaultValue !== true) {
       column.defaultTo(hasDefaultValue)
     }
   }


### PR DESCRIPTION
if you delete your docker db volume, and then run "./shift up", mysql will error out. 
this bug was introduced with the dev-improvments pr ( it changed the table initialization to make that code easier to read. ) ... not sure if mysql5.6 complained, or if this is just a mysql 8+ issue. 

at any rate -- the code was trying to set the default value of highlights to "true", but highlight can only be null, 0, or 1. the intention ( and comment ) was that passing 'true' should create a "nullable column with no specific default value"