### PR TITLE
make sure hugo builds on docker startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     volumes:
       - ./site/:/src/
       - ./site/public/:/output/
-    command: "hugo -v"
+    command: "--logLevel debug"
 
   node:
     restart: always


### PR DESCRIPTION
fixes #776 

hugo is the "entrypoint" for this new hugo container; so command should only pass switches to it.
./shift watch is already doing the right thing

i also changed the `-v` to `--loglevel debug` to quiet its deprecation warning: `~ERROR deprecated: --verbose was deprecated in Hugo v0.114.0 and will be removed in Hugo 0.129.0. use --logLevel info`