### PR TITLE
Update nginx to latest patch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ volumes:
 
 services:
   nginx:
-    image: nginx:1.26.1
+    image: nginx:1.26.2
     restart: always
     volumes:
       # DEV SITE:


### PR DESCRIPTION
From v1.26.1 to v1.26.2, released 2024-08-12: https://nginx.org/en/CHANGES-1.26