### PR TITLE
refactor layouts to use a base template

### DIFF
--- a/site/themes/s2b_hugo_theme/layouts/404.html
+++ b/site/themes/s2b_hugo_theme/layouts/404.html
@@ -1,3 +1,11 @@
+{{/* 
+	this file gets overwritten by netlify.toml
+	with 404.md on preview and deploy.
+	static/admin/config.yml points to that file as well.
+
+	the apparent advantage is that 404.md 
+	can reuse layout/_default/single.html 
+*/}}
 <!DOCTYPE html>
 <html lang="{{ .Site.LanguageCode }}">
 

--- a/site/themes/s2b_hugo_theme/layouts/_default/baseof.html
+++ b/site/themes/s2b_hugo_theme/layouts/_default/baseof.html
@@ -1,0 +1,47 @@
+{{/*
+  The layout provides a common structure for all pages.
+  Each {{ block }} has content that can be overridden in other layouts.
+*/}}
+<!DOCTYPE html>
+<html lang="{{ .Site.LanguageCode }}">
+<head>
+{{ block "html_header" . }}
+  {{ partial "head.html" . }}
+  {{ partial "cal/head.html" . }}
+{{ end }}
+</head>
+<body>
+  <div id="all">
+    <header>
+      {{ partial "nav.html" . }}
+    </header>
+    <main>
+    {{ block "main" . }}
+      {{ partial "breadcrumbs.html" . }}
+      <div id="content">
+        <div class="container">
+          <div class="row">
+            {{ block "page_body" . }}
+            {{ end }}
+          </div>{{/* /.row */}}
+        </div>{{/* /.container */}}
+      </div>{{/* /#content */}}
+    {{ end }}{{/* main */}}
+    </main>
+    <footer>
+      {{ partial "footer.html" . }}
+    </footer>
+  </div>{{/* /#all */}}
+  {{/* 
+      all pages need script.html for the dropdown menus 
+  */}}
+  {{ block "core_scripts" . }}
+    {{ partial "scripts.html" . }}
+  {{ end }}
+  {{/* 
+     pages can use postscript to add additional scripts.
+  */}}
+  {{ block "postscript" . }}
+  {{ end }}
+</body>
+</html>

