### PR TITLE
Removed indentation that was causing HTML-in-Markdown to render as a code block on Pedalpalooza 2005 page

### DIFF
--- a/site/content/archive/pedalpalooza/pedalpalooza-2005.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2005.md
@@ -215,25 +215,25 @@ poster-image: "/images/pp/pp2005.jpg"
     </tr>
   </tbody></table>
 
-  <hr>
-  <h2><a name="June9">Thursday June 9</a></h2>
-  <dl>
-    <dt><a name="June9:Kickoff Parade">KICKOFF PARADE</a>
-    <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
-    </dt><dd>Jamison Square, 810 NW 11th, by Johnson St.
-    <br>5:30pm.  At 6:00pm we ride.
-    <br>Decorate your bike (come early),
+<hr>
+<h2><a name="June9">Thursday June 9</a></h2>
+<dl>
+  <dt><a name="June9:Kickoff Parade">KICKOFF PARADE</a>
+  <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
+  </dt><dd>Jamison Square, 810 NW 11th, by Johnson St.
+  <br>5:30pm.  At 6:00pm we ride.
+  <br>Decorate your bike (come early),
 	wear a costume and join us for
 	a ride filled with chills, thrills, sequins and more.
 	Noisemakers strongly encouraged.
 	Family Friendly.
-    <br>Joanna, rippleeffects<img src="images/at.gif" alt="[at]">gmail.com
+  <br>Joanna, rippleeffects<img src="images/at.gif" alt="[at]">gmail.com
 
-    </dd><dt><a name="June9:VBC Thursday">VANCOUVER BICYCLE CLUB THURSDAY EVENING RIDE</a>
-    <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
-    </dt><dd>Vancouver, Marshall Center, 1009 E. McLoughlin
-    <br>6:00pm every Thursday
-    <br>Join Pete or Jim for this Thursday evening ride following
+  </dd><dt><a name="June9:VBC Thursday">VANCOUVER BICYCLE CLUB THURSDAY EVENING RIDE</a>
+  <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
+  </dt><dd>Vancouver, Marshall Center, 1009 E. McLoughlin
+  <br>6:00pm every Thursday
+  <br>Join Pete or Jim for this Thursday evening ride following
 	the RACC route towards 164th Avenue,
 	head south to SE Cascade Park Drive, and
 	follow the "low road" back to the start.
@@ -243,50 +243,50 @@ poster-image: "/images/pp/pp2005.jpg"
 	In case of rain we will hand out cue sheets and wish you well.
 	Make this ride part of your weekly ritual.
 	Minor Hills, 12mph, Re-group, 22 miles.
-    <br>Pete Lyall, 360-604-3124 &amp; Jim Ryan, 360-256-4354
-    <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
+  <br>Pete Lyall, 360-604-3124 &amp; Jim Ryan, 360-256-4354
+  <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
 
-    </dd><dt><a name="June9:VBC Time Trial">VANCOUVER BICYCLE CLUB TIME TRIAL SERIES</a>
-    <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
-    </dt><dd>Vancouver, Port of Vancouver office, 3103 NW Lower River Road
-    <br>6:30pm (sign in at 6:15pm)
-    <br>A flat 10-mile course.
+  </dd><dt><a name="June9:VBC Time Trial">VANCOUVER BICYCLE CLUB TIME TRIAL SERIES</a>
+  <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
+  </dt><dd>Vancouver, Port of Vancouver office, 3103 NW Lower River Road
+  <br>6:30pm (sign in at 6:15pm)
+  <br>A flat 10-mile course.
 	Open to all! $1.00 entry fee; VBC members are FREE!
-    <br>Mike Lusby, 360-750-4875,
+  <br>Mike Lusby, 360-750-4875,
 	vbctt<img src="images/at.gif" alt="[at]">netzero.net
-    <br><a href="http://www.vancouverbicycleclub.com/trials.html">http://www.vancouverbicycleclub.com/trials.html</a>
+  <br><a href="http://www.vancouverbicycleclub.com/trials.html">http://www.vancouverbicycleclub.com/trials.html</a>
 
-    </dd><dt><a name="June9:CCC Women's">WOMEN'S VOLUNTEER NIGHT</a>
-    </dt><dd>Community Cycling Center, 1700 NE Alberta Street
-    <br>7:00pm - 9:30pm
-    <br>Learn about bike repair in a super supportive setting.
-    <br>Ayleen<img src="images/at.gif" alt="[at]">CommunityCyclingCenter.org, 503-546-8864
+  </dd><dt><a name="June9:CCC Women's">WOMEN'S VOLUNTEER NIGHT</a>
+  </dt><dd>Community Cycling Center, 1700 NE Alberta Street
+  <br>7:00pm - 9:30pm
+  <br>Learn about bike repair in a super supportive setting.
+  <br>Ayleen<img src="images/at.gif" alt="[at]">CommunityCyclingCenter.org, 503-546-8864
 
-    </dd><dt><a name="June9:Bike-In Movie">BIKE-IN MOVIE AT LAURELHURST THEATER</a>
-    <img src="/images/legacy/beer.gif" alt="21+" title="Adult Only (21+)" align="left">
-    </dt><dd>Laurelhurst Theater, 2735 E. Burnside
-    <br>9:00pm
-    <br>Admission is free if you arrive by bike, or regular price otherwise.
+  </dd><dt><a name="June9:Bike-In Movie">BIKE-IN MOVIE AT LAURELHURST THEATER</a>
+  <img src="/images/legacy/beer.gif" alt="21+" title="Adult Only (21+)" align="left">
+  </dt><dd>Laurelhurst Theater, 2735 E. Burnside
+  <br>9:00pm
+  <br>Admission is free if you arrive by bike, or regular price otherwise.
 	Valet bike parking.
 	Showing <em>"Triplets of Belleville"</em>
-    <br>Woody,
+  <br>Woody,
 	<a href="http://www.laurelhursttheater.com">www.laurelhursttheater.com</a>
-  </dd></dl>
+</dd></dl>
 
-  <hr>
-  <h2><a name="June10">Friday June 10</a></h2>
-  <dl>
-    <dt><a name="June10:BonB">BREAKFAST ON THE BRIDGES</a>
-    <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
-    </dt><dd>Broadway &amp; Hawthorne Bridges (Westbound Sides)
-    <br>7:00am - 9:00am
-    <br>Ride the Bridge, eat a nosh, have a cawfee. No big whoop
-    <br>timolandia<img src="images/at.gif" alt="[at]">shifttobikes.org
+<hr>
+<h2><a name="June10">Friday June 10</a></h2>
+<dl>
+  <dt><a name="June10:BonB">BREAKFAST ON THE BRIDGES</a>
+  <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
+  </dt><dd>Broadway &amp; Hawthorne Bridges (Westbound Sides)
+  <br>7:00am - 9:00am
+  <br>Ride the Bridge, eat a nosh, have a cawfee. No big whoop
+  <br>timolandia<img src="images/at.gif" alt="[at]">shifttobikes.org
 
-    </dd><dt><a name="June10:Taco Ride">EASTSIDE TACO RIDE</a>
-    </dt><dd>Cha Cha Cha!, 3433 SE Hawthorne Blvd.
-    <br>5:45pm, lasting as long as we can eat more tacos and ride.
-    <br>Who makes the best carnitas/pollo/fish/vege taco in town?
+  </dd><dt><a name="June10:Taco Ride">EASTSIDE TACO RIDE</a>
+  </dt><dd>Cha Cha Cha!, 3433 SE Hawthorne Blvd.
+  <br>5:45pm, lasting as long as we can eat more tacos and ride.
+  <br>Who makes the best carnitas/pollo/fish/vege taco in town?
 	Find out as we visit several local taquerias around town,
 	stopping for a taco at each.
 	Route not yet set, probably 2-3 hours and up to 20 miles,
@@ -294,49 +294,49 @@ poster-image: "/images/pp/pp2005.jpg"
 	depending on how ambitious/hungry we are.
 	Bring cash for tacos and Jarritos
 	(usually $1 - $1.75/taco, drinks are usually $1)
-    <br>Ben, ben<img src="images/at.gif" alt="[at]">ridemybike.org
+  <br>Ben, ben<img src="images/at.gif" alt="[at]">ridemybike.org
 
-    </dd><dt><a name="June10:MMR">MIDNIGHT MYSTERY RIDE</a>
-    <img src="/images/legacy/beer.gif" alt="21+" title="Adult Only (21+)" align="left">
-    </dt><dd>Matador, 1967 W Burnside St.
-    <br>11:00pm, at Midnight we ride
-    <br>Ride to a mystery destination.
+  </dd><dt><a name="June10:MMR">MIDNIGHT MYSTERY RIDE</a>
+  <img src="/images/legacy/beer.gif" alt="21+" title="Adult Only (21+)" align="left">
+  </dt><dd>Matador, 1967 W Burnside St.
+  <br>11:00pm, at Midnight we ride
+  <br>Ride to a mystery destination.
 	Bring a snack or something special to share.
-    <br>Corey, see7e<img src="images/at.gif" alt="[at]">yahoo.com
-    <br><a href="http://www.yeabikes.net/midnight/">www.yeabikes.net/midnight</a>
-  </dd></dl>
+  <br>Corey, see7e<img src="images/at.gif" alt="[at]">yahoo.com
+  <br><a href="http://www.yeabikes.net/midnight/">www.yeabikes.net/midnight</a>
+</dd></dl>
 
-  <hr>
-  <h2><a name="June11">Saturday June 11</a></h2>
-  <dl>
-    <dt><a name="June11:Kids Pedal">CCC KIDS' PEDAL</a>
-    <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
-    </dt><dd>SW 4th and Glisan
-    <br>7:00am for the rodeo; parade starts at 8:00am
-    </dd><dd>Safety skills rodeo, followed by a kids bike parade to lead off
+<hr>
+<h2><a name="June11">Saturday June 11</a></h2>
+<dl>
+  <dt><a name="June11:Kids Pedal">CCC KIDS' PEDAL</a>
+  <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
+  </dt><dd>SW 4th and Glisan
+  <br>7:00am for the rodeo; parade starts at 8:00am
+  </dd><dd>Safety skills rodeo, followed by a kids bike parade to lead off
 	the Rose Festival Grand Floral Parade.
 	The entry fee is $20 per child, which includes a
 	t-shirt, free bike safety checks, lunch, THE PARADE and
 	a chance to earn prizes.
 	<em>Helmets required.</em>
 	Volunteers needed for all aspects of the event.
-    <br><a href="http://www.communitycyclingcenter.org/kidspedal/">http://www.communitycyclingcenter.org/kidspedal/</a>
+  <br><a href="http://www.communitycyclingcenter.org/kidspedal/">http://www.communitycyclingcenter.org/kidspedal/</a>
 
-    </dd><dt><a name="June11:Wine + Wheels">WINE &amp; WHEELS</a>
-    </dt><dd>Bike Gallery Beaverton, 3645 SW Hall Blvd.
-    <br>7:45am for carpool to start of ride;
+  </dd><dt><a name="June11:Wine + Wheels">WINE &amp; WHEELS</a>
+  </dt><dd>Bike Gallery Beaverton, 3645 SW Hall Blvd.
+  <br>7:45am for carpool to start of ride;
 	Ride starts at 9:00am at Panther Creek Cellars.
-    <br>Meet at the Bike Gallery-Beaverton at 7:45 am to carpool, or
+  <br>Meet at the Bike Gallery-Beaverton at 7:45 am to carpool, or
 	at Panther Creek Cellars in McMinnville at 9:00 am.
 	Join us for a ride through Willamette wine country and
 	end with a glass of wine.
-    <br>503-641-2580
-    <br><a href="http://www.bikegallery.com/">www.bikegallery.com</a>
+  <br>503-641-2580
+  <br><a href="http://www.bikegallery.com/">www.bikegallery.com</a>
 
-    </dd><dt><a name="June11:Doughnut Ride">THE REAL DOUGHNUT RIDE</a>
-    </dt><dd>Helen Bernhard Bakery, 1717 NE Broadway
-    <br>8:30am, until we run out of shops or can no longer pedal
-    <br>Start off with the light ones (cruller, raised)
+  </dd><dt><a name="June11:Doughnut Ride">THE REAL DOUGHNUT RIDE</a>
+  </dt><dd>Helen Bernhard Bakery, 1717 NE Broadway
+  <br>8:30am, until we run out of shops or can no longer pedal
+  <br>Start off with the light ones (cruller, raised)
 	and work your way up to the ones that really weigh you down
 	(old-fashioned, buttermilk bar) and hopefully still have
 	room for a bacon maple bar.
@@ -344,13 +344,13 @@ poster-image: "/images/pp/pp2005.jpg"
 	This could last a few hours and we'll probably work off a
 	donut or two on a couple of hours' ride.
 	Pay your own way (should be a dollar or so each stop).
-    <br>Jeme, jeme<img src="images/at.gif" alt="[at]">bikearmy.org
+  <br>Jeme, jeme<img src="images/at.gif" alt="[at]">bikearmy.org
 
-    </dd><dt><a name="June11:Well Field">CYCLE THE WELL FIELD</a>
-    <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
-    </dt><dd>Parkrose/Sumner Transit Center (MAX Red Line), 9841 NE Sandy
-    <br>9:00am - 1:00pm
-    <br>Join the Columbia Slough Watershed Council and the
+  </dd><dt><a name="June11:Well Field">CYCLE THE WELL FIELD</a>
+  <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
+  </dt><dd>Parkrose/Sumner Transit Center (MAX Red Line), 9841 NE Sandy
+  <br>9:00am - 1:00pm
+  <br>Join the Columbia Slough Watershed Council and the
 	City of Portland, Bureau of Water Works for a FREE bicycle
 	riding tour through Portland's Groundwater Protection Area.
 	Approximately 16 miles over flat terrain,
@@ -360,13 +360,13 @@ poster-image: "/images/pp/pp2005.jpg"
 	Groundwater Protection T-shirt.
 	<em>Helmets and advance registration are required.
 	Space is limited to 30 riders so register early!</em>
-    <br>Randy Albright, 503-823-3421, ralbright<img src="images/at.gif" alt="[at]">water.ci.portland.or.us,
-    <br>Eric Kellon, 503-281-1132, eric.kellon<img src="images/at.gif" alt="[at]">columbiaslough.org
+  <br>Randy Albright, 503-823-3421, ralbright<img src="images/at.gif" alt="[at]">water.ci.portland.or.us,
+  <br>Eric Kellon, 503-281-1132, eric.kellon<img src="images/at.gif" alt="[at]">columbiaslough.org
 
-    </dd><dt><a name="June11:Women on Bikes">WOMEN ON BIKES CLINIC: Riding over the Hurdles</a>
-    </dt><dd>Mt. Tabor Sports, 5941 SE Division St.
-    <br>9:00am - 12:00pm noon
-    <br>What is keeping you from riding?
+  </dd><dt><a name="June11:Women on Bikes">WOMEN ON BIKES CLINIC: Riding over the Hurdles</a>
+  </dt><dd>Mt. Tabor Sports, 5941 SE Division St.
+  <br>9:00am - 12:00pm noon
+  <br>What is keeping you from riding?
 	Feel a little vulnerable in traffic?
 	Have to haul children around?
 	Have too many errands to do by bike?
@@ -376,14 +376,14 @@ poster-image: "/images/pp/pp2005.jpg"
 	Plus, we will demonstrate how to put your bike on the bus.
 	WomenStrength, a personal safety program, will show us
 	techniques to build our confidence.
-    <br>Janis McDonald, 503-823-5358, janis.mcdonald<img src="images/at.gif" alt="[at]">pdxtrans.org
+  <br>Janis McDonald, 503-823-5358, janis.mcdonald<img src="images/at.gif" alt="[at]">pdxtrans.org
 
-    </dd><dt><a name="June11:Rodeo Fun">BIKE RODEO/BIKE COLLECTION AND FUN DAY</a>
-    <img src="images/ffwa.gif" alt="Family-Friendly" title="Family Friendly, Meet in/around Vancouver" align="left">
-    </dt><dd>Vancouver Fire Station 83,
+  </dd><dt><a name="June11:Rodeo Fun">BIKE RODEO/BIKE COLLECTION AND FUN DAY</a>
+  <img src="images/ffwa.gif" alt="Family-Friendly" title="Family Friendly, Meet in/around Vancouver" align="left">
+  </dt><dd>Vancouver Fire Station 83,
 	213 NE 120th Ave (just north of Mill Plain)
