### PR TITLE
switch from .Site.BaseURL to absURL

### DIFF
--- a/site/themes/s2b_hugo_theme/layouts/404.html
+++ b/site/themes/s2b_hugo_theme/layouts/404.html
@@ -21,7 +21,7 @@
                 <div class="box">
 
                     <p class="text-center">
-                        <a href="{{ .Site.BaseURL }}">
+                        <a href="{{ absURL "" }}">
                             <img src="{{ .Site.Params.logo }}" alt="{{ .Title }} logo">
                         </a>
                     </p>
@@ -29,7 +29,7 @@
                     <h3>We are sorry - this page is not here anymore</h3>
                     <h4 class="text-muted">Error 404 - Page not found</h4>
 
-                    <p class="buttons"><a href="{{ .Site.BaseURL }}" class="btn btn-template-main"><i class="fa fa-home"></i> Go to Homepage</a>
+                    <p class="buttons"><a href="{{ absURL "" }}" class="btn btn-template-main"><i class="fa fa-home"></i> Go to Homepage</a>
                     </p>
                 </div>
 

--- a/site/themes/s2b_hugo_theme/layouts/_default/list.html
+++ b/site/themes/s2b_hugo_theme/layouts/_default/list.html
@@ -31,9 +31,9 @@
                   <div class="image">
                     <a href="{{ .Permalink }}">
                       {{ if .Params.banner }}
-                      <img src="{{ .Site.BaseURL}}{{ .Params.banner }}" class="img-responsive" alt="">
+                      <img src="{{ absURL .Params.banner }}" class="img-responsive" alt="">
                       {{ else }}
-                      <img src="{{ .Site.BaseURL}}img/placeholder.png" class="img-responsive" alt="">
+                      <img src="{{ absURL "img/placeholder.png" }}" class="img-responsive" alt="">
                       {{ end }}
                     </a>
                   </div>
@@ -47,7 +47,7 @@
                       {{ end }}
                       {{ if isset .Params "categories" }}
                       {{ if gt (len .Params.categories) 0 }}
-                      in <a href="{{ $.Site.BaseURL }}categories/{{ index .Params.categories 0 | urlize | lower }}">{{ index .Params.categories 0 }}</a>
+                      in <a href="{{ absURL "categories" }}/{{ index .Params.categories 0 | urlize | lower }}">{{ index .Params.categories 0 }}</a>
                       {{ end }}
                       {{ end }}
 
@@ -66,13 +66,13 @@
 
               <ul class="pager">
                 {{ if .Paginator.HasPrev }}
-                <li class="previous"><a href="{{ .Site.BaseURL }}{{ .Paginator.Prev.URL }}">&larr; {{ i18n "newer" }}</a></li>
+                <li class="previous"><a href="{{ absURL .Paginator.Prev.URL }}">&larr; {{ i18n "newer" }}</a></li>
                 {{ else }}
                 <li class="previous disabled"><a href="#">&larr; {{ i18n "newer" }}</a></li>
                 {{ end }}
 
                 {{ if .Paginator.HasNext }}
-                <li class="next"><a href="{{ .Site.BaseURL }}{{ .Paginator.Next.URL }}">{{ i18n "older" }} &rarr;</a></li>
+                <li class="next"><a href="{{ absURL .Paginator.Next.URL }}">{{ i18n "older" }} &rarr;</a></li>
                 {{ else }}
                 <li class="next disabled"><a href="#">{{ i18n "older" }} &rarr;</a></li>
                 {{ end }}

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
@@ -140,7 +140,7 @@
               <div class="image-form">
                 <div class="image-display">
                   [[^ image]]
