### PR TITLE
Pedalpalooza-specific page template

### DIFF
--- a/site/content/archive/pedalpalooza/pedalpalooza-2002.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2002.md
@@ -2,7 +2,7 @@
 title: 2002 Pedalpalooza calendar
 weight: 2
 id: pedalpalooza-calendar
-type: calevents
+type: calfestival
 pp: true
 year: 2002
 startdate: 2002-08-01

--- a/site/content/archive/pedalpalooza/pedalpalooza-2003.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2003.md
@@ -3,7 +3,7 @@ title: "2003 Pedalpalooza calendar"
 description: "2003 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
-type: calevents
+type: calfestival
 pp: true
 year: 2003
 startdate: 2003-06-13

--- a/site/content/archive/pedalpalooza/pedalpalooza-2004.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2004.md
@@ -3,7 +3,7 @@ title: "2004 Pedalpalooza calendar"
 description: "2004 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
-type: calevents
+type: calfestival
 pp: true
 year: 2004
 startdate: 2004-06-10

--- a/site/content/archive/pedalpalooza/pedalpalooza-2005.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2005.md
@@ -3,7 +3,7 @@ title: "2005 Pedalpalooza calendar"
 description: "2005 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
-type: calevents
+type: calfestival
 pp: true
 year: 2005
 startdate: 2005-06-09

--- a/site/content/archive/pedalpalooza/pedalpalooza-2006.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2006.md
@@ -3,7 +3,7 @@ title: "2006 Pedalpalooza calendar"
 description: "2006 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
-type: calevents
+type: calfestival
 pp: true
 year: 2006
 startdate: 2006-06-08

--- a/site/content/archive/pedalpalooza/pedalpalooza-2007.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2007.md
@@ -3,7 +3,7 @@ title: "2007 Pedalpalooza calendar"
 description: "2007 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
-type: calevents
+type: calfestival
 pp: true
 year: 2007
 startdate: 2007-06-07

--- a/site/content/archive/pedalpalooza/pedalpalooza-2008.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2008.md
@@ -3,7 +3,7 @@ title: "2008 Pedalpalooza calendar"
 description: "2008 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
-type: calevents
+type: calfestival
 pp: true
 year: 2008
 startdate: 2008-06-12

--- a/site/content/archive/pedalpalooza/pedalpalooza-2009.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2009.md
@@ -3,7 +3,7 @@ title: "2009 Pedalpalooza calendar"
 description: "2009 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
-type: calevents
+type: calfestival
 pp: true
 year: 2009
 startdate: 2009-06-11

--- a/site/content/archive/pedalpalooza/pedalpalooza-2010.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2010.md
@@ -3,7 +3,7 @@ title: "2010 Pedalpalooza calendar"
 description: "2010 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
-type: calevents
+type: calfestival
 pp: true
 year: 2010
 startdate: 2010-06-10

--- a/site/content/archive/pedalpalooza/pedalpalooza-2011.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2011.md
@@ -3,7 +3,7 @@ title: "2011 Pedalpalooza calendar"
 description: "2011 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
-type: calevents
+type: calfestival
 pp: true
 year: 2011
 startdate: 2011-06-09

--- a/site/content/archive/pedalpalooza/pedalpalooza-2012.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2012.md
@@ -3,7 +3,7 @@ title: "2012 Pedalpalooza calendar"
 description: "2012 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
-type: calevents
+type: calfestival
 pp: true
 year: 2012
 startdate: 2012-06-07

--- a/site/content/archive/pedalpalooza/pedalpalooza-2013.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2013.md
@@ -3,7 +3,7 @@ title: "2013 Pedalpalooza calendar"
 description: "2013 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
-type: calevents
+type: calfestival
 pp: true
 year: 2013
 startdate: 2013-06-06

--- a/site/content/archive/pedalpalooza/pedalpalooza-2014.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2014.md
@@ -3,7 +3,7 @@ title: "2014 Pedalpalooza calendar"
 description: "2014 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
-type: calevents
+type: calfestival
 pp: true
 year: 2014
 startdate: 2014-06-05

--- a/site/content/archive/pedalpalooza/pedalpalooza-2015.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2015.md
@@ -3,7 +3,7 @@ title: "2015 Pedalpalooza calendar"
 description: "2015 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
-type: calevents
+type: calfestival
 pp: true
 year: 2015
 startdate: 2015-06-04

