### PR TITLE
Go to date tweaks

### DIFF
--- a/site/themes/s2b_hugo_theme/assets/js/cal/main.js
+++ b/site/themes/s2b_hugo_theme/assets/js/cal/main.js
@@ -85,10 +85,14 @@ $(document).ready(function() {
     // the returned object gets passed to getEventHTML().
     function getInitialView(options) {
         const today = dayjs().startOf('day');
-        const start = dayjs(options.startdate); // if start or end are missing ( from the url )
-        const end   = dayjs(options.enddate);   // dayjs returns today.
+
+        // use the start/end dates from the url; otherwise, use today
+        const start = options.startdate ? dayjs(options.startdate) : dayjs(today);
+        const end = options.enddate ? dayjs(options.enddate) : dayjs(today);
+
         const inRange = today >= start && today <= end;
         const from = (inRange && options.pp) ? today : start;
+
         return {
           // since this year's PP will be in range
           // ( as will the normal calendar events page )
@@ -178,15 +182,6 @@ $(document).ready(function() {
       } else {
         url.searchParams.delete('show_details');
         window.location.href = url.href;
-      }
-    });
-
-    $(document).on('click', '#go-to-date', function() {
-      var date = $("#go-to-date-field").val();
-      if (date) {
-        window.location.href = '/calendar/?startdate=' + date;
-      } else {
-        window.location.href = '/calendar/';
       }
     });
 

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
@@ -384,10 +384,10 @@
     <div class="show-details">
       <button type="button" id="show-details" class="btn">Toggle details</button>
     </div>
-    <div class="go-to-date">
+    <form class="go-to-date" action="/calendar/" method="GET">
       <label for="go-to-date-field">Go to date</label>
-      <input type="date" id="go-to-date-field" min="2008-01-01">
-      <button type="button" id="go-to-date" class="btn">Go</button>
-    </div>
+      <input type="date" name="startdate" id="go-to-date-field" min="2008-01-01">
+      <button type="submit" class="btn">Go</button>
+    </form>
   </div>
 </script>


### PR DESCRIPTION
Use HTML form instead of JS for the "Go to date" option; we're doing a full page load on submit so it's easier to just use a regular HTML form.

Also, when building the API request from the URL, the `startdate` / `enddate` params are now checked for any falsy value. Today in production, a request like `https://www.shift2bikes.org/calendar/?startdate=` (where `startdate` is present, but its value is an empty string) isn't handled which results in an API request like `https://www.shift2bikes.org/api/events.php?startdate=Invalid Date&enddate=Invalid Date`.