--- a/site/themes/s2b_hugo_theme/layouts/_default/list.html
+++ b/site/themes/s2b_hugo_theme/layouts/_default/list.html
@@ -1,115 +1,16 @@
-<!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
-
-<head>
-  {{ partial "head.html" . }}
-</head>
-
-<body>
-
-  <div id="all">
-
-    <header>
-      {{ partial "nav.html" . }}
-    </header>
-
-    <main>
-      {{ partial "breadcrumbs.html" . }}
-
-      <div id="content">
-        <div class="container">
-        <div class="row">
-            <!-- *** LEFT COLUMN *** -->
-
-            <div class="col-md-9" id="blog-listing-medium">
-
-              {{ $paginator := .Paginate (where .Data.Pages "Type" "blog") }}
-              {{ range $paginator.Pages }}
-              <section class="post">
-                <div class="row">
-                  <div class="col-md-4">
-                  <div class="image">
-                    <a href="{{ .Permalink }}">
-                      {{ if .Params.banner }}
-                      <img src="{{ .Site.BaseURL}}{{ .Params.banner }}" class="img-responsive" alt="">
-                      {{ else }}
-                      <img src="{{ .Site.BaseURL}}img/placeholder.png" class="img-responsive" alt="">
-                      {{ end }}
-                    </a>
-                  </div>
-                  </div>
-                  <div class="col-md-8">
-                    <h2><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
-                    <div class="clearfix">
-                      <p class="author-category">
-                      {{ if isset .Params "author" }}
-                      {{ i18n "authorBy" }} <a href="#">{{ .Params.author }}</a>
-                      {{ end }}
-                      {{ if isset .Params "categories" }}
-                      {{ if gt (len .Params.categories) 0 }}
-                      in <a href="{{ $.Site.BaseURL }}categories/{{ index .Params.categories 0 | urlize | lower }}">{{ index .Params.categories 0 }}</a>
-                      {{ end }}
-                      {{ end }}
-
-                      </p>
-                      <p class="date-comments">
-                        <a href="{{ .Permalink }}"><i class="fa fa-calendar-o"></i> {{ .Date.Format .Site.Params.date_format }}</a>
-                      </p>
-                    </div>
-                    <p class="intro">{{ .Summary }}</p>
-                    <p class="read-more"><a href="{{ .Permalink }}" class="btn btn-template-main">{{ i18n "continueReading" }}</a>
-                    </p>
-                  </div>
-                </div>
-              </section>
-              {{ end }}
-
-              <ul class="pager">
-                {{ if .Paginator.HasPrev }}
-                <li class="previous"><a href="{{ .Site.BaseURL }}{{ .Paginator.Prev.URL }}">&larr; {{ i18n "newer" }}</a></li>
-                {{ else }}
-                <li class="previous disabled"><a href="#">&larr; {{ i18n "newer" }}</a></li>
-                {{ end }}
-
-                {{ if .Paginator.HasNext }}
-                <li class="next"><a href="{{ .Site.BaseURL }}{{ .Paginator.Next.URL }}">{{ i18n "older" }} &rarr;</a></li>
-                {{ else }}
-                <li class="next disabled"><a href="#">{{ i18n "older" }} &rarr;</a></li>
-                {{ end }}
-              </ul>
-            </div>
-            <!-- /.col-md-9 -->
-
-            <!-- *** LEFT COLUMN END *** -->
-
-            <!-- *** RIGHT COLUMN *** -->
-
-            <div class="col-md-3">
-
-              <!-- *** MENUS AND WIDGETS *** -->
-
-            </div>
-            <!-- /.col-md-3 -->
-
-            <!-- *** RIGHT COLUMN END *** -->
-
-          </div>
-          <!-- /.row -->
-        </div>
-        <!-- /.container -->
-      </div>
-      <!-- /#content -->
-    </main>
-
-    <footer>
-    {{ partial "footer.html" . }}
-    </footer>
-
-  </div>
-  <!-- /#all -->
-
-  {{ partial "scripts.html" . }}
-
-</body>
-
-</html>
+{{/*
+	This layout is used by hugo to describe every directory under site/contents.
+	None of the shift pages link to those listings, but hugo still generates them.
+  ex. https://www.shift2bikes.org/archive/
+  
+	Currently, this forces a redirect to the 404 page.
+	Previously, those pages would display erroneous content, 
+  including some broken next/prev page buttons.
+*/}}
+{{ define "html_header" }}
+<meta http-equiv="refresh" content="0; url=/404.html" />
+{{ end }}
+{{ define "main" }}
+{{ end }}
+{{ define "core_scripts" }}
+{{ end }}

--- a/site/themes/s2b_hugo_theme/layouts/_default/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/_default/single.html
@@ -1,27 +1,12 @@
-<!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
-
-<head>
-  {{ partial "head.html" . }}
-</head>
-
-<body>
-
-  <div id="all">
-
-    <header>
-      {{ partial "nav.html" . }}
-    </header>
-
-    <main>
-      {{ partial "breadcrumbs.html" . }}
-
-      <div id="content">
-        <div class="container">
-
-          <div class="row">
-
-            <!-- *** LEFT COLUMN *** -->
+{{/*
+	This layout is used for all of the "static" content 
+  ( about, faq, /playbooks, /pages, etc. ).
+  and whenever no specific 'type:' has been set by a .md file. 
+*/}}
+{{ define "html_header" }}
+	{{ partial "head.html" . }}
+{{ end }}
+{{ define "page_body" }}
 
             <div class="col-md-9" id="blog-post">
 