-    <br>11:00am - 2:00pm
-    <br>There will be "yummy treats" for the kids.
+  <br>11:00am - 2:00pm
+  <br>There will be "yummy treats" for the kids.
 	Helmets offered at reduced price and
 	helmet fitters to properly size them.
 	Fun bike rodeo for the kids led by
@@ -391,29 +391,29 @@ poster-image: "/images/pp/pp2005.jpg"
 	Also, the Community Cycling Center accepting bike donations
 	(any size, model or condition) for their bike programs
 	serving low-income kids.
-    <br>Val Stewart, pastew06<img src="images/at.gif" alt="[at]">aol.com
+  <br>Val Stewart, pastew06<img src="images/at.gif" alt="[at]">aol.com
 
-    </dd><dt><a name="June11:Bridge Curious">R U BRIDGE CURIOUS?! GUIDED TOUR</a>
-    <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
-    </dt><dd>Vancouver Farmers' Market, W. 8th St. &amp; Franklin at the bike rack
-    <br>11:00am - 2:00pm
-    <br>A guided bike + transit tour.
+  </dd><dt><a name="June11:Bridge Curious">R U BRIDGE CURIOUS?! GUIDED TOUR</a>
+  <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
+  </dt><dd>Vancouver Farmers' Market, W. 8th St. &amp; Franklin at the bike rack
+  <br>11:00am - 2:00pm
+  <br>A guided bike + transit tour.
 	Learn the secrets of conquering your fears of the
 	Interstate Bridge crossing.
 	<em>(Helmets required, maximum 20 participants,
 	no hand guns allowed, please RSVP. FREE)</em>
-    <br>City of Vancouver, 360-696-8290,
+  <br>City of Vancouver, 360-696-8290,
 	vantrans<img src="images/at.gif" alt="[at]">ci.vancouver.wa.us
 
-    </dd><dt><a name="June11:Musical Mystery Ride">NOON-TIME MUSICAL MYSTERY RIDE</a>
-    <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
-    </dt><dd>Laurelhurst Park by the pond, SE 39th and Stark
-    <br>11:00am (ride at noon)
-    <br>Slow paced social ride ending at a mystery location for a BBQ.
+  </dd><dt><a name="June11:Musical Mystery Ride">NOON-TIME MUSICAL MYSTERY RIDE</a>
+  <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
+  </dt><dd>Laurelhurst Park by the pond, SE 39th and Stark
+  <br>11:00am (ride at noon)
+  <br>Slow paced social ride ending at a mystery location for a BBQ.
 	Arrive early to decorate your bike!
 	Store stop planned for beverage and BBQ items -
 	We'll have a trailer with cooler.
-    <br><em>**Bring a musical instrument to play -
+  <br><em>**Bring a musical instrument to play -
 	prizes will be awarded for originality, musicianship,
 	and most difficult instrument.**</em>
 	Be prepared to play a few rounds of musical bikes en route.
@@ -422,44 +422,44 @@ poster-image: "/images/pp/pp2005.jpg"
 	Bring your most unusual bike!
 	Family Friendly, but be aware that a barbecue generally
 	involves consumption of beer.
-    <br>Chops, freebeebumble<img src="images/at.gif" alt="[at]">yahoo.com;
+  <br>Chops, freebeebumble<img src="images/at.gif" alt="[at]">yahoo.com;
 	and Bethany, postbethany<img src="images/at.gif" alt="[at]">hotmail.com
 
-    </dd><dt><a name="June11:Repairs / Sun">BIKE REPAIRS UNDER THE SUN</a>
-    <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
-    </dt><dd>I-205 bike path &amp; Springwater Corridor
+  </dd><dt><a name="June11:Repairs / Sun">BIKE REPAIRS UNDER THE SUN</a>
+  <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
+  </dt><dd>I-205 bike path &amp; Springwater Corridor
 	(near SE 92nd and Rural)
-    <br>3:00pm - 5:00pm
-    <br>Volunteer repair classes.
+  <br>3:00pm - 5:00pm
+  <br>Volunteer repair classes.
 	Learn about simple bike maintenance, street riding,
 	and the simple power of the bike....out in the sun!
 	Feel free to come help out, or just listen and enjoy.
 	I'll hopefully be bringing water for those thirsty trail users.
-    <br>Aaron Tarfman, bikephoto<img src="images/at.gif" alt="[at]">aol.com
+  <br>Aaron Tarfman, bikephoto<img src="images/at.gif" alt="[at]">aol.com
 
-    </dd><dt><a name="June11:Dance Party">DANCE PARTY FOR THE NAKED RIDE</a>
-    </dt><dd>Free Geek, 1731 SE 10th Avenue
-    <br>9:30pm
-    <br>Totally free, partially geek.
+  </dd><dt><a name="June11:Dance Party">DANCE PARTY FOR THE NAKED RIDE</a>
+  </dt><dd>Free Geek, 1731 SE 10th Avenue
+  <br>9:30pm
+  <br>Totally free, partially geek.
 	This is the party for the World Naked Bike Ride.
 	Consider yourself warned.
-    <br>Corey, see7e<img src="images/at.gif" alt="[at]">yahoo.com;
+  <br>Corey, see7e<img src="images/at.gif" alt="[at]">yahoo.com;
 
-    </dd><dt><a name="June11:Naked Ride">WORLD NAKED BIKE RIDE</a>
-    </dt><dd>Free Geek, 1731 SE 10th Avenue (same as the Dance Party)
-    <br>11:59pm
-    <br>Yes, this is exactly what it sounds like.
-    <br>Local organizer is Corey, see7e<img src="images/at.gif" alt="[at]">yahoo.com;
+  </dd><dt><a name="June11:Naked Ride">WORLD NAKED BIKE RIDE</a>
+  </dt><dd>Free Geek, 1731 SE 10th Avenue (same as the Dance Party)
+  <br>11:59pm
+  <br>Yes, this is exactly what it sounds like.
+  <br>Local organizer is Corey, see7e<img src="images/at.gif" alt="[at]">yahoo.com;
 	for general info, see <a href="http://www.worldnakedbikeride.org/">http://www.worldnakedbikeride.org</a>.
-  </dd></dl>
+</dd></dl>
 
-  <hr>
-  <h2><a name="June12">Sunday June 12</a></h2>
-  <dl>
-    <dt><a name="June12:ZB Century">100 MILES AND RUNNIN'</a>
-    </dt><dd>Top of the Tri-Met elevators at Washington Park Zoo
-    <br>8:30am
-    <br>Also known as the Third Annual Zoobomb Century.
+<hr>
+<h2><a name="June12">Sunday June 12</a></h2>
+<dl>
+  <dt><a name="June12:ZB Century">100 MILES AND RUNNIN'</a>
+  </dt><dd>Top of the Tri-Met elevators at Washington Park Zoo
+  <br>8:30am
+  <br>Also known as the Third Annual Zoobomb Century.
 	100 miles, mostly downhill, all in one day.
 	(This is in addition to the regular Sunday Zoobomb.)
 	$7 entry fee gets you bag lunch and T-shirt and spoke card,
@@ -468,15 +468,15 @@ poster-image: "/images/pp/pp2005.jpg"
 	<em>You are encouraged to pre-register with Zach via email
 	to ensure that there are enough lunches and right-sized
 	shirts.</em>
-    <br>Zach Crinklebine,
+  <br>Zach Crinklebine,
 	crinkllbine<img src="images/at.gif" alt="[at]">yahoo.com
 
-    </dd><dt><a name="June12:VBC North">VANCOUVER BICYCLE CLUB NORTH RIDE</a>
-    <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
-    </dt><dd>Vancouver, SW corner of NE 63rd St. &amp; Andresen
+  </dd><dt><a name="June12:VBC North">VANCOUVER BICYCLE CLUB NORTH RIDE</a>
+  <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
+  </dt><dd>Vancouver, SW corner of NE 63rd St. &amp; Andresen
 	(meet in NW corner of parking lot)
-    <br>9:00am
-    <br>This enjoyable loop goes from the Safeway lot out through
+  <br>9:00am
+  <br>This enjoyable loop goes from the Safeway lot out through
 	Battle Ground and back.
 	This ride frequently breaks into two groups,
 	one riding at a social 12-14 mph pace and one riding at
@@ -486,14 +486,14 @@ poster-image: "/images/pp/pp2005.jpg"
 	If it's really wet,
 	we can drink coffee and just talk about riding.
 	Moderate Hills, 12mph, Group, 28miles.
-    <br>Clay Kind, 360-256-1595
-    <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
+  <br>Clay Kind, 360-256-1595
+  <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
 
-    </dd><dt><a name="June12:Couv Curious">ARE YOU COUV CURIOUS?</a>
-    </dt><dd>Meet along Interstate MAX line (yellow line)
-    <br>11:00am at Interstate/Rose Quarter MAX station, or
-    <br>11:30am at Paul Bunyan statue (Kenton/N.Denver Ave. MAX station)
-    <br>Ever wonder how to get to our sister city to the north by bike,
+  </dd><dt><a name="June12:Couv Curious">ARE YOU COUV CURIOUS?</a>
+  </dt><dd>Meet along Interstate MAX line (yellow line)
+  <br>11:00am at Interstate/Rose Quarter MAX station, or
+  <br>11:30am at Paul Bunyan statue (Kenton/N.Denver Ave. MAX station)
+  <br>Ever wonder how to get to our sister city to the north by bike,
 	but didn't know how?
 	Or didn't know what to do or where to go when you get there?
 	This ride is for you!
@@ -501,12 +501,12 @@ poster-image: "/images/pp/pp2005.jpg"
 	Vancouver, Washington.
 	Learn how to get to the 'Couv and back again, and see some of
 	the sights of this fair city.
-    <br>urbanadventureleague<img src="images/at.gif" alt="[at]">scribble.com
+  <br>urbanadventureleague<img src="images/at.gif" alt="[at]">scribble.com
 
-    </dd><dt><a name="June12:Bike Polo">BIKE POLO</a>
-    </dt><dd>Alberta Park, NE 21st and Killingsworth
-    <br>3:00pm until dark
-    <br>Mayhem in the cage!
+  </dd><dt><a name="June12:Bike Polo">BIKE POLO</a>
+  </dt><dd>Alberta Park, NE 21st and Killingsworth
+  <br>3:00pm until dark
+  <br>Mayhem in the cage!
 	This is the real deal!
 	Free for all!
 	Pick-up games and more.
@@ -514,13 +514,13 @@ poster-image: "/images/pp/pp2005.jpg"
 	If yr not a hippie, you may actually like this!
 	NOT FAMILY FRIENDLY -the kids WILL pick up bad habits from
 	watching us.
-    <br>BLDZR, bill<img src="images/at.gif" alt="[at]">axlesofevil.org
-    <br><a href="http://www.axlesofevil.org">www.axlesofevil.org</a>
+  <br>BLDZR, bill<img src="images/at.gif" alt="[at]">axlesofevil.org
+  <br><a href="http://www.axlesofevil.org">www.axlesofevil.org</a>
 
-    </dd><dt><a name="June12:Dinner Mystery Ride">DINNERTIME MYSTERY RIDE</a>
-    </dt><dd>Bikehenge, a.k.a. the traffic circle at SW 18th &amp; Jefferson St.
-    <br>6:00pm
-    <br>Have you always wanted to ride with the Midnight Mystery Ride
+  </dd><dt><a name="June12:Dinner Mystery Ride">DINNERTIME MYSTERY RIDE</a>
+  </dt><dd>Bikehenge, a.k.a. the traffic circle at SW 18th &amp; Jefferson St.
+  <br>6:00pm
+  <br>Have you always wanted to ride with the Midnight Mystery Ride
 	crue, but can't handle the sleep deprivation?
 	This ride will pack all the fun of an MMR,
 	and at a time in harmony with your circadian rhythm.
@@ -528,36 +528,36 @@ poster-image: "/images/pp/pp2005.jpg"
 	for a picnic dinner.
 	Bring something to eat, or cash enough for a stop at a
 	grocery store deli on the way.
-    <br>Hosted by the Cougars
+  <br>Hosted by the Cougars
 
-    </dd><dt><a name="June12:Zoobomb">ZOOBOMB</a>
-    </dt><dd>Roccos Pizza, 949 SW Oak St
-    <br>8:30pm
-    <br>Ride the Max to the zoo with your bike and zoobomb down.
+  </dd><dt><a name="June12:Zoobomb">ZOOBOMB</a>
+  </dt><dd>Roccos Pizza, 949 SW Oak St
+  <br>8:30pm
+  <br>Ride the Max to the zoo with your bike and zoobomb down.
 	Costumes and little bikes optional.
 	(The "100 Miles and Runnin'" Zoobomb Century starts earlier
 	this day, and will doubtless still be going on.)
-    <br><a href="http://www.zoobomb.org/">www.zoobomb.org</a>
-  </dd></dl>
+  <br><a href="http://www.zoobomb.org/">www.zoobomb.org</a>
+</dd></dl>
 
-  <hr>
-  <h2><a name="June13">Monday June 13</a></h2>
-  <dl>
-    <dt><a name="June13:Bikestation">BIKE PARKING SOCIAL: MEET MS. BIKESTATION</a>
-    </dt><dd>Lucky Lab, 915 SE Hawthorne
-    <br>5:30pm
-    <br>Drink a beer, meet Andrea White of bikestation and discuss
+<hr>
+<h2><a name="June13">Monday June 13</a></h2>
+<dl>
+  <dt><a name="June13:Bikestation">BIKE PARKING SOCIAL: MEET MS. BIKESTATION</a>
+  </dt><dd>Lucky Lab, 915 SE Hawthorne
+  <br>5:30pm
+  <br>Drink a beer, meet Andrea White of bikestation and discuss
 	how Portland/Vancouver can catch up with other bike cities
 	regarding bike parking.  RSVP
-    <br>Todd Boulanger, 360-281-0944,
+  <br>Todd Boulanger, 360-281-0944,
 	oulanger<img src="images/at.gif" alt="[at]">excite.com
-    <br><a href="http://www.bikestation.org">www.bikestation.org</a>
+  <br><a href="http://www.bikestation.org">www.bikestation.org</a>
 
-    </dd><dt><a name="June13:Trans. Geek Ride">TRANSPORTATION GEEKS' RIDE</a>
-    <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
-    </dt><dd>Ladd's Circle, SE 16th and Harrison
-    <br>6:00pm
-    <br>You know riding in Portland is great,
+  </dd><dt><a name="June13:Trans. Geek Ride">TRANSPORTATION GEEKS' RIDE</a>
+  <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
+  </dt><dd>Ladd's Circle, SE 16th and Harrison
+  <br>6:00pm
+  <br>You know riding in Portland is great,
 	but you aren't sure exactly why.
 	Come and find out!
 	Tour around some choice spots in the city to look at various
@@ -569,29 +569,29 @@ poster-image: "/images/pp/pp2005.jpg"
 	This is a fun tour with lots of great information about
 	cycling in the city.
 	Led by two members of the Portland Bicycle Advisory Committee.
-    <br>eliciacardenas<img src="images/at.gif" alt="[at]">hotmail.com
+  <br>eliciacardenas<img src="images/at.gif" alt="[at]">hotmail.com
 
-    </dd><dt><a name="June13:VBC East Cty.">VANCOUVER BICYCLE CLUB EAST COUNTY EXPLORER</a>
-    <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
-    </dt><dd>Lacamas Swim &amp; Sport, 2950 NW 38th Avenue, Camas
-    <br>6:00pm every Monday
-    <br>We will offer varying routes around the Camas or Washougal area,
+  </dd><dt><a name="June13:VBC East Cty.">VANCOUVER BICYCLE CLUB EAST COUNTY EXPLORER</a>
+  <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
+  </dt><dd>Lacamas Swim &amp; Sport, 2950 NW 38th Avenue, Camas
+  <br>6:00pm every Monday
+  <br>We will offer varying routes around the Camas or Washougal area,
 	most of the time including climbs of Crown Road and Prune Hill.
 	Moderate hills, 16mph, Non-Group, 22-31 Miles.