--- a/site/content/archive/pedalpalooza/pedalpalooza-2016.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2016.md
@@ -3,7 +3,7 @@ title: "2016 Pedalpalooza calendar"
 description: "2016 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
-type: calevents
+type: calfestival
 pp: true
 year: 2016
 startdate: 2016-06-09

--- a/site/content/archive/pedalpalooza/pedalpalooza-2017.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2017.md
@@ -3,7 +3,7 @@ title: "2017 Pedalpalooza calendar"
 description: "2017 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
-type: calevents
+type: calfestival
 pp: true
 year: 2017
 startdate: 2017-06-01

--- a/site/content/archive/pedalpalooza/pedalpalooza-2018.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2018.md
@@ -3,7 +3,7 @@ title: "2018 Pedalpalooza calendar"
 description: "2018 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
-type: calevents
+type: calfestival
 pp: true
 year: 2018
 startdate: 2018-06-01

--- a/site/content/archive/pedalpalooza/pedalpalooza-2019.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2019.md
@@ -3,7 +3,7 @@ title: "2019 Pedalpalooza calendar"
 description: "2019 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
-type: calevents
+type: calfestival
 pp: true
 year: 2019
 startdate: 2019-06-01

--- a/site/content/archive/pedalpalooza/pedalpalooza-2021.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2021.md
@@ -3,7 +3,7 @@ title: "2021 Pedalpalooza calendar"
 description: "2021 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
-type: calevents
+type: calfestival
 pp: true
 year: 2021
 startdate: 2021-06-01

--- a/site/content/archive/pedalpalooza/pedalpalooza-2022.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2022.md
@@ -3,7 +3,7 @@ title: "2022 Pedalpalooza calendar"
 description: "2022 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
-type: calevents
+type: calfestival
 pp: true
 year: 2022
 startdate: 2022-06-01

--- a/site/content/archive/pedalpalooza/pedalpalooza-2023.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2023.md
@@ -3,7 +3,7 @@ title: "2023 Pedalpalooza calendar"
 description: "2023 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
-type: calevents
+type: calfestival
 pp: true
 year: 2023
 startdate: 2023-06-01

--- a/site/content/archive/pedalpalooza/pedalpalooza-2024.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2024.md
@@ -3,7 +3,7 @@ title: "2024 Pedalpalooza calendar"
 description: "2024 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
-type: calevents
+type: calfestival
 pp: true
 year: 2024
 startdate: 2024-06-01

--- a/site/content/pedalpalooza-calendar.md
+++ b/site/content/pedalpalooza-calendar.md
@@ -3,7 +3,7 @@ title: "Pedalpalooza calendar"
 description: "Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
-type: calevents
+type: calfestival
 pp: true
 year: 2024
 startdate: 2024-06-01

--- a/site/themes/s2b_hugo_theme/layouts/calevents/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/calevents/single.html
@@ -25,38 +25,22 @@
               <div class="col-md-12">
 
                 <div>
-                  {{ if isset .Params "pp" }}
-                    <!-- on PP cal page, display full PP header -->
-                    {{ partial "cal/pp-header.html" . }}
-                  {{ else }}
-                    <!-- on other cal pages, display smaller banner that links to PP cal page -->
-                    <!-- only display when PP is coming soon or happening now -->
-                    <!-- {{ partial "cal/pp-promo-banner.html" . }} -->
+                  <!-- when PP is coming soon or happening now, display smaller banner that links to PP cal page -->
+                  <!-- {{ partial "cal/pp-promo-banner.html" . }} -->
 
-                    <!-- only display during Steptember -->
-                    <!-- {{ partial "cal/promo-banner-steptember.html" . }} -->
-                  {{ end }}
+                  <!-- only display during Steptember -->
+                  <!-- {{ partial "cal/promo-banner-steptember.html" . }} -->
 
                   {{ .Content }}
                 </div>
 
-                {{ if not .Params.pp }}
-                  {{ partial "cal/shift-feed.html" . }}
-                {{ end }}
+                {{ partial "cal/shift-feed.html" . }}
 
                 <div id="fullcalendar"></div>
-
-                {{ if .Params.pp }}
-                  {{ partial "cal/pp-feed.html" . }}
-                {{ end }}
 
                 <div id="mustache-html" class="container">
 
                 </div>
-
-                {{ if isset .Params "pp" }}
-                  {{ partial "cal/promo-banner-main-cal.html" . }}
-                {{ end }}
 
                 {{ partial "alert_banner.html" . }}
 
