### PR TITLE
Add "all events feed" banner to calgrid

### DIFF
--- a/site/themes/s2b_hugo_theme/layouts/calgrid/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/calgrid/single.html
@@ -34,6 +34,7 @@
               <!-- only display during Steptember -->
               <!-- {{ partial "cal/promo-banner-steptember.html" . }} -->
 
+              {{ partial "cal/shift-feed.html" . }}
               {{ partial "cal/view-options.html" . }}
               {{ partial "cal/fullcal.html" . }} 
 

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-promo-banner.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-promo-banner.html
@@ -13,7 +13,12 @@
 <script>
   document.addEventListener("DOMContentLoaded", function() {
     const pathname = window.location.pathname;
-    if (pathname !== "/calendar/") {
+    const calpage = "/calendar/";
+    // todo: we should try to separate each unique "endpoint"
+    // into separate hugo .md and layout files so we don't need this kind of test.
+    // see also: events.html which tries to suss out which page we are on.
+    // ( and possibly, move this there )
+    if (pathname.startsWith(calpage) && !pathname.endsWith(calpage)) {
       document.body.classList.add("single-event-calendar-page");
     }
   });


### PR DESCRIPTION
partial support for #802 to add the all event feed info to the calgrid page;
but also fixes the fact that the calgrid page is missing the pedalp banner. 😔
( regression from https://github.com/shift-org/shift-docs/commit/5d7dfac5756529c34f22dee3674cc484d7a29776 )