@@ -29,39 +14,8 @@
               {{ .Content }}
               </div>
             </div>
-            <!-- /#blog-post -->
-
-            <!-- *** LEFT COLUMN END *** -->
-
-            <!-- *** RIGHT COLUMN *** -->
 
             <div class="col-md-3">
 
-              <!-- *** MENUS AND WIDGETS *** -->
-
             </div>
-            <!-- /.col-md-3 -->
-
-            <!-- *** RIGHT COLUMN END *** -->
-
-          </div>
-          <!-- /.row -->
-
-        </div>
-        <!-- /.container -->
-      </div>
-      <!-- /#content -->
-    </main>
-
-    <footer>
-    {{ partial "footer.html" . }}
-    </footer>
-
-  </div>
-  <!-- /#all -->
-
-  {{ partial "scripts.html" . }}
-
-</body>
-
-</html>
+{{ end }}

--- a/site/themes/s2b_hugo_theme/layouts/caledit/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/caledit/single.html
@@ -1,26 +1,4 @@
-<!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
-
-<head>
-  {{ partial "head.html" . }}
-  {{ partial "cal/head.html" . }}
-</head>
-
-<body>
-
-  <div id="all">
-
-    <header>
-      {{ partial "nav.html" . }}
-    </header>
-
-    <main>
-        {{ partial "breadcrumbs.html" . }}
-
-        <div id="content">
-          <div class="container">
-
-            <div class="row">
+{{ define "page_body" }}
 
               <div class="col-md-12">
 
@@ -37,30 +15,10 @@
                 <div id="mustache-html" class="container"></div>
 
               </div>
-
-            </div>
-            <!-- /.row -->
-
-          </div>
-          <!-- /.container -->
-        </div>
-        <!-- /#content -->
-    </main>
-
-    <footer>
-      {{ partial "footer.html" . }}
-    </footer>
-
-  </div>
-  <!-- /#all -->
-
-  {{ partial "scripts.html" . }}
+{{ end }}
+{{ define "postscript" }}
   {{ partial "cal/edit.html" . }}
-
   <script type="text/javascript">
     window.cal_renderpage = "{{ .Params.id }}";
   </script>
-
-</body>
-
-</html>
+{{ end }}

--- a/site/themes/s2b_hugo_theme/layouts/caledit/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/caledit/single.html
@@ -1,20 +1,16 @@
 {{ define "page_body" }}
+<div class="col-md-12">
+  {{ partial "alert_banner.html" . }}
+  <div>
+    {{ .Content }}
 
-              <div class="col-md-12">
-
-                {{ partial "alert_banner.html" . }}
-
-                <div>
-                  {{ .Content }}
-
-                  {{ if isset .Params "pp" }}
-                    {{ partial "cal/pp-header.html" . }}
-                  {{ end }}
-                </div>
-
-                <div id="mustache-html" class="container"></div>
-
-              </div>
+    {{ if isset .Params "pp" }}
+      {{ partial "cal/pp-header.html" . }}
+    {{ end }}
+  </div>
+  <div id="mustache-html" class="container">
+  </div>
+</div>
 {{ end }}
 {{ define "postscript" }}
   {{ partial "cal/edit.html" . }}

--- a/site/themes/s2b_hugo_theme/layouts/calevents/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/calevents/single.html
@@ -1,27 +1,4 @@
-<!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
-
-<head>
-  {{ partial "head.html" . }}
-  {{ partial "cal/head.html" . }}
-</head>
-
-<body>
-
-  <div id="all">
-
-    <header>
-      {{ partial "nav.html" . }}
-    </header>
-
-    <main>
-        {{ partial "breadcrumbs.html" . }}
-
-        <div id="content">
-          <div class="container">
-
-            <div class="row">
-
+{{ define "page_body" }}
               <div class="col-md-12">
 
                 <div>
