### PR TITLE
Truncate long event description in page metadata with an ellipsis when needed

### DIFF
--- a/site/themes/s2b_hugo_theme/assets/js/cal/main.js
+++ b/site/themes/s2b_hugo_theme/assets/js/cal/main.js
@@ -68,8 +68,12 @@ $(document).ready(function() {
                     if (event.printdescr) {
                         $('meta[property="og:description"]')[0].setAttribute("content", event.printdescr);
                     } else {
-                        var desc = event.details.substring(0,250);
-                        $('meta[property="og:description"]')[0].setAttribute("content", desc);
+                        var descr = event.details.substring(0,250);
+                        if (event.details.length > 250) {
+                          // replace the last character with an ellipsis
+                          descr = descr.slice(0, -1) + "…";
+                        }
+                        $('meta[property="og:description"]')[0].setAttribute("content", descr);
                     }
                     document.title = event.title + " - Calendar - " + SITE_TITLE;
                 }


### PR DESCRIPTION
Fixes #784