@@ -81,6 +65,7 @@
   <!-- /#all -->
 
   {{ partial "scripts.html" . }}
+  {{ partial "cal/scripts.html" . }}
   {{ partial "cal/events.html" . }}
 
   <script type="text/javascript">

--- a/site/themes/s2b_hugo_theme/layouts/calfestival/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/calfestival/single.html
@@ -24,17 +24,25 @@
 
               <div class="col-md-12">
 
-                {{ partial "alert_banner.html" . }}
-
                 <div>
-                  {{ .Content }}
+                  {{ partial "cal/pp-header.html" . }}
 
-                  {{ if isset .Params "pp" }}
-                    {{ partial "cal/pp-header.html" . }}
-                  {{ end }}
+                  {{ .Content }}
                 </div>
 
-                <div id="mustache-html" class="container"></div>
+                <div id="fullcalendar"></div>
+
+                {{ partial "cal/pp-feed.html" . }}
+
+                <div id="mustache-html" class="container">
+
+                </div>
+
+                {{ partial "cal/promo-banner-main-cal.html" . }}
+
+                {{ partial "alert_banner.html" . }}
+
+                {{ partial "disclaimer.html" . }}
 
               </div>
 
@@ -56,12 +64,12 @@
 
   {{ partial "scripts.html" . }}
   {{ partial "cal/scripts.html" . }}
-  {{ partial "cal/edit.html" . }}
+  {{ partial "cal/events.html" . }}
 
   <script type="text/javascript">
     window.cal_renderpage = "{{ .Params.id }}";
+    // TODO
   </script>
 
 </body>
-
 </html>

--- a/site/themes/s2b_hugo_theme/layouts/calfestival/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/calfestival/single.html
@@ -32,15 +32,22 @@
 
                 <div id="fullcalendar"></div>
 
-                {{ partial "cal/pp-feed.html" . }}
+                <!-- only display on current year -->
+                {{ if eq (.Param "year") 2024 }}
+                  {{ partial "cal/pp-feed.html" . }}
+                {{ end }}
 
-                <div id="mustache-html" class="container">
+                <!-- don't display for old PP pages with static content -->
+                {{ if ge (.Param "year") 2008 }}
+                <div id="mustache-html" class="container"></div>
+                {{ end }}
 
-                </div>
+                <!-- only display on current year -->
+                {{ if eq (.Param "year") 2024 }}
+                  {{ partial "cal/promo-banner-main-cal.html" . }}
 
-                {{ partial "cal/promo-banner-main-cal.html" . }}
-
-                {{ partial "alert_banner.html" . }}
+                  {{ partial "alert_banner.html" . }}
+                {{ end }}
 
                 {{ partial "disclaimer.html" . }}
 

--- a/site/themes/s2b_hugo_theme/layouts/calgrid/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/calgrid/single.html
@@ -35,7 +35,6 @@
               <!-- {{ partial "cal/promo-banner-steptember.html" . }} -->
 
               {{ partial "cal/view-options.html" . }}
-              {{ partial "cal/fullcal.html" . }}
 
               <div id="fullcalendar"></div>
 
@@ -63,6 +62,7 @@
 
   {{ partial "scripts.html" . }}
   {{ partial "cal/scripts.html" . }}
+  {{ partial "cal/fullcal.html" . }}
 
 </body>
 

--- a/site/themes/s2b_hugo_theme/layouts/calgrid/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/calgrid/single.html
@@ -35,7 +35,7 @@
               <!-- {{ partial "cal/promo-banner-steptember.html" . }} -->
 
               {{ partial "cal/view-options.html" . }}
-              {{ partial "cal/fullcal.html" . }} 
+              {{ partial "cal/fullcal.html" . }}
 
               <div id="fullcalendar"></div>
 
@@ -62,6 +62,7 @@
   <!-- /#all -->
 
   {{ partial "scripts.html" . }}