-    <br>Scott Martin &amp; Ayla Gokturk, 360-834-6737
-    <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
+  <br>Scott Martin &amp; Ayla Gokturk, 360-834-6737
+  <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
 
-    </dd><dt><a name="June13:Coffee Ride">MONDAY NIGHT COFFEE RIDE</a>
-    </dt><dd>Bike Gallery Hollywood, 5329 NE Sandy Blvd.
-    <br>6:00pm (every Monday)
-    <br>Social ride to a coffee shop.
-    <br>503-281-9800
-    <br><a href="http://www.bikegallery.com/">www.bikegallery.com</a>
+  </dd><dt><a name="June13:Coffee Ride">MONDAY NIGHT COFFEE RIDE</a>
+  </dt><dd>Bike Gallery Hollywood, 5329 NE Sandy Blvd.
+  <br>6:00pm (every Monday)
+  <br>Social ride to a coffee shop.
+  <br>503-281-9800
+  <br><a href="http://www.bikegallery.com/">www.bikegallery.com</a>
 
-    </dd><dt><a name="June13:Astronomy Ride">ASTRONOMY RIDE</a>
-    </dt><dd>4841 SE Sherman St.
-    <br>9:00pm, lasting about 3 hours
-    <br>Ride to the top of Powell Butte and look at the stars through
+  </dd><dt><a name="June13:Astronomy Ride">ASTRONOMY RIDE</a>
+  </dt><dd>4841 SE Sherman St.
+  <br>9:00pm, lasting about 3 hours
+  <br>Ride to the top of Powell Butte and look at the stars through
 	my telescope. Bring binoculars if you have them,
 	or a telescope if you have one.
 	It may be a little chilly up there at night
@@ -603,61 +603,61 @@ poster-image: "/images/pp/pp2005.jpg"
 	<strong>Postponed!</strong>  Sorry.
 	If we catch a clear night, Ben may reschedule this but for now
 	the cloudy weather seems endless.</em>
-    <br>Ben, ben<img src="images/at.gif" alt="[at]">ridemybike.org
-  </dd></dl>
+  <br>Ben, ben<img src="images/at.gif" alt="[at]">ridemybike.org
+</dd></dl>
 
-  <hr>
-  <h2><a name="June14">Tuesday June 14 (Flag Day)</a></h2>
-  <dl>
-    <dt><a name="June14:VBC Friends">VANCOUVER BICYCLE CLUB TOUR DE FRIENDS</a>
-    <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
-    </dt><dd>Vancouver, Oxford Athletic Club, 7588 Delaware Lane
+<hr>
+<h2><a name="June14">Tuesday June 14 (Flag Day)</a></h2>
+<dl>
+  <dt><a name="June14:VBC Friends">VANCOUVER BICYCLE CLUB TOUR DE FRIENDS</a>
+  <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
+  </dt><dd>Vancouver, Oxford Athletic Club, 7588 Delaware Lane
 	(One block south of Mill Plain across from Garrison Square)
-    <br>9:00am every Tuesday
-    <br>Join Clay and friends for a leisurely group ride.
+  <br>9:00am every Tuesday
+  <br>Join Clay and friends for a leisurely group ride.
 	Depending on the weather and the group, we may stop for coffee,
 	may do a few more hills, or may go only 10 miles.
 	Who knows?
 	Come ride with Clay - it will be enjoyable.
 	Minor hills, 12mph, Group, 20-30 Miles.
-    <br>Clay Kind, 360-256-1595
-    <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
+  <br>Clay Kind, 360-256-1595
+  <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
 
-    </dd><dt><a name="June14:20 mile">NOON 20 MILE LOOP LUNCH RIDE</a>
-    <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
-    </dt><dd>Vancouver, Clark County Court House (Franklin &amp; 13th St.)
-    <br>12:00pm noon
-    </dd><dd>One hour lunchtime ride out to the end of river road.
+  </dd><dt><a name="June14:20 mile">NOON 20 MILE LOOP LUNCH RIDE</a>
+  <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
+  </dt><dd>Vancouver, Clark County Court House (Franklin &amp; 13th St.)
+  <br>12:00pm noon
+  </dd><dd>One hour lunchtime ride out to the end of river road.
 	Twenty mile flat loop ride designed for training.
 	Speed 16 - 18 mph, non-regroup.
 	FREE.
 	Please RSVP.
-    <br>Monte, 360-696-4421,
+  <br>Monte, 360-696-4421,
 	mhidden<img src="images/at.gif" alt="[at]">pacifier.com
 
-    </dd><dt><a name="June14:CCC-V Volunteer">CCC-VANCOUVER VOLUNTEER NIGHT &amp; BIKE COLLECTION</a>
-    <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
-    </dt><dd>CCC-Vancouver, 8040 E. Mill Plain
-    <br>6:00pm - 8:30pm
-    <br>Volunteer to repair and clean bikes.
+  </dd><dt><a name="June14:CCC-V Volunteer">CCC-VANCOUVER VOLUNTEER NIGHT &amp; BIKE COLLECTION</a>
+  <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
+  </dt><dd>CCC-Vancouver, 8040 E. Mill Plain
+  <br>6:00pm - 8:30pm
+  <br>Volunteer to repair and clean bikes.
 	Bring your old bikes to be recycled at
 	Vancouver's Community Cycling Center
-    <br>Angela McKinney, 360-313-4724,
+  <br>Angela McKinney, 360-313-4724,
 	Vancouver<img src="images/at.gif" alt="[at]">CommunityCyclingCenter.org
 
-    </dd><dt><a name="June14:NoPo Comm.">NO-PO BIKE WORKS COMMUNITY BIKE NIGHT</a>
-    </dt><dd>North Portland Bike Works, 3951 N. Mississippi
-    <br>6:00pm, second Tuesday of every month.
-    <br>Work on your own bike at North Portland Bike Works,
+  </dd><dt><a name="June14:NoPo Comm.">NO-PO BIKE WORKS COMMUNITY BIKE NIGHT</a>
+  </dt><dd>North Portland Bike Works, 3951 N. Mississippi
+  <br>6:00pm, second Tuesday of every month.
+  <br>Work on your own bike at North Portland Bike Works,
 	tools and expertise provided.
-    <br>503-287-1098
-    <br><a href="http://www.npdxbikeworks.org/">http://www.npdxbikeworks.org/</a>
+  <br>503-287-1098
+  <br><a href="http://www.npdxbikeworks.org/">http://www.npdxbikeworks.org/</a>
 
-    </dd><dt><a name="June14:VBC Frenchmans">VANCOUVER BICYCLE CLUB FRENCHMANS BAR RIDE</a>
-    <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
-    </dt><dd>Vancouver, Marshall Center, 1009 E. McLoughlin Blvd.
-    <br>6:00pm every Tuesday
-    <br>Join in for this very popular series.
+  </dd><dt><a name="June14:VBC Frenchmans">VANCOUVER BICYCLE CLUB FRENCHMANS BAR RIDE</a>
+  <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
+  </dt><dd>Vancouver, Marshall Center, 1009 E. McLoughlin Blvd.
+  <br>6:00pm every Tuesday
+  <br>Join in for this very popular series.
 	The route heads through downtown Vancouver on Evergreen
 	and then onto the Mill Plain extension to Lower River Road.
 	There are two options -
@@ -668,13 +668,13 @@ poster-image: "/images/pp/pp2005.jpg"
 	This is mostly a flat route, excellent for those advancing
 	from beginner to intermediate riding.
 	Flat, 14mph, Re-Group, 17-26 miles.
-    <br>Dennis Johnson, 360-576-8781 &amp; Les Mischke, 360-624-3949
-    <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
+  <br>Dennis Johnson, 360-576-8781 &amp; Les Mischke, 360-624-3949
+  <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
 
-    </dd><dt><a name="June14:Pizza Ride">PIZZA NOSTALGIA RIDE</a>
-    </dt><dd>Wallace Park, NW 25th &amp; Raleigh, by Chapman School
-    <br>6:15pm
-    <br>Portland may seem like a pizza wasteland, but never fear, there are
+  </dd><dt><a name="June14:Pizza Ride">PIZZA NOSTALGIA RIDE</a>
+  </dt><dd>Wallace Park, NW 25th &amp; Raleigh, by Chapman School
+  <br>6:15pm
+  <br>Portland may seem like a pizza wasteland, but never fear, there are
 	bastions of thin, run-down-your-chin pies to be found. We'll eat and
 	ride as long as we're able, calling ahead to order cheese pizzas cut
 	into squares (as they were meant to be) so that everyone can eat as
@@ -688,12 +688,12 @@ poster-image: "/images/pp/pp2005.jpg"
 	Bring cash for pizza (cost will depend on number of riders, but will
 	probably be a dollar or two per person per pizza place). RSVP if you
 	can to:
-    <br>pizzaride<img src="images/at.gif" alt="[at]">yahoo.com
+  <br>pizzaride<img src="images/at.gif" alt="[at]">yahoo.com
 
-    </p></dd><dt><a name="June14:PBAC">PORTLAND BIKE ADVISORY COMMITTEE MEETING</a>
-    </dt><dd>City Hall, 1221 SW 4th, Lovejoy Room
-    <br>7:00pm - 9:00pm
-    <br>Come watch policy in action!
+  </p></dd><dt><a name="June14:PBAC">PORTLAND BIKE ADVISORY COMMITTEE MEETING</a>
+  </dt><dd>City Hall, 1221 SW 4th, Lovejoy Room
+  <br>7:00pm - 9:00pm
+  <br>Come watch policy in action!
 	Fun-filled 2 hour meeting about bike policy and practices in
 	the city of Portland.
 	From bike parking to legislative policy to design ideas,
@@ -701,68 +701,68 @@ poster-image: "/images/pp/pp2005.jpg"
 	about everything bicycle related.
 	Everyone is welcome.
 	Note that June 14 is Flag Day!
-    <br><a href="http://www.trans.ci.portland.or.us/bicycles/progstaf.htm">http://www.trans.ci.portland.or.us/bicycles/progstaf.htm</a>
-  </dd></dl>
+  <br><a href="http://www.trans.ci.portland.or.us/bicycles/progstaf.htm">http://www.trans.ci.portland.or.us/bicycles/progstaf.htm</a>
+</dd></dl>
 
-  <hr>
-  <h2><a name="June15">Wednesday June 15</a></h2>
-  <dl>
-    <dt><a name="June15:Breakfast I-205">BREAKFAST OFF THE I-205 BRIDGE</a>
-    <img src="images/ffwa.gif" alt="Family-Friendly" title="Family Friendly, Meet in/around Vancouver" align="left">
-    </dt><dd>Vancouver, North end of the path just off the bridge
-    <br>5:30am - 8:30am
-    <br>Commuter social serving donuts/bagels, coffee, advice, and
+<hr>
+<h2><a name="June15">Wednesday June 15</a></h2>
+<dl>
+  <dt><a name="June15:Breakfast I-205">BREAKFAST OFF THE I-205 BRIDGE</a>
+  <img src="images/ffwa.gif" alt="Family-Friendly" title="Family Friendly, Meet in/around Vancouver" align="left">
+  </dt><dd>Vancouver, North end of the path just off the bridge
+  <br>5:30am - 8:30am
+  <br>Commuter social serving donuts/bagels, coffee, advice, and
 	brochures/maps to bicyclists.
 	Help us record bike traffic for better path sweeping.
-    <br>Ahmad Qayoumi, City of Vancouver, 360-696-8290
+  <br>Ahmad Qayoumi, City of Vancouver, 360-696-8290
 
-    </dd><dt><a name="June15:VBC Earthquake">VANCOUVER BICYCLE CLUB EARTHQUAKE RIDE</a>
-    <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
-    </dt><dd>Vancouver, Marshall Center, 1009 E. McLoughlin
-    <br>9:00am every Wednesday
-    <br>Join Dennis for his Wednesday morning ride heading out of
-	town on reverse RACC to Salmon Creek,
-	down Felida to Salmon Creek trail.
-	Return via Hazel Dell Avenue, Columbia Street,
-	and at the end we get to climb Blandford.
-	Join us for coffee afterwards.
-	Moderate Hills, 14mph, Re-Group, 26 miles.
-    <br>Dennis Funk, 360-571-4454
-    <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
+  </dd><dt><a name="June15:VBC Earthquake">VANCOUVER BICYCLE CLUB EARTHQUAKE RIDE</a>
+  <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
+  </dt><dd>Vancouver, Marshall Center, 1009 E. McLoughlin
+  <br>9:00am every Wednesday
+  <br>Join Dennis for his Wednesday morning ride heading out of
+town on reverse RACC to Salmon Creek,
+down Felida to Salmon Creek trail.
+Return via Hazel Dell Avenue, Columbia Street,
+and at the end we get to climb Blandford.
+Join us for coffee afterwards.
+Moderate Hills, 14mph, Re-Group, 26 miles.
+  <br>Dennis Funk, 360-571-4454
+  <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
 
-    </dd><dt><a name="June15:Mocktails I-205">MOCKTAILS OFF THE I-205 BRIDGE</a>
-    <img src="images/ffwa.gif" alt="FF,WA" title="Family Friendly, Meet in/around Vancouver" align="left">
-    </dt><dd>Vancouver, North end of the path just off the bridge
-    <br>2:30pm - 5:30pm
-    <br>Commuter social serving virgin cocktails and finger food,
+  </dd><dt><a name="June15:Mocktails I-205">MOCKTAILS OFF THE I-205 BRIDGE</a>
+  <img src="images/ffwa.gif" alt="FF,WA" title="Family Friendly, Meet in/around Vancouver" align="left">
+  </dt><dd>Vancouver, North end of the path just off the bridge
+  <br>2:30pm - 5:30pm
+  <br>Commuter social serving virgin cocktails and finger food,
 	advice, brochures &amp; maps to bicyclists.
 	Help us record bike traffic for better path sweeping.
 	FREE.
-    <br>Angela McKinney, 360-313-4724
+  <br>Angela McKinney, 360-313-4724
 
-    </dd><dt><a name="June15:DIY Repair">D.I.Y. BIKE REPAIR AND WASH</a>
-    </dt><dd>SE 13th &amp; Lafayette (5 blocks south of Powell)
-    <br>6:00pm - 9:00pm, preceding the <a href="#June15:Sellwood">Sellwood</a> ride
-    <br>B.Y.O.B. (Bring Your Own Bike!)
+  </dd><dt><a name="June15:DIY Repair">D.I.Y. BIKE REPAIR AND WASH</a>
+  </dt><dd>SE 13th &amp; Lafayette (5 blocks south of Powell)
+  <br>6:00pm - 9:00pm, preceding the <a href="#June15:Sellwood">Sellwood</a> ride
+  <br>B.Y.O.B. (Bring Your Own Bike!)
 	Wash it, fix it, learn from others how to work on your
 	own bike, share what you know of bikes with others.
-    <br>Bethany, postbethany<img src="images/at.gif" alt="[at]">hotmail.com
+  <br>Bethany, postbethany<img src="images/at.gif" alt="[at]">hotmail.com
 
-    </dd><dt><a name="June15:NoPo Womens">NO-PO WOMENS VOLUNTEER NIGHT</a>
-    </dt><dd>North Portland Bike Works, 3951 N. Mississippi
-    <br>6:00pm - 8:00pm
-    <br>Free workshop open to all women and transgendered people;
+  </dd><dt><a name="June15:NoPo Womens">NO-PO WOMENS VOLUNTEER NIGHT</a>
+  </dt><dd>North Portland Bike Works, 3951 N. Mississippi
+  <br>6:00pm - 8:00pm
+  <br>Free workshop open to all women and transgendered people;
 	volunteers are there to provide bike repair help
 	and good company.
 	Every Wednesday.
-    <br>Alex, 503-287-1098
-    <br><a href="http://www.npdxbikeworks.org/">http://www.npdxbikeworks.org/</a>
+  <br>Alex, 503-287-1098
+  <br><a href="http://www.npdxbikeworks.org/">http://www.npdxbikeworks.org/</a>
 