@@ -32,9 +9,8 @@
                     <!-- on other cal pages, display smaller banner that links to PP cal page -->
                     <!-- only display when PP is coming soon or happening now -->
                     {{ partial "cal/pp-promo-banner.html" . }}
-
-                    <!-- only display during Steptember -->
-                    <!-- {{ partial "cal/promo-banner-steptember.html" . }} -->
+                    {{/* only display during Steptember */}}
+                    {{/* partial "cal/promo-banner-steptember.html" . */}}
                   {{ end }}
 
                   {{ .Content }}
@@ -57,32 +33,13 @@
                 {{ partial "alert_banner.html" . }}
 
                 {{ partial "disclaimer.html" . }}
-
               </div>
 
-            </div>
-            <!-- /.row -->
-
-          </div>
-          <!-- /.container -->
-        </div>
-        <!-- /#content -->
-    </main>
-
-    <footer>
-      {{ partial "footer.html" . }}
-    </footer>
-
-  </div>
-  <!-- /#all -->
-
-  {{ partial "scripts.html" . }}
+{{ end }}
+{{ define "postscript" }}
   {{ partial "cal/events.html" . }}
 
   <script type="text/javascript">
     window.cal_renderpage = "{{ .Params.id }}";
-    // TODO
   </script>
-
-</body>
-</html>
+{{ end }}

--- a/site/themes/s2b_hugo_theme/layouts/calevents/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/calevents/single.html
@@ -1,44 +1,38 @@
 {{ define "page_body" }}
-              <div class="col-md-12">
+<div class="col-md-12">
+  <div>
+    {{ if isset .Params "pp" }}
+      <!-- on PP cal page, display full PP header -->
+      {{ partial "cal/pp-header.html" . }}
+    {{ else }}
+      <!-- on other cal pages, display smaller banner that links to PP cal page -->
+      <!-- only display when PP is coming soon or happening now -->
+      {{ partial "cal/pp-promo-banner.html" . }}
+      {{/* only display during Steptember */}}
+      {{/* partial "cal/promo-banner-steptember.html" . */}}
+    {{ end }}
 
-                <div>
-                  {{ if isset .Params "pp" }}
-                    <!-- on PP cal page, display full PP header -->
-                    {{ partial "cal/pp-header.html" . }}
-                  {{ else }}
-                    <!-- on other cal pages, display smaller banner that links to PP cal page -->
-                    <!-- only display when PP is coming soon or happening now -->
-                    {{ partial "cal/pp-promo-banner.html" . }}
-                    {{/* only display during Steptember */}}
-                    {{/* partial "cal/promo-banner-steptember.html" . */}}
-                  {{ end }}
+    {{ .Content }}
+  </div>
 
-                  {{ .Content }}
-                </div>
+  <div id="fullcalendar"></div>
 
-                <div id="fullcalendar"></div>
+  {{ if isset .Params "pp" }}
+    {{ partial "cal/pp-feed.html" . }}
+  {{ end }}
 
-                {{ if isset .Params "pp" }}
-                  {{ partial "cal/pp-feed.html" . }}
-                {{ end }}
+  <div id="mustache-html" class="container"> 
+  </div>
 
-                <div id="mustache-html" class="container">
-
-                </div>
-
-                {{ if isset .Params "pp" }}
-                  {{ partial "cal/promo-banner-main-cal.html" . }}
-                {{ end }}
-
-                {{ partial "alert_banner.html" . }}
-
-                {{ partial "disclaimer.html" . }}
-              </div>
-
+  {{ if isset .Params "pp" }}
+    {{ partial "cal/promo-banner-main-cal.html" . }}
+  {{ end }}
+  {{ partial "alert_banner.html" . }}
+  {{ partial "disclaimer.html" . }}
+</div>
 {{ end }}
 {{ define "postscript" }}
   {{ partial "cal/events.html" . }}
-
   <script type="text/javascript">
     window.cal_renderpage = "{{ .Params.id }}";
   </script>