-                  <img src="{{ .Site.BaseURL }}img/cal/icons/image.svg" alt="" class="event-image placeholder" />
+                  <img src="{{ absURL "img/cal/icons/image.svg" }}" alt="" class="event-image placeholder" />
                   [[/ image]]
                   [[# image]]
                   <a href="[[image]]" target="_blank" title="View full size in a new window">

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
@@ -145,7 +145,7 @@
           <div class="eventImg">
             [[# image]]
             <a href="[[image]]">
-              <img class="lazy" src="{{ .Site.BaseURL }}img/cal/icons/blank.svg" data-src="[[image]]" alt="User-uploaded image for [[title]]" />
+              <img class="lazy" src="{{ absURL "img/cal/icons/blank.svg" }}" data-src="[[image]]" alt="User-uploaded image for [[title]]" />
             </a>
             [[/ image]]
           </div>
@@ -216,7 +216,7 @@
           <div class="eventlink">
             <p class="facebook-share">
               <a href="https://www.facebook.com/sharer/sharer.php?u=[[shareable]]" target="_blank">
-                <img src="{{ .Site.BaseURL }}img/cal/icons/facebook.svg" alt="Facebook"/>Share</a>
+                <img src="{{ absURL "img/cal/icons/facebook.svg" }}" alt="Facebook"/>Share</a>
             </p>
             <ul>
               <li>

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/fullcal.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/fullcal.html
@@ -35,7 +35,7 @@
       navLinks: true,
       eventSources: [
         {
-          url: '{{ .Site.BaseURL }}api/events.php',
+          url: '{{ absURL "api/events.php" }}',
           startParam: 'startdate',
           endParam: 'enddate',
           success: function( content ) {

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-2020-cal.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-2020-cal.html
@@ -1,7 +1,7 @@
-<script src="{{ .Site.BaseURL }}lib/fullcalendar/core/main.min.js"></script>
-<script src="{{ .Site.BaseURL }}lib/fullcalendar/daygrid/main.min.js"></script>
-<script src="{{ .Site.BaseURL }}lib/fullcalendar/timegrid/main.min.js"></script>
-<script src="{{ .Site.BaseURL }}lib/fullcalendar/list/main.min.js"></script>
+<script src="{{ absURL "lib/fullcalendar/core/main.min.js" }}"></script>
+<script src="{{ absURL "lib/fullcalendar/daygrid/main.min.js" }}"></script>
+<script src="{{ absURL "lib/fullcalendar/timegrid/main.min.js" }}"></script>
+<script src="{{ absURL "lib/fullcalendar/list/main.min.js" }}"></script>
 
 {{ partial "cal/pp-2020-themes.html" . }}
 

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/scripts.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/scripts.html
@@ -5,16 +5,16 @@
   {{ $jsCalMain := resources.Get "js/cal/main.js" | minify }}
   <script src="{{ $jsCalMain.Permalink }}"></script>
 
-  <script src="{{ .Site.BaseURL }}lib/mustache/mustache.min.js"></script>
+  <script src="{{ absURL "lib/mustache/mustache.min.js" }}"></script>
 
   {{ partial "cal/dayjs.html" . }}
 {{ end }}
 
 <!-- only load FullCal scripts on calendar grid and festival pages; not needed on list, single ride, or edit pages -->
 {{ if or (eq .Type "calgrid") (eq .Type "calfestival") (eq .Type "pp-theme-cal") }}
-  <script src="{{ .Site.BaseURL }}lib/fullcalendar/core/main.min.js"></script>
-  <script src="{{ .Site.BaseURL }}lib/fullcalendar/daygrid/main.min.js"></script>
-  <script src="{{ .Site.BaseURL }}lib/fullcalendar/timegrid/main.min.js"></script>
+  <script src="{{ absURL "lib/fullcalendar/core/main.min.js" }}"></script>
+  <script src="{{ absURL "lib/fullcalendar/daygrid/main.min.js" }}"></script>
+  <script src="{{ absURL "lib/fullcalendar/timegrid/main.min.js" }}"></script>
 {{ end }}
 
 <!-- load on all cal pages -->
@@ -98,7 +98,7 @@
       navLinks: true,
       eventSources: [
         {
-          url: '{{ .Site.BaseURL }}api/events.php',
+          url: '{{ absURL "api/events.php" }}',
           startParam: 'startdate',
           endParam: 'enddate',
           success: function( content ) {

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/up-next.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/up-next.html
@@ -1,5 +1,5 @@
-<script src="{{ .Site.BaseURL }}lib/fullcalendar/core/main.min.js"></script>
-<script src="{{ .Site.BaseURL }}lib/fullcalendar/list/main.min.js"></script>
+<script src="{{ absURL "lib/fullcalendar/core/main.min.js" }}"></script>
+<script src="{{ absURL "lib/fullcalendar/list/main.min.js" }}"></script>
 
 <script type="text/javascript">
   {{/* 
@@ -32,7 +32,7 @@
       noEventsMessage: "No events happening today or tomorrow",
       eventSources: [
         {
-          url: '{{ .Site.BaseURL }}api/events.php',
+          url: '{{ absURL "api/events.php" }}',
           startParam: 'startdate',
           endParam: 'enddate',
           success: function( content ) {

--- a/site/themes/s2b_hugo_theme/layouts/partials/head.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/head.html
@@ -33,7 +33,7 @@
 <link rel="stylesheet" href="//stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
 
 <!-- Preload header background image -->
-<link rel="preload" as="image" href="{{ .Site.BaseURL }}img/banner_bikes_city-bw.webp" type="image/webp" />
+<link rel="preload" as="image" href="{{ absURL "img/banner_bikes_city-bw.webp" }}" type="image/webp" />
 
 <!-- Theme stylesheet, if possible do not edit this stylesheet -->
 {{ $cssTheme := resources.Get "css/theme.css" | minify }}
@@ -44,9 +44,9 @@
 <link rel="stylesheet" href="{{ $cssCustom.Permalink }}">
 
 <!-- Favicon and apple touch icons-->
-<link rel="icon" href="{{ .Site.BaseURL }}img/favicon.ico">
-<link rel="icon" href="{{ .Site.BaseURL }}img/favicon.png" type="image/png">
-<link rel="apple-touch-icon" href="{{ .Site.BaseURL }}img/apple-touch-icon.png">
+<link rel="icon" href="{{ absURL "img/favicon.ico" }}">
+<link rel="icon" href="{{ absURL "img/favicon.png" }}" type="image/png">
+<link rel="apple-touch-icon" href="{{ absURL "img/apple-touch-icon.png" }}">
 
 <!-- owl carousel; only load styles on homepage -->
 {{ if (eq .Type "homepage") }}

--- a/site/themes/s2b_hugo_theme/layouts/partials/head.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/head.html
@@ -62,7 +62,7 @@
 <meta property="og:title" content="{{ .Title }}" />
 <meta property="og:description" content="{{ .Description }}" />
 <meta property="og:type" content="website" />
-<meta property="og:image" content="https://www.shift2bikes.org/{{ .Site.Params.logo }}" />
+<meta property="og:image" content="{{ absURL .Site.Params.logo }}" />
 <meta property="og:image:height" content="1200" />
 <meta property="og:image:width" content="1200" />
 

--- a/site/themes/s2b_hugo_theme/layouts/partials/nav.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/nav.html
@@ -5,9 +5,9 @@
 
         <div class="container">
             <div class="navbar-header">
-                <a class="navbar-brand home" href="{{ .Site.BaseURL }}">
+                <a class="navbar-brand home" href="{{ absURL "" }}">
                     <svg class="logo" role="img" aria-hidden="true" width="100" height="55" viewBox="0 0 206 112">
-                        <use href="{{ .Site.BaseURL }}img/cal/logos/shift-logo.svg#shift-logo" />
+                        <use href="{{ absURL "img/cal/logos/shift-logo.svg#shift-logo" }}"/>
                     </svg>
                     <span class="sr-only">{{ .Site.Title }} - {{ i18n "navHome" }}</span>
                 </a>


### PR DESCRIPTION
re #779 -- changes from {{ .Site.BaseURL }} composition to hugo's absURL function
( as per the hugo recommendation - https://gohugo.io/methods/site/baseurl/ )

i generated the site before and after and compared the results.
the site's base is just '/' so absolute urls ( with both methods ) wind up looking like this example:
```
<use href="/img/cal/logos/shift-logo.svg#shift-logo"/>
```

the one difference before and after are the pages that use fullcalendar ( for instance: `calgrid/index.html` )

previously it would generate javascript with:
```
 eventSources: [{ url: '\/api\/events.php',
```

where now it looks like: 
```
 eventSources: [{ url: '\/api/events.php',
```

note that the second forward slash isn't escaped now; but, forward slashes don't need to be escaped so.... all good?