-    </dd><dt><a name="June15:VBC Wednesday">VANCOUVER BICYCLE CLUB WEDNESDAY EVENING RIDE</a>
-    <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
-    </dt><dd>Salmon Creek Fred Meyer Shopping Center just west of the I-5 and I-205 junction, 800 NE Tenney Road
-    <br>6:00pm every Wednesday
-    <br>Routes will vary, depending on the amount of daylight and who
+  </dd><dt><a name="June15:VBC Wednesday">VANCOUVER BICYCLE CLUB WEDNESDAY EVENING RIDE</a>
+  <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
+  </dt><dd>Salmon Creek Fred Meyer Shopping Center just west of the I-5 and I-205 junction, 800 NE Tenney Road
+  <br>6:00pm every Wednesday
+  <br>Routes will vary, depending on the amount of daylight and who
 	is leading the ride that week.
 	We will head mostly north, getting plenty of rollers toward
 	the Fairgrounds and Ridgefield, as well as the occasional
@@ -771,50 +771,50 @@ poster-image: "/images/pp/pp2005.jpg"
 	you choose.
 	Maps will be provided.
 	Moderate to Significant Hills, 16mph, Non-Group, 20-30 miles.
-    <br>Scott Martin, 360-834-6737 &amp; Les Mischke, 360-624-3949
-    <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
+  <br>Scott Martin, 360-834-6737 &amp; Les Mischke, 360-624-3949
+  <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
 
-    </dd><dt><a name="June15:HOB-Nob Ride">HOB-NOB (HIGH OCCUPANCY BIKE)</a>
-    <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
-    </dt><dd>Jamison Square, NW 11th &amp; Kearney
-    <br>7:00pm
-    <br>Bring your tandems, triples, trailers, and cargo bikes
+  </dd><dt><a name="June15:HOB-Nob Ride">HOB-NOB (HIGH OCCUPANCY BIKE)</a>
+  <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
+  </dt><dd>Jamison Square, NW 11th &amp; Kearney
+  <br>7:00pm
+  <br>Bring your tandems, triples, trailers, and cargo bikes
 	to the HOB-nob.
 	A leisurely social ride and sight-seeing tour of interesting,
 	out-of-the-way locations in Portland's west-side.
-    <br>cariewf<img src="images/at.gif" alt="[at]">hotmail.com
+  <br>cariewf<img src="images/at.gif" alt="[at]">hotmail.com
 
-    </dd><dt><a name="June15:CCC Orientation">VOLUNTEER ORIENTATION</a>
-    </dt><dd>Community Cycling Center, 1700 NE Alberta Street
-    <br>7:00pm - 8:00pm
-    <br>Ayleen<img src="images/at.gif" alt="[at]">CommunityCyclingCenter.org, 503-546-8864
+  </dd><dt><a name="June15:CCC Orientation">VOLUNTEER ORIENTATION</a>
+  </dt><dd>Community Cycling Center, 1700 NE Alberta Street
+  <br>7:00pm - 8:00pm
+  <br>Ayleen<img src="images/at.gif" alt="[at]">CommunityCyclingCenter.org, 503-546-8864
 
-    </dd><dt><a name="June15:Sellwood Ride">SUNSET RIDE TO SELLWOOD PARK</a>
-    </dt><dd>Leaves from the D.I.Y. Bike Repair and Wash, SE 13th &amp; Lafayette
-    <br>9:00pm
-    <br>Now that our bikes are all clean and shiny and running better,
+  </dd><dt><a name="June15:Sellwood Ride">SUNSET RIDE TO SELLWOOD PARK</a>
+  </dt><dd>Leaves from the D.I.Y. Bike Repair and Wash, SE 13th &amp; Lafayette
+  <br>9:00pm
+  <br>Now that our bikes are all clean and shiny and running better,
 	we should go for a ride!  An easy 3-4 miles along the river.
-    <br>Bethany, postbethany<img src="images/at.gif" alt="[at]">hotmail.com
+  <br>Bethany, postbethany<img src="images/at.gif" alt="[at]">hotmail.com
 
-  </dd></dl>
+</dd></dl>
 
-  <hr>
-  <h2><a name="June16">Thursday June 16</a></h2>
-  <dl>
-    <dt><a name="June16:Breakfast I-5">BREAKFAST OFF THE I-5 BRIDGE</a>
-    <img src="images/ffwa.gif" alt="FF,WA" title="Family Friendly, Meet in/around Vancouver" align="left">
-    </dt><dd>Vancouver, North&amp;West end of the path just off the bridge
-    <br>5:30am - 8:30am
-    <br>Commuter social serving donuts/bagels, coffee, advice, and
+<hr>
+<h2><a name="June16">Thursday June 16</a></h2>
+<dl>
+  <dt><a name="June16:Breakfast I-5">BREAKFAST OFF THE I-5 BRIDGE</a>
+  <img src="images/ffwa.gif" alt="FF,WA" title="Family Friendly, Meet in/around Vancouver" align="left">
+  </dt><dd>Vancouver, North&amp;West end of the path just off the bridge
+  <br>5:30am - 8:30am
+  <br>Commuter social serving donuts/bagels, coffee, advice, and
 	brochures/maps to bicyclists.
 	Help us record bike traffic for better path sweeping.
-    <br>Chad Kays, Wallis Engineering, 360-695-7041
+  <br>Chad Kays, Wallis Engineering, 360-695-7041
 
-    </dd><dt><a name="June16:20 mile">NOON 20 MILE LOOP LUNCH RIDE</a>
-    <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
-    </dt><dd>Vancouver, Clark County Court House (Franklin &amp; 13th St.)
-    <br>12:00pm noon
-    </dd><dd>The ride will leave form the Gazebo at the County office
+  </dd><dt><a name="June16:20 mile">NOON 20 MILE LOOP LUNCH RIDE</a>
+  <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
+  </dt><dd>Vancouver, Clark County Court House (Franklin &amp; 13th St.)
+  <br>12:00pm noon
+  </dd><dd>The ride will leave form the Gazebo at the County office
 	building and head out to the end of river road.
 	The ride is flat out and back.
 	The speed will be 16-18 MPH and depending on how much time
@@ -825,23 +825,23 @@ poster-image: "/images/pp/pp2005.jpg"
 	we could go a little faster so we get back in one hour,
 	it will depend or how many riders and what they want to do.
 	I am most flexible and want it to be fun.
-    <br>Monte, 360-696-4421,
+  <br>Monte, 360-696-4421,
 	mhidden<img src="images/at.gif" alt="[at]">pacifier.com
 
-    </dd><dt><a name="June16:Mocktails I-5">MOCKTAILS OFF THE INTERSTATE BRIDGE</a>
-    <img src="images/ffwa.gif" alt="FF,WA" title="Family Friendly, Meet in/around Vancouver" align="left">
-    </dt><dd>Vancouver, North &amp; West end of the path just off the I-5 bridge
-    <br>2:30pm - 5:30pm
-    <br>Commuter social serving virgin cocktails and finger food,
+  </dd><dt><a name="June16:Mocktails I-5">MOCKTAILS OFF THE INTERSTATE BRIDGE</a>
+  <img src="images/ffwa.gif" alt="FF,WA" title="Family Friendly, Meet in/around Vancouver" align="left">
+  </dt><dd>Vancouver, North &amp; West end of the path just off the I-5 bridge
+  <br>2:30pm - 5:30pm
+  <br>Commuter social serving virgin cocktails and finger food,
 	advice, brochures &amp; maps to bicyclists.
 	Help us record bike traffic for better path sweeping.
 	FREE.
-    <br>Chad Kays, Wallis Engineering, 360-695-7041
+  <br>Chad Kays, Wallis Engineering, 360-695-7041
 
-    </dd><dt><a name="June16:MW-Represent">MW-REPRESENT EVENT</a>
-    </dt><dd>1158 NE Morton
-    <br>4:00pm - 8:00pm
-    <br>Illinoisians and Wisconsonites; Michiganders, Indianians,
+  </dd><dt><a name="June16:MW-Represent">MW-REPRESENT EVENT</a>
+  </dt><dd>1158 NE Morton
+  <br>4:00pm - 8:00pm
+  <br>Illinoisians and Wisconsonites; Michiganders, Indianians,
 	Ohians; Minnesotans and Missourians;
 	all midwesterners have our own special flair.
 	Out here on the west coast people don't understand.
@@ -859,20 +859,20 @@ poster-image: "/images/pp/pp2005.jpg"
 	and funnest midwest party game.
 	Bring some beverage for the kiddie pool and
 	food to throw on the grill.
-    <br><a href="http://www.YeaBikes.net/mw-represent/">www.YeaBikes.net/mw-represent/</a>
+  <br><a href="http://www.YeaBikes.net/mw-represent/">www.YeaBikes.net/mw-represent/</a>
 
-    </p></dd><dt><a name="June16:Happy Hour">HAPPY HOUR FOR CYCLISTS</a>
-    <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
-    </dt><dd>East end of Hawthorne Bridge
-    <br>4:30pm - 6:30pm
-    <br>Free mocktails and snacks for cyclists and walkers.
-    <br>Amy Stork, amy<img src="images/at.gif" alt="[at]">storkmarketing.com
+  </p></dd><dt><a name="June16:Happy Hour">HAPPY HOUR FOR CYCLISTS</a>
+  <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
+  </dt><dd>East end of Hawthorne Bridge
+  <br>4:30pm - 6:30pm
+  <br>Free mocktails and snacks for cyclists and walkers.
+  <br>Amy Stork, amy<img src="images/at.gif" alt="[at]">storkmarketing.com
 
-    </dd><dt><a name="June16:VBC Thursday">VANCOUVER BICYCLE CLUB THURSDAY EVENING RIDE</a>
-    <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
-    </dt><dd>Vancouver, Marshall Center, 1009 E. McLoughlin
-    <br>6:00pm every Thursday
-    <br>Join Pete or Jim for this Thursday evening ride following
+  </dd><dt><a name="June16:VBC Thursday">VANCOUVER BICYCLE CLUB THURSDAY EVENING RIDE</a>
+  <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
+  </dt><dd>Vancouver, Marshall Center, 1009 E. McLoughlin
+  <br>6:00pm every Thursday
+  <br>Join Pete or Jim for this Thursday evening ride following
 	the RACC route towards 164th Avenue,
 	head south to SE Cascade Park Drive, and
 	follow the "low road" back to the start.
@@ -882,82 +882,82 @@ poster-image: "/images/pp/pp2005.jpg"
 	In case of rain we will hand out cue sheets and wish you well.
 	Make this ride part of your weekly ritual.
 	Minor Hills, 12mph, Re-group, 22 miles.
-    <br>Pete Lyall, 360-604-3124 &amp; Jim Ryan, 360-256-4354
-    <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
+  <br>Pete Lyall, 360-604-3124 &amp; Jim Ryan, 360-256-4354
+  <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
 
-    </dd><dt><a name="June16:VBC Time Trial">VANCOUVER BICYCLE CLUB TIME TRIAL SERIES</a>
-    <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
-    </dt><dd>Port of Vancouver office, 3103 NW Lower River Road, Vancouver WA
-    <br>6:30pm (sign in at 6:15pm)
-    <br>A flat 10-mile course.
+  </dd><dt><a name="June16:VBC Time Trial">VANCOUVER BICYCLE CLUB TIME TRIAL SERIES</a>
+  <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
+  </dt><dd>Port of Vancouver office, 3103 NW Lower River Road, Vancouver WA
+  <br>6:30pm (sign in at 6:15pm)
+  <br>A flat 10-mile course.
 	Open to all! $1.00 entry fee; VBC members are FREE!
-    <br>Mike Lusby, 360-750-4875,
+  <br>Mike Lusby, 360-750-4875,
 	vbctt<img src="images/at.gif" alt="[at]">netzero.net
-    <br><a href="http://www.vancouverbicycleclub.com/trials.html">http://www.vancouverbicycleclub.com/trials.html</a>
+  <br><a href="http://www.vancouverbicycleclub.com/trials.html">http://www.vancouverbicycleclub.com/trials.html</a>
 
-    </dd><dt><a name="June16:CCC Women's">WOMEN'S VOLUNTEER NIGHT</a>
-    </dt><dd>Community Cycling Center, 1700 NE Alberta Street
-    <br>7:00pm - 9:30pm
-    <br>Learn about bike repair in a super supportive setting.
-    <br>Ayleen<img src="images/at.gif" alt="[at]">CommunityCyclingCenter.org, 503-546-8864
+  </dd><dt><a name="June16:CCC Women's">WOMEN'S VOLUNTEER NIGHT</a>
+  </dt><dd>Community Cycling Center, 1700 NE Alberta Street
+  <br>7:00pm - 9:30pm
+  <br>Learn about bike repair in a super supportive setting.
+  <br>Ayleen<img src="images/at.gif" alt="[at]">CommunityCyclingCenter.org, 503-546-8864
 
-    </dd><dt><a name="June16:Martini Tour">MARTINI TOUR</a>
-    <img src="images/beerwa.gif" alt="21+,WA" title="Adult Only (21+), Meet in/near Vancouver" align="left">
-    </dt><dd>Vancouver WA.,
+  </dd><dt><a name="June16:Martini Tour">MARTINI TOUR</a>
+  <img src="images/beerwa.gif" alt="21+,WA" title="Adult Only (21+), Meet in/near Vancouver" align="left">
+  </dt><dd>Vancouver WA.,
 	Tiger Bar, 312 W. 8th St., across from Ester Short Park
-    <br>7:00pm for pre-ride gnash and libations;
+  <br>7:00pm for pre-ride gnash and libations;
 	we will leave shaken or stirred 7:45pm
-    <br>Riders are destined for two other stops on the tour
+  <br>Riders are destined for two other stops on the tour
 	(Beaches and the Commander Whiskey and Wine Bar at the
 	Historic Reserve).
 	Loop back to the beginning or rouse the group into
 	visiting your favorite night spot.
 	For 21+, but non-drinking respected.
-    <br>angelamechanic<img src="images/at.gif" alt="[at]">hotmail.com
+  <br>angelamechanic<img src="images/at.gif" alt="[at]">hotmail.com
 
-    </dd><dt><a name="June16:Toga Ride">TOGA RIDE</a>
-    </dt><dd>The Slammer, 500 SE 8th
-    <br>8:00pm
-    <br>Come to enjoy an evening ride dressed as your
+  </dd><dt><a name="June16:Toga Ride">TOGA RIDE</a>
+  </dt><dd>The Slammer, 500 SE 8th
+  <br>8:00pm
+  <br>Come to enjoy an evening ride dressed as your
 	favorite mythical greek god/goddess.
 	Carefully fly low above the tarmac for a
 	short but adventurous ride in p-town.
-    <br>dan_mudpuddle<img src="images/at.gif" alt="[at]">yahoo.com
+  <br>dan_mudpuddle<img src="images/at.gif" alt="[at]">yahoo.com
 
-    </dd><dt><a name="June16:Bike Movie">BIKE TO BIKE MOVIE IN VANCOUVER</a>
-    </dt><dd>Expo MAX Station (North end of Yellow Line) in Portland
-    <br>9:30pm
-    <br>Bike to a bike movie in Downtown Vancouver,
+  </dd><dt><a name="June16:Bike Movie">BIKE TO BIKE MOVIE IN VANCOUVER</a>
+  </dt><dd>Expo MAX Station (North end of Yellow Line) in Portland
+  <br>9:30pm
+  <br>Bike to a bike movie in Downtown Vancouver,
 	317 Columbia Blvd - 10 minute ride from EXPO stop.
 	Outside parking lot showing.
 	FREE
-    <br>Chad Kays, Wallis Engineering, 360-695-7041
-  </dd></dl>
+  <br>Chad Kays, Wallis Engineering, 360-695-7041
+</dd></dl>
 
-  <hr>
-  <h2><a name="June17">Friday June 17</a></h2>
-  <dl>
-    <dt><a name="June17:BonB">BREAKFAST ON THE BRIDGES</a>
-    <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
-    </dt><dd>Broadway &amp; Hawthorne Bridges (Westbound Sides)
-    <br>7:00am - 9:00am
-    <br>Ride the Bridge, eat a nosh, have a cawfee. No big whoop
-    <br>timolandia<img src="images/at.gif" alt="[at]">shifttobikes.org
+<hr>
+<h2><a name="June17">Friday June 17</a></h2>
+<dl>
+  <dt><a name="June17:BonB">BREAKFAST ON THE BRIDGES</a>
+  <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
+  </dt><dd>Broadway &amp; Hawthorne Bridges (Westbound Sides)
+  <br>7:00am - 9:00am
+  <br>Ride the Bridge, eat a nosh, have a cawfee. No big whoop
+  <br>timolandia<img src="images/at.gif" alt="[at]">shifttobikes.org
 