--- a/site/themes/s2b_hugo_theme/layouts/calgrid/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/calgrid/single.html
@@ -1,22 +1,20 @@
 {{ define "page_body" }}
-            <div class="col-md-12">
+<div class="col-md-12">
+  <div>
+    {{ .Content }}
+  </div>
+  {{/*  only display when PP is coming soon or happening now */}}
+  {{ partial "cal/pp-promo-banner.html" . }}
+  
+  {{/* only display during Steptember */}}
+  {{/* partial "cal/promo-banner-steptember.html" . */}}
 
-              <div>
-                {{ .Content }}
-              </div>
-              {{/*  only display when PP is coming soon or happening now */}}
-              {{ partial "cal/pp-promo-banner.html" . }}
-              {{/* only display during Steptember */}}
-              {{/* partial "cal/promo-banner-steptember.html" . */}}
+  {{ partial "cal/view-options.html" . }}
+  {{ partial "cal/fullcal.html" . }} 
 
-              {{ partial "cal/view-options.html" . }}
-              {{ partial "cal/fullcal.html" . }} 
+  <div id="fullcalendar"></div>
 
-              <div id="fullcalendar"></div>
-
-              {{ partial "alert_banner.html" . }}
-
-              {{ partial "disclaimer.html" . }}
-
-            </div>
+  {{ partial "alert_banner.html" . }}
+  {{ partial "disclaimer.html" . }}
+</div>
 {{ end }}

--- a/site/themes/s2b_hugo_theme/layouts/calgrid/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/calgrid/single.html
@@ -1,38 +1,13 @@
-<!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
-
-<head>
-  {{ partial "head.html" . }}
-  {{ partial "cal/head.html" . }}
-</head>
-
-<body>
-
-  <div id="all">
-
-    <header>
-      {{ partial "nav.html" . }}
-    </header>
-
-    <main>
-      {{ partial "breadcrumbs.html" . }}
-
-      <div id="content">
-        <div class="container">
-
-          <div class="row">
-
+{{ define "page_body" }}
             <div class="col-md-12">
 
               <div>
                 {{ .Content }}
               </div>
-
-              <!-- only display when PP is coming soon or happening now -->
+              {{/*  only display when PP is coming soon or happening now */}}
               {{ partial "cal/pp-promo-banner.html" . }}
-
-              <!-- only display during Steptember -->
-              <!-- {{ partial "cal/promo-banner-steptember.html" . }} -->
+              {{/* only display during Steptember */}}
+              {{/* partial "cal/promo-banner-steptember.html" . */}}
 
               {{ partial "cal/view-options.html" . }}
               {{ partial "cal/fullcal.html" . }} 
@@ -44,25 +19,4 @@
               {{ partial "disclaimer.html" . }}
 
             </div>
-
-          </div>
-          <!-- /.row -->
-
-        </div>
-        <!-- /.container -->
-      </div>
-      <!-- /#content -->
-    </main>
-
-    <footer>
-      {{ partial "footer.html" . }}
-    </footer>
-
-  </div>
-  <!-- /#all -->
-
-  {{ partial "scripts.html" . }}
-
-</body>
-
-</html>
+{{ end }}

--- a/site/themes/s2b_hugo_theme/layouts/index.html
+++ b/site/themes/s2b_hugo_theme/layouts/index.html
@@ -1,20 +1,4 @@
-<!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
-
-<head>
-  {{ partial "head.html" . }}
-  {{ partial "cal/head.html" . }}
-</head>
-
-<body>
-
-  <div id="all">
-
-    <header>
-      {{ partial "nav.html" . }}
-    </header>
-
-    <main>
+{{ define "main" }}
       {{ partial "carousel.html" . }}
 
       {{ partial "cal/up-next.html" . }}
@@ -22,17 +6,7 @@
       {{ partial "alert_banner.html" . }}
 
       {{ partial "sponsors.html" . }}
-    </main>
 