+  {{ partial "cal/scripts.html" . }}
 
 </body>
 

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
@@ -1,16 +1,3 @@
-{{ $jsCalHelpers := resources.Get "js/cal/helpers.js" | minify }}
-<script src="{{ $jsCalHelpers.Permalink }}"></script>
-{{ $jsCalMain := resources.Get "js/cal/main.js" | minify }}
-<script src="{{ $jsCalMain.Permalink }}"></script>
-
-<script src="{{ .Site.BaseURL }}lib/mustache/mustache.min.js"></script>
-
-{{ partial "cal/dayjs.html" . }}
-
-<script src="{{ .Site.BaseURL }}lib/fullcalendar/core/main.min.js"></script>
-<script src="{{ .Site.BaseURL }}lib/fullcalendar/daygrid/main.min.js"></script>
-<script src="{{ .Site.BaseURL }}lib/fullcalendar/timegrid/main.min.js"></script>
-
 <script type="text/javascript">
   //only show grid view for PP pages, 2008 or later
   if ({{ .Param "pp" }} && ( {{ .Param "year" }} >= 2008 ) ) {
@@ -86,8 +73,6 @@
   }
 </script>
 
-{{ partial "cal/scripts.html" . }}
-
 <script type="text/javascript">
   //Mustache delimiter changing: https://stackoverflow.com/questions/13944623/escape-double-braces-in-mustache-template-templating-a-template-in-n
   Mustache.tags = ["[[", "]]"];
@@ -122,10 +107,6 @@
 </script>
 
 {{ partial "cal/icons.html" . }}