-    </dd><dt><a name="June17:Friday Family">FRIDAY FAMILY RIDE</a>
-    <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
-    </dt><dd>Bike Gallery Woodstock, 4235 SE Woodstock
-    <br>10:00am - 12:00pm noon, first &amp; third Fridays.
-    <br>Ride and play group for families (pre-school age kids).
+  </dd><dt><a name="June17:Friday Family">FRIDAY FAMILY RIDE</a>
+  <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
+  </dt><dd>Bike Gallery Woodstock, 4235 SE Woodstock
+  <br>10:00am - 12:00pm noon, first &amp; third Fridays.
+  <br>Ride and play group for families (pre-school age kids).
 	2 - 10 miles.
-    <br>503-774-3531
-    <br><a href="http://www.bikegallery.com/">www.bikegallery.com</a>
+  <br>503-774-3531
+  <br><a href="http://www.bikegallery.com/">www.bikegallery.com</a>
 
-    </dd><dt><a name="June17:Small Museums I">SMALL MUSEUMS &amp; COLLECTIONS TOUR I</a>
-    <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
-    </dt><dd>Old Town Pizza, 226 NW Davis
-    <br>12:00pm noon, ride leaves at 1:00pm (length 3 hours)
-    <br>Tour I: Join Carye Bye, director of the Bathtub Art Museum,
+  </dd><dt><a name="June17:Small Museums I">SMALL MUSEUMS &amp; COLLECTIONS TOUR I</a>
+  <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
+  </dt><dd>Old Town Pizza, 226 NW Davis
+  <br>12:00pm noon, ride leaves at 1:00pm (length 3 hours)
+  <br>Tour I: Join Carye Bye, director of the Bathtub Art Museum,
 	on a bicycle tour of small museums located in and around
 	Old Town.
 	We won't cover a lot of ground, but the number &amp; diversity
@@ -965,34 +965,34 @@ poster-image: "/images/pp/pp2005.jpg"
 	Bring a few dollars for museum donation boxes.
 	Come early for lunch.
 <br>Carye Bye, 503-248-4454,
-	info<img src="images/at.gif" alt="[at]">bathtubmuseum.org
+info<img src="images/at.gif" alt="[at]">bathtubmuseum.org
 
-    </dd><dt><a name="June17:Kiss-In">BIKE KISS-IN</a>
-    </dt><dd>City Bikes Mothershop, 1914 SE Ankeny
-    <br>5:00pm, leaving to destination at 5:15pm
-    <br>Let's show 'em that bikes really do have more fun.
-	Bring your own kissing partner (mints will be provided)
-	to this make-out "demonstration" of bike love!
-	Meet at 5pm at City Bikes  at 5:15 we'll ride to our nearby,
-	heavily car-trafficked, destination.
-    <br>ecmarsh<img src="images/at.gif" alt="[at]">gmail.com
+  </dd><dt><a name="June17:Kiss-In">BIKE KISS-IN</a>
+  </dt><dd>City Bikes Mothershop, 1914 SE Ankeny
+  <br>5:00pm, leaving to destination at 5:15pm
+  <br>Let's show 'em that bikes really do have more fun.
+Bring your own kissing partner (mints will be provided)
+to this make-out "demonstration" of bike love!
+Meet at 5pm at City Bikes  at 5:15 we'll ride to our nearby,
+heavily car-trafficked, destination.
+  <br>ecmarsh<img src="images/at.gif" alt="[at]">gmail.com
 
-    </dd><dt><a name="June17:Pub Crawl">BICYCLE PUB CRAWL</a>
-    <img src="/images/legacy/beer.gif" alt="21+" title="Adult Only (21+)" align="left">
-    </dt><dd>Bitter End Pub, 1981 W. Burnside
-    <br>7:00pm
-    <br>Third Friday pub crawl by bike. Be responsible.
-    <br>Ms. Pez, agent.lapis<img src="images/at.gif" alt="[at]">gmail.com
-  </dd></dl>
+  </dd><dt><a name="June17:Pub Crawl">BICYCLE PUB CRAWL</a>
+  <img src="/images/legacy/beer.gif" alt="21+" title="Adult Only (21+)" align="left">
+  </dt><dd>Bitter End Pub, 1981 W. Burnside
+  <br>7:00pm
+  <br>Third Friday pub crawl by bike. Be responsible.
+  <br>Ms. Pez, agent.lapis<img src="images/at.gif" alt="[at]">gmail.com
+</dd></dl>
 
-  <hr>
-  <h2><a name="June18">Saturday June 18</a></h2>
-  <dl>
-    <dt><a name="June18:Scavenger Hunt">BIKE SCAVENGER HUNT</a>
-    <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
-    </dt><dd>River City Bicycles, 706 SE MLK Blvd.
-    <br>9:00am - 1:00pm
-    <br>Explore the Rose City's streets by bicycle in a
+<hr>
+<h2><a name="June18">Saturday June 18</a></h2>
+<dl>
+  <dt><a name="June18:Scavenger Hunt">BIKE SCAVENGER HUNT</a>
+  <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
+  </dt><dd>River City Bicycles, 706 SE MLK Blvd.
+  <br>9:00am - 1:00pm
+  <br>Explore the Rose City's streets by bicycle in a
 	family-friendly search that will bring you to known and
 	lesser-known locales around Portland. Bring your local
 	knowledge, your friends and family, your bicycle and
@@ -1001,38 +1001,38 @@ poster-image: "/images/pp/pp2005.jpg"
 	the world that is Portland, Oregon.
 	Registration is $12 in advance, $15 day-of,
 	proceeds to benefit the BTA.
-    <br>David Ross, (503) 281-3794,
+  <br>David Ross, (503) 281-3794,
 	dave<img src="images/at.gif" alt="[at]">ross.name,
 	<a href="http://www.bikescavengerhunt.org/">www.bikescavengerhunt.org</a>
 
-    </dd><dt><a name="June18:Family Fun Ride">FAMILY FUN RIDE</a>
-    <img src="images/ffwa.gif" alt="FF,WA" title="Family Friendly, Meet in/around Vancouver" align="left">
-    </dt><dd>Vancouver, Ester Short Park, meet near the clock tower
-    <br>10:00am - 1:00pm
-    <br>Come decorate your bike and helmet and celebrate summer fun.
+  </dd><dt><a name="June18:Family Fun Ride">FAMILY FUN RIDE</a>
+  <img src="images/ffwa.gif" alt="FF,WA" title="Family Friendly, Meet in/around Vancouver" align="left">
+  </dt><dd>Vancouver, Ester Short Park, meet near the clock tower
+  <br>10:00am - 1:00pm
+  <br>Come decorate your bike and helmet and celebrate summer fun.
 	Some supplies provided, but bring more to share.
 	Bike ride leaves at 10:45am for a mellow 3 mile loop.
 	Trailers, tagalongs and tandems welcome.
 	Not suitable for training wheels and tricycles.
-    <br>angelamechanic<img src="images/at.gif" alt="[at]">hotmail.com
+  <br>angelamechanic<img src="images/at.gif" alt="[at]">hotmail.com
 
-    </dd><dt><a name="June18:Bike Art">CCC-VANCOUVER BIKE ART DAY</a>
-    <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
-    </dt><dd>Community Cycling Center - Vancouver, 8040 E. Mill Plain
-    <br>10:00am - 2:00pm (Same as VOLUNTEER DAY)
-    <br>Don't throw that junky bike away!
+  </dd><dt><a name="June18:Bike Art">CCC-VANCOUVER BIKE ART DAY</a>
+  <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
+  </dt><dd>Community Cycling Center - Vancouver, 8040 E. Mill Plain
+  <br>10:00am - 2:00pm (Same as VOLUNTEER DAY)
+  <br>Don't throw that junky bike away!
 	Make wind chimes, bracelets, belts and more.
 	Don't know how?  We'll show you!
 	Join CCC Recycling Coordinator Justin Valls for
 	an afternoon of bike art creations,
 	and take something home with you.
-    <br>Vancouver<img src="images/at.gif" alt="[at]">CommunityCyclingCenter.org, 503-871-0120
+  <br>Vancouver<img src="images/at.gif" alt="[at]">CommunityCyclingCenter.org, 503-871-0120
 
-    </dd><dt><a name="June18:Juke Off">THE SECOND MORE THAN ANNUAL JUKE OFF BOOZE CRUISE</a>
-    <img src="/images/legacy/beer.gif" alt="21+" title="Adult Only (21+)" align="left">
-    </dt><dd>The 'Vern (Hanigan's), 2622 SE Belmont
-    <br>3:00pm, ending at thE CloWn HouSe event
-    <br>A contest to see which bar has the best jukebox in town.
+  </dd><dt><a name="June18:Juke Off">THE SECOND MORE THAN ANNUAL JUKE OFF BOOZE CRUISE</a>
+  <img src="/images/legacy/beer.gif" alt="21+" title="Adult Only (21+)" align="left">
+  </dt><dd>The 'Vern (Hanigan's), 2622 SE Belmont
+  <br>3:00pm, ending at thE CloWn HouSe event
+  <br>A contest to see which bar has the best jukebox in town.
 	Last ride, the Vern won.
 	This year, we're starting there and heading west... I think.
 	A tribunal of jukebox snobs will be scoring each juke
@@ -1045,13 +1045,13 @@ poster-image: "/images/pp/pp2005.jpg"
 	<a href="http://www.ridemybike.org/">ridemybike.org</a>
 	under the '<tt>juke off booze cruise</tt>' board
 	to be considered for the route.
-    <br>Sam, yeahyeahsam<img src="images/at.gif" alt="[at]">hotmail.com
+  <br>Sam, yeahyeahsam<img src="images/at.gif" alt="[at]">hotmail.com
 
-    </dd><dt><a name="June18:Clown House">GENERAL BIKE CIRCUS MAYHEM AT THE CLOWN HOUSE</a>
-    <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
-    </dt><dd>Clown House, 2425 NE Alberta
-    <br>7:30pm - 10:30pm
-    <br>the clowns who brought you "The Big Bang Cirkus,"
+  </dd><dt><a name="June18:Clown House">GENERAL BIKE CIRCUS MAYHEM AT THE CLOWN HOUSE</a>
+  <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
+  </dt><dd>Clown House, 2425 NE Alberta
+  <br>7:30pm - 10:30pm
+  <br>the clowns who brought you "The Big Bang Cirkus,"
 	Portland's Pepto Dizmal Clownarchy, are happy to
 	bring you "GeneRal bIke CircUs MayhEm aT thE CloWn
 	HouSe!" Come join us in the yard at The Clown House, as
@@ -1065,69 +1065,69 @@ poster-image: "/images/pp/pp2005.jpg"
 	(or walk) down the street for "Bike Shorts At The Know"
 	for 21-and-over beers and CrAzY bike movies. After that
 	we don't care what you do, just don't blame us.
-    <br>Dingo, dawgsnax<img src="images/at.gif" alt="[at]">fastmail.fm
+  <br>Dingo, dawgsnax<img src="images/at.gif" alt="[at]">fastmail.fm
 
-    </dd><dt><a name="June18:Crazy Shorts">CRAZY BIKE SHORTS AT THE KNOW</a>
-    <img src="/images/legacy/beer.gif" alt="21+" title="Adult Only (21+)" align="left">
-    </dt><dd>The Know, 2022 NE Alberta
-    <br>10:30pm
-    <br>After taking in the Rodeo Circus at the CloWn HouSe,
+  </dd><dt><a name="June18:Crazy Shorts">CRAZY BIKE SHORTS AT THE KNOW</a>
+  <img src="/images/legacy/beer.gif" alt="21+" title="Adult Only (21+)" align="left">
+  </dt><dd>The Know, 2022 NE Alberta
+  <br>10:30pm
+  <br>After taking in the Rodeo Circus at the CloWn HouSe,
 	head down to The Know for Crazy Bike Flicks and beer.
 	21+
-    <br>Dingo, dawgsnax<img src="images/at.gif" alt="[at]">fastmail.fm
+  <br>Dingo, dawgsnax<img src="images/at.gif" alt="[at]">fastmail.fm
 
-  </dd></dl>
+</dd></dl>
 
-  <hr>
-  <h2><a name="June19">Sunday June 19 (Fathers Day)</a></h2>
-  <dl>
-    <dt><a name="June19:River Bomb">WILLAMETTE RIVER BOMB</a>
-    </dt><dd>Irvington Park, NE 7th &amp; Fremont
-    <br>7:03am <em>sharp</em>
-    <br>Bring your big bike with the tall gears for the fastest bomb
+<hr>
+<h2><a name="June19">Sunday June 19 (Fathers Day)</a></h2>
+<dl>
+  <dt><a name="June19:River Bomb">WILLAMETTE RIVER BOMB</a>
+  </dt><dd>Irvington Park, NE 7th &amp; Fremont
+  <br>7:03am <em>sharp</em>
+  <br>Bring your big bike with the tall gears for the fastest bomb
 	in Portland.
 	Breakfast and libations to follow.
 	Bail money recommended.
-    <br>Hosted by the Cougars
+  <br>Hosted by the Cougars
 
-    </dd><dt><a name="June19:VBC 2 Bridge">VANCOUVER BICYCLE CLUB TWO BRIDGE LOOP</a>
-    <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
-    </dt><dd>Sunrise Bagels, 808 Harney Street
-    <br>9:00am
-    <br>This enjoyable VBC staple goes east on McLoughlin,
+  </dd><dt><a name="June19:VBC 2 Bridge">VANCOUVER BICYCLE CLUB TWO BRIDGE LOOP</a>
+  <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
+  </dt><dd>Sunrise Bagels, 808 Harney Street
+  <br>9:00am
+  <br>This enjoyable VBC staple goes east on McLoughlin,
 	south across the I-205 bridge, west along Marine Drive,
 	then north across the I-5 Bridge to Sunrise,
 	where we usually all have a bagel after the ride.
 	Please park on the street, not in the Sunrise lot.
 	Minor hills, 12mph, Re-group, 22miles.
-    <br>Clay Kind, 360-256-1595
-    <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
+  <br>Clay Kind, 360-256-1595
+  <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
 
-    </dd><dt><a name="June19:Skilled Mech">SKILLED MECHANICS VOLUNTEER DAY</a>
-    </dt><dd>Community Cycling Center, 1700 NE Alberta Street
-    <br>10:00am - 2:00pm
-    <br>Spend a day sharing your skills and wrenching on bikes with
-    the CCC.  Lunch, tools and stands provided.
-    <br>Ayleen<img src="images/at.gif" alt="[at]">CommunityCyclingCenter.org, 503-546-8864
+  </dd><dt><a name="June19:Skilled Mech">SKILLED MECHANICS VOLUNTEER DAY</a>
+  </dt><dd>Community Cycling Center, 1700 NE Alberta Street
+  <br>10:00am - 2:00pm
+  <br>Spend a day sharing your skills and wrenching on bikes with
+  the CCC.  Lunch, tools and stands provided.
+  <br>Ayleen<img src="images/at.gif" alt="[at]">CommunityCyclingCenter.org, 503-546-8864
 
-    </dd><dt><a name="June19:Rose Ride">SLUG VELO THIRD ANNUAL ROSE RIDE</a>
-    <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
-    </dt><dd>Peninsula Rose Garden, N. Ainsworth at Albina
-    <br>10:30am
-    <br>About 10 ~ 15 miles.
+  </dd><dt><a name="June19:Rose Ride">SLUG VELO THIRD ANNUAL ROSE RIDE</a>
+  <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
+  </dt><dd>Peninsula Rose Garden, N. Ainsworth at Albina
+  <br>10:30am
+  <br>About 10 ~ 15 miles.
 	Dig the flora as we check out rose gardens both public
 	and residential on this eastside ride.
 	Decorate your bike with roses, real or fake!
 	Bring money for lunch at the end of the ride,
 	and/or snacks to nibble along the way.
 	<em>Helmets required.</em>