-    <footer>
-      {{ partial "footer.html" . }}
-    </footer>
-
-  </div>
-  <!-- /#all -->
-
-  {{ partial "scripts.html" . }}
-
-</body>
-
-</html>
+      {{/* include the .md file content if any */}}
+      {{ .Content }}
+{{ end }}

--- a/site/themes/s2b_hugo_theme/layouts/partials/breadcrumbs.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/breadcrumbs.html
@@ -1,3 +1,7 @@
+{{/* 
+		this is the banner image an text at the top of most pages.
+		ex. "ADD EVENT", or "CALENDAR"
+*/}}
 <div id="heading-breadcrumbs">
     <div class="header-dark-mask">
         <div class="container">

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
@@ -4,7 +4,11 @@
 <script src="{{ $jsCalAddEvent.Permalink }}"></script>
 {{ $jsCalDatePicker := resources.Get "js/cal/datepicker.js" | minify }}
 <script src="{{ $jsCalDatePicker.Permalink }}"></script>
-
+{{/* 
+		helper to prompt fixes for common email mistakes:
+			example@hotnail.con 
+		https://github.com/mailcheck/mailcheck 
+*/}}
 <script src="//cdnjs.cloudflare.com/ajax/libs/mailcheck/1.1.2/mailcheck.min.js"></script>
 
 <div class="modal fade" tabindex="-1" id="cancel-modal" role="dialog">

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-promo-banner.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-promo-banner.html
@@ -7,5 +7,5 @@
     </div>
   </div>
 
-<!--   {{ partial "cal/pp-merch.html" . }} -->
+  {{/* partial "cal/pp-merch.html" . */}}
 </div>

--- a/site/themes/s2b_hugo_theme/layouts/pp-landing/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/pp-landing/single.html
@@ -1,26 +1,4 @@
-<!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
-
-<head>
-  {{ partial "head.html" . }}
-  {{ partial "cal/head.html" . }}
-</head>
-
-<body>
-
-  <div id="all">
-    <header>
-      {{ partial "nav.html" . }}
-    </header>
-
-    <main>
-        {{ partial "breadcrumbs.html" . }}
-
-        <div id="content">
-          <div class="container">
-
-            <div class="row">
-
+{{ define "page_body" }}
               <div class="col-md-12">
 
                 <div>
@@ -38,37 +16,5 @@
                   
                 </div>
 
-                <!-- 
-                {{ partial "alert_banner.html" . }}
-
-                {{ partial "cal/view-options.html" . }}
-                {{ partial "cal/fullcal.html" . }} 
-
-                <div id="fullcalendar"></div>
-
-                {{ partial "disclaimer.html" . }}
-                -->
-
               </div>
-
-            </div>
-            <!-- /.row -->
-
-          </div>
-          <!-- /.container -->
-        </div>
-        <!-- /#content -->
-    </main>
-
-    <footer>
-      {{ partial "footer.html" . }}
-    </footer>
-
-  </div>
-  <!-- /#all -->
-
-  {{ partial "scripts.html" . }}
-
-</body>
-
-</html>
+{{ end }}

--- a/site/themes/s2b_hugo_theme/layouts/pp-landing/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/pp-landing/single.html
@@ -1,20 +1,15 @@
 {{ define "page_body" }}
-              <div class="col-md-12">
-
-                <div>
-                  <!-- modified pp_heading partial -->
-                  <div class="pp-banner">
-                    <a href="{{ .Param "poster-image" }}"><img alt="Pedalpalooza" id="pedalpalooza-img" src="{{ .Param "banner-image" }}"></a>
-                    <div>
-                      <span class="pp-headline">Pedalpalooza!</span>
-                      <!-- <span class="pp-daterange">{{ .Param "daterange" }}</span> -->
-                    </div>
-
-                  {{ .Content }}
-                  
-                  </div> <!-- end pp_heading -->
-                  
-                </div>
-
-              </div>
+<div class="col-md-12">
+  <div>
+    <!-- modified pp_heading partial -->
+    <div class="pp-banner">
+      <a href="{{ .Param "poster-image" }}"><img alt="Pedalpalooza" id="pedalpalooza-img" src="{{ .Param "banner-image" }}"></a>
+      <div>
+        <span class="pp-headline">Pedalpalooza!</span>
+        <!-- <span class="pp-daterange">{{ .Param "daterange" }}</span> -->
+      </div>
+      {{ .Content }}
+    </div>
+  </div>
+</div>
 {{ end }}

