### PR TITLE
Dont show banner on single calendar event pages

### DIFF
--- a/site/themes/s2b_hugo_theme/assets/css/cal/main.css
+++ b/site/themes/s2b_hugo_theme/assets/css/cal/main.css
@@ -714,3 +714,9 @@ button.jump-to-date[aria-expanded="true"] .icon.expand {
   display: flex;
   justify-content: space-between;
 }
+
+.single-event-calendar-page {
+    .pp-banner {
+        display: none;
+    }
+}

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-promo-banner.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-promo-banner.html
@@ -9,3 +9,12 @@
 
 <!--   {{ partial "cal/pp-merch.html" . }} -->
 </div>
+
+<script>
+  document.addEventListener("DOMContentLoaded", function() {
+    const pathname = window.location.pathname;
+    if (pathname !== "/calendar/") {
+      document.body.classList.add("single-event-calendar-page");
+    }
+  });
+</script>


### PR DESCRIPTION
Addresses issue https://github.com/shift-org/shift-docs/issues/435

Adds a class to body that doesn't show the banner on any `calendar/x` pages, but still shows it on `/calendar`. Other options I considered (well, Simon considered let's be real):
- Remove the banner entirely from the page in the `<script>`
- Add a class to the `pp-banner` itself that gives it a `display: none`
- Try and modify the hugo template to not show the banner on single event pages, but this seems like it would require a huge refactor to hugo and I got scared

Calendar page:
<img width="1440" alt="Screenshot 2024-07-24 at 8 50 59 PM" src="https://github.com/user-attachments/assets/e6c2e296-040e-4ebe-92b9-fde40b881a6d">

Event page:
<img width="1439" alt="Screenshot 2024-07-24 at 8 51 18 PM" src="https://github.com/user-attachments/assets/5f8a94e3-0a0a-400e-a448-9f11aa96be85">