-
-<script id="scrollToTop" type="text/template">
-  <a href="#" class="scrollToTop">Back To Top</a>
-</script>
 
 <script id="view-events-template" type="text/template">
   [[#dates]]
@@ -390,4 +371,8 @@
       <button type="button" id="go-to-date" class="btn">Go</button>
     </div>
   </div>
+</script>
+
+<script id="scrollToTop" type="text/template">
+  <a href="#" class="scrollToTop">Back To Top</a>
 </script>

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/fullcal.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/fullcal.html
@@ -1,9 +1,3 @@
-<script src="{{ .Site.BaseURL }}lib/fullcalendar/core/main.min.js"></script>
-<script src="{{ .Site.BaseURL }}lib/fullcalendar/daygrid/main.min.js"></script>
-<script src="{{ .Site.BaseURL }}lib/fullcalendar/timegrid/main.min.js"></script>
-
-{{ partial "cal/scripts.html" . }}
-
 <script type="text/javascript">
   {{/*
     this partial is used by the calgrid and pp-landing layouts.

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/head.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/head.html
@@ -2,14 +2,14 @@
 {{ $cssCalMain := resources.Get "css/cal/main.css" | minify }}
 <link rel="stylesheet" href="{{ $cssCalMain.Permalink }}">
 
-<!-- only load grid view styles on calendar list pages; not needed on edit pages -->
-{{ if or (eq .Type "calevents") (eq .Type "calgrid") (eq .Type "pp-theme-cal") }}
+<!-- only load FullCal grid view styles on calendar grid and festival pages; not needed on list or edit pages -->
+{{ if or (eq .Type "calgrid") (eq .Type "calfestival") (eq .Type "pp-theme-cal") }}
 <link rel="stylesheet" type="text/css" href="/lib/fullcalendar/core/main.min.css">
 <link rel="stylesheet" type="text/css" href="/lib/fullcalendar/daygrid/main.min.css">
 <link rel="stylesheet" type="text/css" href="/lib/fullcalendar/timegrid/main.min.css">
 {{ end }}
 
-<!-- only load list view styles on homepage for "up next" widget and PP cal page -->
+<!-- only load FullCal list view styles on homepage for "up next" widget and festival cal page -->
 {{ if or (eq .Type "homepage") (eq .Type "pp-theme-cal") }}
 <link rel="stylesheet" type="text/css" href="/lib/fullcalendar/core/main.min.css"/>
 <link rel="stylesheet" type="text/css" href="/lib/fullcalendar/list/main.min.css"/>

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/scripts.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/scripts.html
@@ -1,3 +1,19 @@
+{{ $jsCalHelpers := resources.Get "js/cal/helpers.js" | minify }}
+<script src="{{ $jsCalHelpers.Permalink }}"></script>
+{{ $jsCalMain := resources.Get "js/cal/main.js" | minify }}
+<script src="{{ $jsCalMain.Permalink }}"></script>
+
+<script src="{{ .Site.BaseURL }}lib/mustache/mustache.min.js"></script>
+
+{{ partial "cal/dayjs.html" . }}
+
+<!-- only load FullCal scripts on calendar grid and festival pages; not needed on list or edit pages -->
+{{ if or (eq .Type "calgrid") (eq .Type "calfestival") (eq .Type "pp-theme-cal") }}
+<script src="{{ .Site.BaseURL }}lib/fullcalendar/core/main.min.js"></script>
+<script src="{{ .Site.BaseURL }}lib/fullcalendar/daygrid/main.min.js"></script>
+<script src="{{ .Site.BaseURL }}lib/fullcalendar/timegrid/main.min.js"></script>
+{{ end }}
+
 <script type="text/javascript">
   function parseURL() {
     var urlParams = {};

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/scripts.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/scripts.html
@@ -1,3 +1,4 @@
+<!-- only load on list, edit, and festival pages; not needed for grid view page -->
 {{ if or (eq .Type "calevents") (eq .Type "caledit") (eq .Type "calfestival") }}
   {{ $jsCalHelpers := resources.Get "js/cal/helpers.js" | minify }}
   <script src="{{ $jsCalHelpers.Permalink }}"></script>
@@ -16,6 +17,7 @@
   <script src="{{ .Site.BaseURL }}lib/fullcalendar/timegrid/main.min.js"></script>
 {{ end }}
 
+<!-- load on all cal pages -->
 <script type="text/javascript">
   function parseURL() {
     var urlParams = {};

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/scripts.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/scripts.html
@@ -1,17 +1,19 @@
-{{ $jsCalHelpers := resources.Get "js/cal/helpers.js" | minify }}
-<script src="{{ $jsCalHelpers.Permalink }}"></script>
-{{ $jsCalMain := resources.Get "js/cal/main.js" | minify }}
-<script src="{{ $jsCalMain.Permalink }}"></script>
+{{ if or (eq .Type "calevents") (eq .Type "calfestival") }}
+  {{ $jsCalHelpers := resources.Get "js/cal/helpers.js" | minify }}
+  <script src="{{ $jsCalHelpers.Permalink }}"></script>
+  {{ $jsCalMain := resources.Get "js/cal/main.js" | minify }}
+  <script src="{{ $jsCalMain.Permalink }}"></script>
 
-<script src="{{ .Site.BaseURL }}lib/mustache/mustache.min.js"></script>
+  <script src="{{ .Site.BaseURL }}lib/mustache/mustache.min.js"></script>
 
-{{ partial "cal/dayjs.html" . }}
+  {{ partial "cal/dayjs.html" . }}
+{{ end }}
 
 <!-- only load FullCal scripts on calendar grid and festival pages; not needed on list or edit pages -->
 {{ if or (eq .Type "calgrid") (eq .Type "calfestival") (eq .Type "pp-theme-cal") }}
-<script src="{{ .Site.BaseURL }}lib/fullcalendar/core/main.min.js"></script>
-<script src="{{ .Site.BaseURL }}lib/fullcalendar/daygrid/main.min.js"></script>
-<script src="{{ .Site.BaseURL }}lib/fullcalendar/timegrid/main.min.js"></script>
+  <script src="{{ .Site.BaseURL }}lib/fullcalendar/core/main.min.js"></script>
+  <script src="{{ .Site.BaseURL }}lib/fullcalendar/daygrid/main.min.js"></script>
+  <script src="{{ .Site.BaseURL }}lib/fullcalendar/timegrid/main.min.js"></script>
 {{ end }}
 
 <script type="text/javascript">

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/scripts.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/scripts.html
@@ -1,4 +1,4 @@
-{{ if or (eq .Type "calevents") (eq .Type "calfestival") }}
+{{ if or (eq .Type "calevents") (eq .Type "caledit") (eq .Type "calfestival") }}
   {{ $jsCalHelpers := resources.Get "js/cal/helpers.js" | minify }}
   <script src="{{ $jsCalHelpers.Permalink }}"></script>
   {{ $jsCalMain := resources.Get "js/cal/main.js" | minify }}


### PR DESCRIPTION
The `calevents` layout template was a bit overloaded with is-it-PP-or-not logic, so this splits that out to its own page template. That also lets us be more exact in which calendar scripts load on which calendar pages. e.g. now the FullCalendar scripts can be omitted from the default list view (`/calendar`)

Also, consolidated most calendar scripts into `layouts/partials/cal/scripts.html`, so the usage is now similar to `layouts/partials/cal/head.html`. There's still some more untangling we can do to avoid some of these conditional load statements, but this at least organizes it a bit better and in some cases trims down the page transfer size.

Note: This _doesn't_ resolve #744 — I added a bit of logic to prevent unneeded partials from loading, but we could still use a dedicated page template for those older ones.