--- a/site/themes/s2b_hugo_theme/layouts/pp-theme-cal/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/pp-theme-cal/single.html
@@ -1,29 +1,5 @@
-<!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}">
-
-<head>
-  {{ partial "head.html" . }}
-  {{ partial "cal/head.html" . }}
-</head>
-
-<body>
-
-  <div id="all">
-    <header>
-      {{ partial "nav.html" . }}
-    </header>
-
-    <main>
-        {{ partial "breadcrumbs.html" . }}
-
-        <div id="content">
-          <div class="container">
-
-            <div class="row">
-
+{{ define "page_body" }}
               <div class="col-md-12">
-
-                   <!-- {{ partial "alert_banner.html" . }} -->
 
                   <!-- modified pp_heading partial -->
                   <div class="pp-banner">
@@ -36,25 +12,4 @@
                 {{ partial "disclaimer.html" . }}
 
               </div>
-
-            </div>
-            <!-- /.row -->
-
-          </div>
-          <!-- /.container -->
-        </div>
-        <!-- /#content -->
-    </main>
-
-    <footer>
-      {{ partial "footer.html" . }}
-    </footer>
-
-  </div>
-  <!-- /#all -->
-
-  {{ partial "scripts.html" . }}
-
-</body>
-
-</html>
+{{ end }}

--- a/site/themes/s2b_hugo_theme/layouts/pp-theme-cal/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/pp-theme-cal/single.html
@@ -1,15 +1,11 @@
 {{ define "page_body" }}
-              <div class="col-md-12">
-
-                  <!-- modified pp_heading partial -->
-                  <div class="pp-banner">
-                    <a href="{{ .Param "poster-image" }}"><img alt="Pedalpalooza" id="pedalpalooza-img" src="{{ .Param "banner-image" }}"></a>
-                    {{ .Content }}
-                  </div> <!-- end pp_heading -->
-
-                {{ partial "cal/pp-2020-cal.html" . }}
-
-                {{ partial "disclaimer.html" . }}
-
-              </div>
+<div class="col-md-12">
+  <!-- modified pp_heading partial -->
+  <div class="pp-banner">
+    <a href="{{ .Param "poster-image" }}"><img alt="Pedalpalooza" id="pedalpalooza-img" src="{{ .Param "banner-image" }}"></a>
+    {{ .Content }}
+  </div>
+  {{ partial "cal/pp-2020-cal.html" . }}
+  {{ partial "disclaimer.html" . }}
+</div>
 {{ end }}


### PR DESCRIPTION
this moves the duplicated "chrome" of each page ( the html header, the menus, etc. ) into a "baseof.html" layout. ( which is a good first step for #790 )

the base defines `{{ block" name" }}...{{end}}` sections which have default content used by _most_ layouts; but which can be replaced by certain pages when needed. https://gohugo.io/templates/base/

as part of this, i discovered some strange pages ( ex. https://www.shift2bikes.org/archive/ ). they are generated for each directory under "contents" using the `list.html` layout. none of the other shift pages link to them, but still: they seem a bit broken. In this pr, i replaced the contents of list.html with a meta redirect header to 404.html.

to make comparing the templates i did two submits. the first refactors to layouts, and the second cleans up the whitespace. when comparing it might be easiest to look at the first submit. 

to test the final output, i regenerated the site locally and used BeyondCompare to diff the new and the old generated public directories.