-    <br><a href="http://www.slugvelo.com/">http://www.slugvelo.com/</a>
+  <br><a href="http://www.slugvelo.com/">http://www.slugvelo.com/</a>
 
-    </dd><dt><a name="June19:Fathers Day">FATHERS DAY TRAILER KIDS PARK TOUR</a>
-    <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
-    </dt><dd>Wilshire Park, NE 35th and Skidmore, at the sandbox
-    <br>11:00am, leaving for next park at 12:00pm noon
-    <br>Hitch up the trailer and grab the kids,
+  </dd><dt><a name="June19:Fathers Day">FATHERS DAY TRAILER KIDS PARK TOUR</a>
+  <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
+  </dt><dd>Wilshire Park, NE 35th and Skidmore, at the sandbox
+  <br>11:00am, leaving for next park at 12:00pm noon
+  <br>Hitch up the trailer and grab the kids,
 	we're going to the park by bike!
 	We will travel to a few parks, the ride ending when our
 	interest fades.
@@ -1136,12 +1136,12 @@ poster-image: "/images/pp/pp2005.jpg"
 	We will want to cover some ground, so only tag-along bikes,
 	tandems, and trailers.
 	Ride leaves for next park at 12:00 pm.
-    <br>patrickb<img src="images/at.gif" alt="[at]">portlandrainbarrels.com
+  <br>patrickb<img src="images/at.gif" alt="[at]">portlandrainbarrels.com
 
-    </dd><dt><a name="June19:Womens Polo">POLO: EMPOWERED BY BIG STICKS</a>
-    </dt><dd>North Portland Bike Works, 3951 N. Mississippi
-    <br>12:00pm noon - 3:00pm
-    <br>A women and trans polo bike building workshop.
+  </dd><dt><a name="June19:Womens Polo">POLO: EMPOWERED BY BIG STICKS</a>
+  </dt><dd>North Portland Bike Works, 3951 N. Mississippi
+  <br>12:00pm noon - 3:00pm
+  <br>A women and trans polo bike building workshop.
 	Come create your own little monster for the polo court.
 	Based on the infamous "Sassy" and "Masquerade" bikes,
 	we'll convert your bike into a lean, mean, bike hockey machine.
@@ -1152,23 +1152,23 @@ poster-image: "/images/pp/pp2005.jpg"
 	for you, and may even be able to help find you a bike.
 	Afterwards we'll ride our new creations to Alberta Park for
 	some hot polo action.
-    <br>Tori, 503-287-1098,
+  <br>Tori, 503-287-1098,
 	gracieswrench<img src="images/at.gif" alt="[at]">gmail.com,
 
 
-    </dd><dt><a name="June19:Heritage Tree Ride">HERITAGE TREE TOUR</a>
-    <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
-    </dt><dd>DaVinci Arts Middle School, 2508 NE Everett St.
-    <br>1:00pm, lasting about 1.5 - 2 hours
-    <br>This will be a leisurely bike ride visiting
+  </dd><dt><a name="June19:Heritage Tree Ride">HERITAGE TREE TOUR</a>
+  <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
+  </dt><dd>DaVinci Arts Middle School, 2508 NE Everett St.
+  <br>1:00pm, lasting about 1.5 - 2 hours
+  <br>This will be a leisurely bike ride visiting
 	Portland Heritage Trees in the Laurelhurst area.
 	Join us and learn about these botantical treasures!
-    <br>Emily, mlemily<img src="images/at.gif" alt="[at]">gmail.com
+  <br>Emily, mlemily<img src="images/at.gif" alt="[at]">gmail.com
 
-    </dd><dt><a name="June19:Bike Polo">BIKE POLO</a>
-    </dt><dd>Alberta Park, NE 21st and Killingsworth
-    <br>3:00pm until dark
-    <br>Mayhem in the cage!
+  </dd><dt><a name="June19:Bike Polo">BIKE POLO</a>
+  </dt><dd>Alberta Park, NE 21st and Killingsworth
+  <br>3:00pm until dark
+  <br>Mayhem in the cage!
 	This is the real deal!
 	Free for all!
 	Pick-up games and more.
@@ -1176,34 +1176,34 @@ poster-image: "/images/pp/pp2005.jpg"
 	If yr not a hippie, you actually like this!
 	NOT FAMILY FRIENDLY -the kids WILL pick up bad habits from
 	watching us.
-    <br>BLDZR, bill<img src="images/at.gif" alt="[at]">axlesofevil.org
-    <br><a href="http://www.axlesofevil.org">www.axlesofevil.org</a>
+  <br>BLDZR, bill<img src="images/at.gif" alt="[at]">axlesofevil.org
+  <br><a href="http://www.axlesofevil.org">www.axlesofevil.org</a>
 
-    </dd><dt><a name="June19:Zoobomb">ZOOBOMB</a>
-    </dt><dd>Roccos Pizza, 949 SW Oak St
-    <br>8:30pm
-    <br>Ride the Max to the zoo with your bike and zoobomb down. Costumes and little bikes optional.
-    <br><a href="http://www.zoobomb.org/">www.zoobomb.org</a>
-  </dd></dl>
+  </dd><dt><a name="June19:Zoobomb">ZOOBOMB</a>
+  </dt><dd>Roccos Pizza, 949 SW Oak St
+  <br>8:30pm
+  <br>Ride the Max to the zoo with your bike and zoobomb down. Costumes and little bikes optional.
+  <br><a href="http://www.zoobomb.org/">www.zoobomb.org</a>
+</dd></dl>
 
-  <hr>
-  <h2><a name="June20">Monday June 20 (Summer Solstice)</a></h2>
-  <dl>
-    <dt><a name="June20:Seattle Tour">BIKESTATION SEATTLE DAY TOUR BY TRAIN</a>
-    </dt><dd>Portland Amtrak Station
-    <br>8:00am - 9:00pm
-    <br>Visit the best bike parking facility
+<hr>
+<h2><a name="June20">Monday June 20 (Summer Solstice)</a></h2>
+<dl>
+  <dt><a name="June20:Seattle Tour">BIKESTATION SEATTLE DAY TOUR BY TRAIN</a>
+  </dt><dd>Portland Amtrak Station
+  <br>8:00am - 9:00pm
+  <br>Visit the best bike parking facility
 	and see what our future bike facilities should look like here.
 	Register one week in advance via email.
 	Contact also for August tour.
-    <br>Todd Boulanger, 360-281-0944,
+  <br>Todd Boulanger, 360-281-0944,
 	oulanger<img src="images/at.gif" alt="[at]">excite.com
-    <br><a href="http://www.bikestation.org">www.bikestation.org</a>
+  <br><a href="http://www.bikestation.org">www.bikestation.org</a>
 
-    </dd><dt><a name="June20:Monday Race">MONDAY NIGHT RACES</a>
-    </dt><dd>Portland International Raceway, 1940 N. Victory Blvd.
-    <br>5:00pm
-    <br>Ever wish you could ride your bike on a car racetrack?
+  </dd><dt><a name="June20:Monday Race">MONDAY NIGHT RACES</a>
+  </dt><dd>Portland International Raceway, 1940 N. Victory Blvd.
+  <br>5:00pm
+  <br>Ever wish you could ride your bike on a car racetrack?
 	Well, now you can!
 	The Lakeside Bicycles Monday Night Masters and Women race series
 	starts another exciting year of racing in May through August.
@@ -1212,112 +1212,112 @@ poster-image: "/images/pp/pp2005.jpg"
 	this year's summer series is looking to be great!
 	OBRA licenses available (single-day $5 or annual $15).
 	Racing fee is $12, or $5 for Jr. Women.
-    <br><a href="http://www.racemondaynight.com">http://www.racemondaynight.com</a>
+  <br><a href="http://www.racemondaynight.com">http://www.racemondaynight.com</a>
 
-    </dd><dt><a name="June20:VBC East Cty.">VANCOUVER BICYCLE CLUB EAST COUNTY EXPLORER</a>
-    <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
-    </dt><dd>Lacamas Swim &amp; Sport, 2950 NW 38th Avenue, Camas
-    <br>6:00pm every Monday
-    <br>We will offer varying routes around the Camas or Washougal area,
+  </dd><dt><a name="June20:VBC East Cty.">VANCOUVER BICYCLE CLUB EAST COUNTY EXPLORER</a>
+  <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
+  </dt><dd>Lacamas Swim &amp; Sport, 2950 NW 38th Avenue, Camas
+  <br>6:00pm every Monday
+  <br>We will offer varying routes around the Camas or Washougal area,
 	most of the time including climbs of Crown Road and Prune Hill.
 	Moderate hills, 16mph, Non-Group, 22-31 Miles.
-    <br>Scott Martin &amp; Ayla Gokturk, 360-834-6737
-    <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
+  <br>Scott Martin &amp; Ayla Gokturk, 360-834-6737
+  <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
 
-    </dd><dt><a name="June20:Coffee Ride">MONDAY NIGHT COFFEE RIDE</a>
-    <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
-    </dt><dd>Bike Gallery Hollywood, 5329 NE Sandy Blvd.
-    <br>6:00pm (every Monday)
-    <br>Social ride to a coffee shop.
-    <br>503-281-9800
-    <br><a href="http://www.bikegallery.com/">www.bikegallery.com</a>
+  </dd><dt><a name="June20:Coffee Ride">MONDAY NIGHT COFFEE RIDE</a>
+  <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
+  </dt><dd>Bike Gallery Hollywood, 5329 NE Sandy Blvd.
+  <br>6:00pm (every Monday)
+  <br>Social ride to a coffee shop.
+  <br>503-281-9800
+  <br><a href="http://www.bikegallery.com/">www.bikegallery.com</a>
 
-    </dd><dt><a name="June20:Clark Map">MAKIN' MAPS - UPDATING CLARK BIKE MAP</a>
-    <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
-    </dt><dd>Vancouver, 1300 Franklin, 4th floor
-    <br>6:00pm - 7:30pm
-    <br>Hey you in that bike lane!
+  </dd><dt><a name="June20:Clark Map">MAKIN' MAPS - UPDATING CLARK BIKE MAP</a>
+  <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
+  </dt><dd>Vancouver, 1300 Franklin, 4th floor
+  <br>6:00pm - 7:30pm
+  <br>Hey you in that bike lane!
 	It's time to update your local bike map.
 	Join the Clark County Bicycle Advisory Committee in this
 	victorious task.
 	FREE
-    <br>Ejaz Khan, Clark County, ejaz.khan<img src="images/at.gif" alt="[at]">co.county.wa.us
+  <br>Ejaz Khan, Clark County, ejaz.khan<img src="images/at.gif" alt="[at]">co.county.wa.us
 
-    </dd><dt><a name="June20:Framebuilding">FRAMEBUILDING WORKSHOP WITH SACHA WHITE</a>
-    </dt><dd>Vanilla Bicycles Workshop, 3450 SE Alder St.
-    <br>6:00pm - 9:00pm
-    <br>Local frame-builder Sacha White opens his shop to anyone
+  </dd><dt><a name="June20:Framebuilding">FRAMEBUILDING WORKSHOP WITH SACHA WHITE</a>
+  </dt><dd>Vanilla Bicycles Workshop, 3450 SE Alder St.
+  <br>6:00pm - 9:00pm
+  <br>Local frame-builder Sacha White opens his shop to anyone
 	interested in learning about how bike frames are made.
 	Sacha will go through all stages including
 	tube selection, preparation and welding.
 	Drinks will be provided.
-    <br>Sacha White, 971-570-3244,
+  <br>Sacha White, 971-570-3244,
 	vanillabicycles<img src="images/at.gif" alt="[at]">hotmail.com
-    <br><a href="http://www.vanillabicycles.com">www.vanillabicycles.com</a>
+  <br><a href="http://www.vanillabicycles.com">www.vanillabicycles.com</a>
 
-    </dd><dt><a name="June20:Tennis">BIKE TO TENNIS</a>
-    </dt><dd>Eastbank Esplanade at Hawthorne Bridge
-    <br>6:15pm
-    <br>Evening ride to play a game of casual tennis.
+  </dd><dt><a name="June20:Tennis">BIKE TO TENNIS</a>
+  </dt><dd>Eastbank Esplanade at Hawthorne Bridge
+  <br>6:15pm
+  <br>Evening ride to play a game of casual tennis.
 	Wear your whites and bring a racket and/or balls
 	if you have them.
 	Canceled if raining.
 	Love/Love
-    <br>Carye Bye, 503-248-4454,
+  <br>Carye Bye, 503-248-4454,
 	caryebye<img src="images/at.gif" alt="[at]">redbatpress.com
 
-    </dd><dt><a name="June20:Shortest Night">SHORTEST NIGHT OF THE YEAR RIDE</a>
-    </dt><dd>Peoples' Food Co-op, SE 21st &amp; Tibbets
-    <br>9:30pm
-    <br>All night ride traversing local cinder cones to celebrate
+  </dd><dt><a name="June20:Shortest Night">SHORTEST NIGHT OF THE YEAR RIDE</a>
+  </dt><dd>Peoples' Food Co-op, SE 21st &amp; Tibbets
+  <br>9:30pm
+  <br>All night ride traversing local cinder cones to celebrate
 	the solstice.
 	Bring plenty of food, drink, and something warm to
 	celebrate until sunrise.
 	The Summer Solstice officially occurs on
 	June 20th at exactly 11:46pm PDT.
-    <br>bikemore<img src="images/at.gif" alt="[at]">gmail.com
-  </dd></dl>
+  <br>bikemore<img src="images/at.gif" alt="[at]">gmail.com
+</dd></dl>
 
-  <hr>
-  <h2><a name="June21">Tuesday June 21</a></h2>
-  <dl>
-    <dt><a name="June21:VBC Friends">VANCOUVER BICYCLE CLUB TOUR DE FRIENDS</a>
-    <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
-    </dt><dd>Vancouver, Oxford Athletic Club, 7588 Delaware Lane
+<hr>
+<h2><a name="June21">Tuesday June 21</a></h2>
+<dl>
+  <dt><a name="June21:VBC Friends">VANCOUVER BICYCLE CLUB TOUR DE FRIENDS</a>
+  <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
+  </dt><dd>Vancouver, Oxford Athletic Club, 7588 Delaware Lane
 	(One block south of Mill Plain across from Garrison Square)
-    <br>9:00am every Tuesday
-    <br>Join Clay and friends for a leisurely group ride.
+  <br>9:00am every Tuesday
+  <br>Join Clay and friends for a leisurely group ride.
 	Depending on the weather and the group, we may stop for coffee,
 	may do a few more hills, or may go only 10 miles.
 	Who knows?
 	Come ride with Clay - it will be enjoyable.
 	Minor hills, 12mph, Group, 20-30 Miles.
-    <br>Clay Kind, 360-256-1595
-    <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
+  <br>Clay Kind, 360-256-1595
+  <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
 
-    </dd><dt><a name="June21:CCC-V Volunteer">CCC-V VOLUNTEER NIGHT &amp; BIKE COLLECTION</a>
-    <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
-    </dt><dd>CCC-Vancouver, 8040 E. Mill Plain
-    <br>6:00pm - 8:30pm
-    <br>Volunteer to repair and clean bikes.
+  </dd><dt><a name="June21:CCC-V Volunteer">CCC-V VOLUNTEER NIGHT &amp; BIKE COLLECTION</a>
+  <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
+  </dt><dd>CCC-Vancouver, 8040 E. Mill Plain
+  <br>6:00pm - 8:30pm
+  <br>Volunteer to repair and clean bikes.
 	Bring your old bikes to be recycled at
 	Vancouver's Community Cycling Center.
-    <br>Angela McKinney, 360-313-4724,
+  <br>Angela McKinney, 360-313-4724,
 	Vancouver<img src="images/at.gif" alt="[at]">CommunityCyclingCenter.org
-    </dd><dt><a name="June21:NoPo Volunteer">NO-PO BIKE WORKS VOLUNTEER NIGHT</a>
-    </dt><dd>North Portland Bike Works, 3951 N. Mississippi
-    <br>6:00pm - 8:00pm
-    <br>Volunteer Night - learn bike repair skills, earn hours.
+  </dd><dt><a name="June21:NoPo Volunteer">NO-PO BIKE WORKS VOLUNTEER NIGHT</a>
+  </dt><dd>North Portland Bike Works, 3951 N. Mississippi
+  <br>6:00pm - 8:00pm
+  <br>Volunteer Night - learn bike repair skills, earn hours.
 	Every Tuesday except second Tuesdays
 	(which are Community Bike Nights).
-    <br>503-287-1098
-    <br><a href="http://www.npdxbikeworks.org/">http://www.npdxbikeworks.org/</a>
+  <br>503-287-1098
+  <br><a href="http://www.npdxbikeworks.org/">http://www.npdxbikeworks.org/</a>
 
-    </dd><dt><a name="June21:VBC Frenchmans">VANCOUVER BICYCLE CLUB FRENCHMANS BAR RIDE</a>
-    <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
-    </dt><dd>Vancouver, Marshall Center, 1009 E. McLoughlin Blvd.
-    <br>6:00pm every Tuesday
-    <br>Join in for this very popular series.
+  </dd><dt><a name="June21:VBC Frenchmans">VANCOUVER BICYCLE CLUB FRENCHMANS BAR RIDE</a>
+  <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
+  </dt><dd>Vancouver, Marshall Center, 1009 E. McLoughlin Blvd.
+  <br>6:00pm every Tuesday
+  <br>Join in for this very popular series.
 	The route heads through downtown Vancouver on Evergreen
 	and then onto the Mill Plain extension to Lower River Road.
 	There are two options -
@@ -1328,52 +1328,52 @@ poster-image: "/images/pp/pp2005.jpg"
 	This is mostly a flat route, excellent for those advancing
 	from beginner to intermediate riding.
 	Flat, 14mph, Re-Group, 17-26 miles.
-    <br>Dennis Johnson, 360-576-8781 &amp; Les Mischke, 360-624-3949
-    <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
+  <br>Dennis Johnson, 360-576-8781 &amp; Les Mischke, 360-624-3949
+  <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
 
-    </dd><dt><a name="June21:Hash Ride">HASH RIDE</a>
-    </dt><dd>Broadway Bridge, Eastside entrance under Sculpture
-    <br>7:00pm
-    <br>Join in with fellow bikers on a wild chase through Portland
+  </dd><dt><a name="June21:Hash Ride">HASH RIDE</a>
+  </dt><dd>Broadway Bridge, Eastside entrance under Sculpture
+  <br>7:00pm
+  <br>Join in with fellow bikers on a wild chase through Portland
 	that involves keen eyes and good communication.
 	Chase down our wiley leading "hares" to a secret destination,
 	where a celebration awaits!
 	Plan on a 2 hours of easy riding and lots of laughs.
-    <br>Jim Meyer, mugnyte<img src="images/at.gif" alt="[at]">yahoo.com
-  </dd></dl>
+  <br>Jim Meyer, mugnyte<img src="images/at.gif" alt="[at]">yahoo.com
+</dd></dl>
 
-  <hr>
-  <h2><a name="June22">Wednesday June 22</a></h2>
-  <dl>
-    <dt><a name="June22:VBC Earthquake">VANCOUVER BICYCLE CLUB EARTHQUAKE RIDE</a>
-    <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
-    </dt><dd>Vancouver, Marshall Center, 1009 E. McLoughlin
-    <br>9:00am every Wednesday
-    <br>Join Dennis for his Wednesday morning ride heading out of
-	town on reverse RACC to Salmon Creek,
-	down Felida to Salmon Creek trail.
-	Return via Hazel Dell Avenue, Columbia Street,
-	and at the end we get to climb Blandford.
-	Join us for coffee afterwards.
-	Moderate Hills, 14mph, Re-Group, 26 miles.
-    <br>Dennis Funk, 360-571-4454
-    <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
+<hr>
+<h2><a name="June22">Wednesday June 22</a></h2>
+<dl>
+  <dt><a name="June22:VBC Earthquake">VANCOUVER BICYCLE CLUB EARTHQUAKE RIDE</a>
+  <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
+  </dt><dd>Vancouver, Marshall Center, 1009 E. McLoughlin
+  <br>9:00am every Wednesday
+  <br>Join Dennis for his Wednesday morning ride heading out of
+town on reverse RACC to Salmon Creek,
+down Felida to Salmon Creek trail.
+Return via Hazel Dell Avenue, Columbia Street,
+and at the end we get to climb Blandford.
+Join us for coffee afterwards.
+Moderate Hills, 14mph, Re-Group, 26 miles.
+  <br>Dennis Funk, 360-571-4454
+  <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
 
-    </dd><dt><a name="June22:Gorge Ride">MIDWEEK RIDE TO THE GORGE</a>
-    </dt><dd>Meet along MAX Blue Line
-    <br>11:00am at Lloyd Center/NE 11th Ave. MAX station,
+  </dd><dt><a name="June22:Gorge Ride">MIDWEEK RIDE TO THE GORGE</a>
+  </dt><dd>Meet along MAX Blue Line
+  <br>11:00am at Lloyd Center/NE 11th Ave. MAX station,
 	11:35am at Gresham City Hall MAX station.
-    <br>Call in sick of weekend car traffic and ride the
+  <br>Call in sick of weekend car traffic and ride the
 	Historic Columbia River Highway!
 	Bring a snack and lots of water.
 	The ride is approximately 25 miles with
 	plenty of nice places to stop.
-    <br>bikemore<img src="images/at.gif" alt="[at]">gmail.com
+  <br>bikemore<img src="images/at.gif" alt="[at]">gmail.com
 
-    </dd><dt><a name="June22:Tour Baby">THE TOUR BABY!</a>
-    </dt><dd>Bagdad Theater, 3702 SE Hawthorne Blvd.
-    <br>5:00pm doors open; the movie starts at 6:30pm
-    <br>Special charity showing of the Tour de France documentary,
+  </dd><dt><a name="June22:Tour Baby">THE TOUR BABY!</a>
+  </dt><dd>Bagdad Theater, 3702 SE Hawthorne Blvd.
+  <br>5:00pm doors open; the movie starts at 6:30pm
+  <br>Special charity showing of the Tour de France documentary,
 	"The Tour Baby!" benefitting the
 	<a href="http://www.laf.org/">Lance Armstrong Foundation</a>.
 	Film maker Scott Coady will be present.
@@ -1383,24 +1383,24 @@ poster-image: "/images/pp/pp2005.jpg"
 	Raffle.
 	This is an All Ages showing; there is also an
 	<a href="#June23:Tour Baby">Adult Only (21+) showing on June 23</a>.
-    <br>Mark Price, mprice<img src="images/at.gif" alt="[at]">pdxbrit.com
-    <br><a href="http://www.pdxtourbaby.com/">www.pdxtourbaby.com</a>
+  <br>Mark Price, mprice<img src="images/at.gif" alt="[at]">pdxbrit.com
+  <br><a href="http://www.pdxtourbaby.com/">www.pdxtourbaby.com</a>
 
-    </dd><dt><a name="June22:Vancouver BTA">VANCOUVER BTA START-UP SOCIAL</a>
-    <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
-    </dt><dd>Vancouver, Salmon Creek Pub, 108 W Evergreen Blvd. (near Main)
+  </dd><dt><a name="June22:Vancouver BTA">VANCOUVER BTA START-UP SOCIAL</a>
+  <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
+  </dt><dd>Vancouver, Salmon Creek Pub, 108 W Evergreen Blvd. (near Main)
 
-    <br>5:30pm - 7:00pm
-    <br>Beer Social to meet-up to organize a Vancouver chapter
+  <br>5:30pm - 7:00pm
+  <br>Beer Social to meet-up to organize a Vancouver chapter
 	of the BTA (Bicycle Transportation Alliance).
 	Please RSVP.
-    <br>Todd Boulanger, 360-696-8290
+  <br>Todd Boulanger, 360-696-8290
 
-    </dd><dt><a name="June22:Theater History Ride">EASTSIDE THEATER HISTORY BICYCLE TOUR</a>
-    <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
-    </dt><dd>Ladd's Circle, SE 16th and Harrison
-    <br>6:00pm
-    <br>Portland has so many great, old theaters!
+  </dd><dt><a name="June22:Theater History Ride">EASTSIDE THEATER HISTORY BICYCLE TOUR</a>
+  <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
+  </dt><dd>Ladd's Circle, SE 16th and Harrison
+  <br>6:00pm
+  <br>Portland has so many great, old theaters!
 	For some reason, this city still has a number of cinemas
 	and vaudeville houses from the 'classic era'
 	-- 1910's to 30's -- still standing, some of which still are
@@ -1413,23 +1413,23 @@ poster-image: "/images/pp/pp2005.jpg"
 	After the full ride, we hope to take in a movie at one of
 	Portland's classic movie palaces;
 	bring appropriate cash if you would like to join us!
-    <br>urbanadventureleague<img src="images/at.gif" alt="[at]">scribble.com
+  <br>urbanadventureleague<img src="images/at.gif" alt="[at]">scribble.com
 
-    </dd><dt><a name="June22:NoPo Womens">NO-PO WOMENS VOLUNTEER NIGHT</a>
-    </dt><dd>North Portland Bike Works, 3951 N. Mississippi
-    <br>6:00pm - 8:00pm
-    <br>Free workshop open to all women and transgendered people;
+  </dd><dt><a name="June22:NoPo Womens">NO-PO WOMENS VOLUNTEER NIGHT</a>
+  </dt><dd>North Portland Bike Works, 3951 N. Mississippi
+  <br>6:00pm - 8:00pm
+  <br>Free workshop open to all women and transgendered people;
 	volunteers are there to provide bike repair help
 	and good company.
 	Every Wednesday.
-    <br>Alex, 503-287-1098
-    <br><a href="http://www.npdxbikeworks.org/">http://www.npdxbikeworks.org/</a>
+  <br>Alex, 503-287-1098
+  <br><a href="http://www.npdxbikeworks.org/">http://www.npdxbikeworks.org/</a>
 
-    </dd><dt><a name="June22:VBC Wednesday">VANCOUVER BICYCLE CLUB WEDNESDAY EVENING RIDE</a>
-    <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
-    </dt><dd>Vancouver, Salmon Creek Fred Meyer Shopping Center just west of the I-5 and I-205 junction, 800 NE Tenney Road
-    <br>6:00pm every Wednesday
-    <br>Routes will vary, depending on the amount of daylight and who
+  </dd><dt><a name="June22:VBC Wednesday">VANCOUVER BICYCLE CLUB WEDNESDAY EVENING RIDE</a>
+  <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
+  </dt><dd>Vancouver, Salmon Creek Fred Meyer Shopping Center just west of the I-5 and I-205 junction, 800 NE Tenney Road
+  <br>6:00pm every Wednesday
+  <br>Routes will vary, depending on the amount of daylight and who
 	is leading the ride that week.
 	We will head mostly north, getting plenty of rollers toward
 	the Fairgrounds and Ridgefield, as well as the occasional
@@ -1438,31 +1438,31 @@ poster-image: "/images/pp/pp2005.jpg"
 	you choose.
 	Maps will be provided.
 	Moderate to Significant Hills, 16mph, Non-Group, 20-30 miles.
-    <br>Scott Martin, 360-834-6737 &amp; Les Mischke, 360-624-3949
-    <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
+  <br>Scott Martin, 360-834-6737 &amp; Les Mischke, 360-624-3949
+  <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
 
-    </dd><dt><a name="June22:Full Moon Ride">RIDE INTO THE FULL MOON</a>
-    <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
-    </dt><dd>Vancouver, Esther Short Park, 6th and Columbia,
+  </dd><dt><a name="June22:Full Moon Ride">RIDE INTO THE FULL MOON</a>
+  <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
+  </dt><dd>Vancouver, Esther Short Park, 6th and Columbia,
 	by the clock tower
-    <br>7:30pm - 11:00pm
-    <br>Ride out by the lake and feel the cool country air and
+  <br>7:30pm - 11:00pm
+  <br>Ride out by the lake and feel the cool country air and
 	howl to the wild animals.
 	Meet at Esther Short Park (clock tower)
 	ride to Frenchman Bar Park and back to Esther Short Park.
 	Bring picnic stuff to share.
 	FREE
-    <br>Ahmad Qayoumi, 360-696-8290
+  <br>Ahmad Qayoumi, 360-696-8290
 
-    </dd><dt><a name="June22:CCC Orientation">VOLUNTEER ORIENTATION</a>
-    </dt><dd>Community Cycling Center, 1700 NE Alberta Street
-    <br>7:00pm - 8:00pm
-    <br>Ayleen<img src="images/at.gif" alt="[at]">CommunityCyclingCenter.org, 503-546-8864
+  </dd><dt><a name="June22:CCC Orientation">VOLUNTEER ORIENTATION</a>
+  </dt><dd>Community Cycling Center, 1700 NE Alberta Street
+  <br>7:00pm - 8:00pm
+  <br>Ayleen<img src="images/at.gif" alt="[at]">CommunityCyclingCenter.org, 503-546-8864
 
-    </dd><dt><a name="June22:Aaron's Panel">PANEL DISCUSSION OF TRANSPORTATION</a>
-    </dt><dd>Redwing Café, 1700 SE 6th Ave.
-    <br>8:00pm - 9:00pm
-    <br>Open panel discussion of transportation and
+  </dd><dt><a name="June22:Aaron's Panel">PANEL DISCUSSION OF TRANSPORTATION</a>
+  </dt><dd>Redwing Café, 1700 SE 6th Ave.
+  <br>8:00pm - 9:00pm
+  <br>Open panel discussion of transportation and
 	it's effects on society.
 	Sure it may sound lofty, but
 	it's just an overview of my website,
@@ -1471,36 +1471,36 @@ poster-image: "/images/pp/pp2005.jpg"
 	<strong>On Hold.</strong>
 	The Redwing Café cannot host this event, because it is closed
 	then.</em>
-    <br>Aaron Tarfman,
+  <br>Aaron Tarfman,
 	bikephoto<img src="images/at.gif" alt="[at]">aol.com
-  </dd></dl>
+</dd></dl>
 
-  <hr>
-  <h2><a name="June23">Thursday June 23</a></h2>
-  <dl>
-    <dt>BIKE COMMUTER RODEO - TRAILERS &amp; EURO GEAR
-    <img src="images/ffwa.gif" alt="FF,WA" title="Family Friendly, Meet in/around Vancouver" align="left">
-    </dt><dd>Plaza @ 1300 Franklin, Vancouver
-    <br>12:00 noon
-    <br>$3 dollar gas and transit fare hikes/route cuts got you down!
+<hr>
+<h2><a name="June23">Thursday June 23</a></h2>
+<dl>
+  <dt>BIKE COMMUTER RODEO - TRAILERS &amp; EURO GEAR
+  <img src="images/ffwa.gif" alt="FF,WA" title="Family Friendly, Meet in/around Vancouver" align="left">
+  </dt><dd>Plaza @ 1300 Franklin, Vancouver
+  <br>12:00 noon
+  <br>$3 dollar gas and transit fare hikes/route cuts got you down!
 	Regain your independence.
 	Test ride unusual bikes, trailers and euro gear that allow
 	you to bike commute and leave your car at home.
 	FREE
-    <br>Todd Boulanger, City of Vancouver, 360-696-8290
+  <br>Todd Boulanger, City of Vancouver, 360-696-8290
 
-    </dd><dt><a name="June23:Happy Hour">HAPPY HOUR FOR CYCLISTS</a>
-    <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
-    </dt><dd>East end of Steel Bridge on the Esplanade
-    <br>4:30pm - 6:30pm
-    <br>Free mocktails and snacks for cyclists and walkers
-    <br>Amy Stork, amy<img src="images/at.gif" alt="[at]">storkmarketing.com
+  </dd><dt><a name="June23:Happy Hour">HAPPY HOUR FOR CYCLISTS</a>
+  <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
+  </dt><dd>East end of Steel Bridge on the Esplanade
+  <br>4:30pm - 6:30pm
+  <br>Free mocktails and snacks for cyclists and walkers
+  <br>Amy Stork, amy<img src="images/at.gif" alt="[at]">storkmarketing.com
 
-    </dd><dt><a name="June23:Tour Baby">THE TOUR BABY!</a>
-    <img src="/images/legacy/beer.gif" alt="21+" title="Adult Only (21+)" align="left">
-    </dt><dd>Bagdad Theater, 3702 SE Hawthorne Blvd.
-    <br>6:00pm doors open; the movie starts at 7:30pm
-    <br>Special charity showing of the Tour de France documentary,
+  </dd><dt><a name="June23:Tour Baby">THE TOUR BABY!</a>
+  <img src="/images/legacy/beer.gif" alt="21+" title="Adult Only (21+)" align="left">
+  </dt><dd>Bagdad Theater, 3702 SE Hawthorne Blvd.
+  <br>6:00pm doors open; the movie starts at 7:30pm
+  <br>Special charity showing of the Tour de France documentary,
 	"The Tour Baby!" benefitting the
 	<a href="http://www.laf.org/">Lance Armstrong Foundation</a>.
 	Film maker Scott Coady will be present.
@@ -1509,14 +1509,14 @@ poster-image: "/images/pp/pp2005.jpg"
 	Raffle and silent auction.
 	This is an Adult Only (21+) showing; there is also an
 	<a href="#June22:Tour Baby">All-Ages showing on June 22</a>.
-    <br>Mark Price, mprice<img src="images/at.gif" alt="[at]">pdxbrit.com
-    <br><a href="http://www.pdxtourbaby.com/">www.pdxtourbaby.com</a>
+  <br>Mark Price, mprice<img src="images/at.gif" alt="[at]">pdxbrit.com
+  <br><a href="http://www.pdxtourbaby.com/">www.pdxtourbaby.com</a>
 
-    </dd><dt><a name="June23:VBC Thursday">VANCOUVER BICYCLE CLUB THURSDAY EVENING RIDE</a>
-    <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
-    </dt><dd>Vancouver, Marshall Center, 1009 E. McLoughlin
-    <br>6:00pm every Thursday
-    <br>Join Pete or Jim for this Thursday evening ride following
+  </dd><dt><a name="June23:VBC Thursday">VANCOUVER BICYCLE CLUB THURSDAY EVENING RIDE</a>
+  <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
+  </dt><dd>Vancouver, Marshall Center, 1009 E. McLoughlin
+  <br>6:00pm every Thursday
+  <br>Join Pete or Jim for this Thursday evening ride following
 	the RACC route towards 164th Avenue,
 	head south to SE Cascade Park Drive, and
 	follow the "low road" back to the start.
@@ -1526,23 +1526,23 @@ poster-image: "/images/pp/pp2005.jpg"
 	In case of rain we will hand out cue sheets and wish you well.
 	Make this ride part of your weekly ritual.
 	Minor Hills, 12mph, Re-group, 22 miles.
-    <br>Pete Lyall, 360-604-3124 &amp; Jim Ryan, 360-256-4354
-    <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
+  <br>Pete Lyall, 360-604-3124 &amp; Jim Ryan, 360-256-4354
+  <br><a href="http://www.vancouverbicycleclub.com/">http://www.vancouverbicycleclub.com/</a>
 
-    </dd><dt><a name="June23:VBC Time Trial">VANCOUVER BICYCLE CLUB TIME TRIAL SERIES</a>
-    <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
-    </dt><dd>Port of Vancouver office, 3103 NW Lower River Road, Vancouver WA
-    <br>6:30pm (sign in at 6:15pm)
-    <br>A flat 10-mile course.
+  </dd><dt><a name="June23:VBC Time Trial">VANCOUVER BICYCLE CLUB TIME TRIAL SERIES</a>
+  <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
+  </dt><dd>Port of Vancouver office, 3103 NW Lower River Road, Vancouver WA
+  <br>6:30pm (sign in at 6:15pm)
+  <br>A flat 10-mile course.
 	Open to all! $1.00 entry fee; VBC members are FREE!
-    <br>Mike Lusby, 360-750-4875,
+  <br>Mike Lusby, 360-750-4875,
 	vbctt<img src="images/at.gif" alt="[at]">netzero.net
-    <br><a href="http://www.vancouverbicycleclub.com/trials.html">http://www.vancouverbicycleclub.com/trials.html</a>
+  <br><a href="http://www.vancouverbicycleclub.com/trials.html">http://www.vancouverbicycleclub.com/trials.html</a>
 
-    </dd><dt><a name="June23:Atomic Ride">ATOMIC WAR PREPAREDNESS RIDE</a>
-    </dt><dd>Eastbank Esplanade by Hawthorne Bridge (by the firehouse)
-    <br>6:30pm
-    <br>It's the year 1958 again!
+  </dd><dt><a name="June23:Atomic Ride">ATOMIC WAR PREPAREDNESS RIDE</a>
+  </dt><dd>Eastbank Esplanade by Hawthorne Bridge (by the firehouse)
+  <br>6:30pm
+  <br>It's the year 1958 again!
 	Slow-moving Russian bombers have been detected over Alaska,
 	and they'll be over Portland in three hours.
 	Now is the time for an <em>orderly evacuation</em> by bicycle,
@@ -1557,109 +1557,109 @@ poster-image: "/images/pp/pp2005.jpg"
 	Riders are encouraged to dress up in either their best 1950's,
 	nuclear war readiness, or post-holocaust togs.
 	Party at Ground Zero
-    <br>urbanadventureleague<img src="images/at.gif" alt="[at]">scribble.com
+  <br>urbanadventureleague<img src="images/at.gif" alt="[at]">scribble.com
 
-    </dd><dt><a name="June23:Lovelab Boggle">MERCURY LOVELAB PRESENTS BIKE 'N' BOGGLE</a>
-    <img src="/images/legacy/beer.gif" alt="21+" title="Adult Only (21+)" align="left">
-    </dt><dd>Portland Mercury HQ, 605 NE 21st; riding to Acme, 1305 SE 8th.
-    <br>6:30pm
-    <br>The Mercury Lovelab is hosting a night of biking to meet
+  </dd><dt><a name="June23:Lovelab Boggle">MERCURY LOVELAB PRESENTS BIKE 'N' BOGGLE</a>
+  <img src="/images/legacy/beer.gif" alt="21+" title="Adult Only (21+)" align="left">
+  </dt><dd>Portland Mercury HQ, 605 NE 21st; riding to Acme, 1305 SE 8th.
+  <br>6:30pm
+  <br>The Mercury Lovelab is hosting a night of biking to meet
 	your match in Boggle.
 	Short bike ride from Mercury HQ to Acme (1305 SE 8th).
 	Or just meet us there!
 	21+ at the bar...
 	Oh yeah, it's FREE of course!
-    <br><a href="http://www.mercurylovelab.com/">www.mercurylovelab.com</a>
-    </dd><dt><a name="June23:CCC Women's">WOMEN'S VOLUNTEER NIGHT</a>
-    </dt><dd>Community Cycling Center, 1700 NE Alberta Street
-    <br>7:00pm - 9:30pm
-    <br>Learn about bike repair in a super supportive setting.
-    <br>Ayleen<img src="images/at.gif" alt="[at]">CommunityCyclingCenter.org, 503-546-8864
+  <br><a href="http://www.mercurylovelab.com/">www.mercurylovelab.com</a>
+  </dd><dt><a name="June23:CCC Women's">WOMEN'S VOLUNTEER NIGHT</a>
+  </dt><dd>Community Cycling Center, 1700 NE Alberta Street
+  <br>7:00pm - 9:30pm
+  <br>Learn about bike repair in a super supportive setting.
+  <br>Ayleen<img src="images/at.gif" alt="[at]">CommunityCyclingCenter.org, 503-546-8864
 
-  </dd></dl>
+</dd></dl>
 
-  <hr>
-  <h2><a name="June24">Friday June 24</a></h2>
-  <dl>
-    <dt><a name="June24:BonB">BREAKFAST ON THE BRIDGES</a>
-    <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
-    </dt><dd>Broadway &amp; Hawthorne Bridges (Westbound Sides)
-    <br>7:00am - 9:00am
-    <br>Ride the Bridge, eat a nosh, have a cawfee. No big whoop
-    <br>timolandia<img src="images/at.gif" alt="[at]">shifttobikes.org
+<hr>
+<h2><a name="June24">Friday June 24</a></h2>
+<dl>
+  <dt><a name="June24:BonB">BREAKFAST ON THE BRIDGES</a>
+  <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
+  </dt><dd>Broadway &amp; Hawthorne Bridges (Westbound Sides)
+  <br>7:00am - 9:00am
+  <br>Ride the Bridge, eat a nosh, have a cawfee. No big whoop
+  <br>timolandia<img src="images/at.gif" alt="[at]">shifttobikes.org
 
-    </dd><dt><a name="June24:Small Museums II">SMALL MUSEUMS &amp; COLLECTIONS TOUR II</a>
-    <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
-    </dt><dd>Laughing Planet Café, 3320 SE Belmont
-    <br>12:00pm noon, leave at 1 pm (length: 4 hours)
-    <br>Tour II: Join Carye Bye, director of the Bathtub Art Museum,
+  </dd><dt><a name="June24:Small Museums II">SMALL MUSEUMS &amp; COLLECTIONS TOUR II</a>
+  <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
+  </dt><dd>Laughing Planet Café, 3320 SE Belmont
+  <br>12:00pm noon, leave at 1 pm (length: 4 hours)
+  <br>Tour II: Join Carye Bye, director of the Bathtub Art Museum,
 	on a bicycle tour of small museums &amp; collections located in
 	SE &amp; Downtown Portland Businesses.
 	Highlights of the tour includes an amazing collection of
 	toy banks, vacuums that suck (as in don't work!),
 	Portland's first traffic light, and Julie Andrew's Dress
 	from the film The Sound of Music.
-    <br>Carye Bye, 503-248-4454,
+  <br>Carye Bye, 503-248-4454,
 	info<img src="images/at.gif" alt="[at]">bathtubmuseum.org
 
-    </dd><dt><a name="June24:Bikeway Design">PRESENTATION: BIKEWAY DESIGN TIPS FOR HERE FROM EUROPE</a>
-    <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
-    </dt><dd>Vancouver, Clark County Service Center, 1300 Franklin St.
-    <br>3:30pm - 5:00pm
-    <br>A digital design discussion for Vancouver-Portland
+  </dd><dt><a name="June24:Bikeway Design">PRESENTATION: BIKEWAY DESIGN TIPS FOR HERE FROM EUROPE</a>
+  <img src="/images/legacy/washington.gif" alt="WA" title="Meet in/around Vancouver" align="left">
+  </dt><dd>Vancouver, Clark County Service Center, 1300 Franklin St.
+  <br>3:30pm - 5:00pm
+  <br>A digital design discussion for Vancouver-Portland
 	with Michael Ronkin. RSVP by June 22 for time check.
 	FREE
-    <br>Todd Boulanger, City of Vancouver, 360-696-8290,
-    <br>todd.boulanger<img src="images/at.gif" alt="[at]">ci.vancouver.wa.us
+  <br>Todd Boulanger, City of Vancouver, 360-696-8290,
+  <br>todd.boulanger<img src="images/at.gif" alt="[at]">ci.vancouver.wa.us
 
-    </dd><dt><a name="June24:Critical Mass">CRITICAL MASS</a>
-    </dt><dd>North Park Blocks NW 9th &amp; Couch
-    <br>5:30pm (Leave at 6 pm)
-    <br>Bicycling's monthly celebration.
+  </dd><dt><a name="June24:Critical Mass">CRITICAL MASS</a>
+  </dt><dd>North Park Blocks NW 9th &amp; Couch
+  <br>5:30pm (Leave at 6 pm)
+  <br>Bicycling's monthly celebration.
 	Be there, Ride, Represent.
 	Obey the laws, and bring your lights!
-    <br><a href="http://www.rosecitycriticalmass.org">http://www.rosecitycriticalmass.org</a>
+  <br><a href="http://www.rosecitycriticalmass.org">http://www.rosecitycriticalmass.org</a>
 
-    </dd><dt><a name="June24:Bike-In Movie">BIKE-IN MOVIE AT HAWTHORNE HOSTEL</a>
-    <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
-    </dt><dd>Hawthorne Hostel, 3031 SE Hawthorne Blvd.
-    <br>8:00pm
-    <br>Live entertainment, some film shorts then a feature decided
+  </dd><dt><a name="June24:Bike-In Movie">BIKE-IN MOVIE AT HAWTHORNE HOSTEL</a>
+  <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
+  </dt><dd>Hawthorne Hostel, 3031 SE Hawthorne Blvd.
+  <br>8:00pm
+  <br>Live entertainment, some film shorts then a feature decided
 	by audience vote.  Raffle later.
 	Food provided, sorry alcohol not permitted at Hawthorne Hostel
 	but stick around to find out about the after-party elsewhere.
 	Staggering good fun.
 	FREE
-    <br>captainplanet<img src="images/at.gif" alt="[at]">hevanet.com
+  <br>captainplanet<img src="images/at.gif" alt="[at]">hevanet.com
 
-  </dd></dl>
+</dd></dl>
 
-  <hr>
-  <h2><a name="June25">Saturday June 25</a></h2>
-  <dl>
-    <dt><a name="June25:CCC-V Volunteer">CCC-V VOLUNTEER DAY &amp; BIKE COLLECTION</a>
-    </dt><dd>Vancouver, CCC, 8040 E. Mill Plain
-    <br>10:00am - 2:00pm
-    <br>Volunteer to repair and clean bikes.
-	Bring your old bikes to be recycled at
-	Vancouver's Community Cycling Center.
-    <br>Angela McKinney, 360-313-4724,
-	Vancouver<img src="images/at.gif" alt="[at]">CommunityCyclingCenter.org
+<hr>
+<h2><a name="June25">Saturday June 25</a></h2>
+<dl>
+  <dt><a name="June25:CCC-V Volunteer">CCC-V VOLUNTEER DAY &amp; BIKE COLLECTION</a>
+  </dt><dd>Vancouver, CCC, 8040 E. Mill Plain
+  <br>10:00am - 2:00pm
+  <br>Volunteer to repair and clean bikes.
+Bring your old bikes to be recycled at
+Vancouver's Community Cycling Center.
+  <br>Angela McKinney, 360-313-4724,
+Vancouver<img src="images/at.gif" alt="[at]">CommunityCyclingCenter.org
 
-    </dd><dt><a name="June25:MCBF">MULTNOMAH COUNTY BIKE FAIR</a>
-    <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
-    </dt><dd>Col. Summers Park, SE 20th &amp; Belmont
-    <br>2:00pm - 7:00pm
-    <br>A *FREE* one-day festival of bicycle music, mayhem and madness.
-	Competitions, tall bike jousting, beer garden,
-	marry your bike booth, food, performances, awards and more.
-	Sign up the day of to compete at the Competitions Stage.
-	Performances by: Sprockettes - Gov't Issue Orchestra -
-	Pheramones - Trash Mountain Boys - Johnny Punchclock - and more.
-	Bring your own bike for jousting &amp; competing,
-	no loaners available.
-	VOLUNTEERS NEEDED - contact
-	EliciaCardenas<img src="images/at.gif" alt="[at]">hotmail.com;
-	free arm bands and accolades for all volunteers.
-  </dd></dl>
+  </dd><dt><a name="June25:MCBF">MULTNOMAH COUNTY BIKE FAIR</a>
+  <img src="/images/legacy/ff.gif" alt="Family-Friendly" title="Family Friendly" align="left">
+  </dt><dd>Col. Summers Park, SE 20th &amp; Belmont
+  <br>2:00pm - 7:00pm
+  <br>A *FREE* one-day festival of bicycle music, mayhem and madness.
+Competitions, tall bike jousting, beer garden,
+marry your bike booth, food, performances, awards and more.
+Sign up the day of to compete at the Competitions Stage.
+Performances by: Sprockettes - Gov't Issue Orchestra -
+Pheramones - Trash Mountain Boys - Johnny Punchclock - and more.
+Bring your own bike for jousting &amp; competing,
+no loaners available.
+VOLUNTEERS NEEDED - contact
+EliciaCardenas<img src="images/at.gif" alt="[at]">hotmail.com;
+free arm bands and accolades for all volunteers.
+</dd></dl>
 </div>


### PR DESCRIPTION
Only whitespace removed