### PR TITLE
CSS variables & custom style normalization

### DIFF
--- a/site/themes/s2b_hugo_theme/assets/css/custom.css
+++ b/site/themes/s2b_hugo_theme/assets/css/custom.css
@@ -1,4 +1,7 @@
 /* your styles go here */
+:root {
+  --primary-accent: #FF9819;
+}
 
 .box-image-text .image {
   min-height: 200px;

--- a/site/themes/s2b_hugo_theme/assets/css/custom.css
+++ b/site/themes/s2b_hugo_theme/assets/css/custom.css
@@ -3,6 +3,7 @@
   --primary-accent: #ff9819;
   --navbar-focus: #ffc14d;
   --navbar-border-top: #ffaf4d;
+  --link-focus: #e57e00;
 }
 
 .box-image-text .image {

--- a/site/themes/s2b_hugo_theme/assets/css/custom.css
+++ b/site/themes/s2b_hugo_theme/assets/css/custom.css
@@ -1,6 +1,7 @@
 /* your styles go here */
 :root {
-  --primary-accent: #FF9819;
+  --primary-accent: #ff9819;
+  --navbar-focus: #ffc14d;
 }
 
 .box-image-text .image {
@@ -69,11 +70,11 @@ main .donate a {
 }
 
 .affix {
-    position: fixed;
-    top: 0;
-    background: #fff;
-    z-index: 1;
-    border-bottom: 1px solid transparent;
+  position: fixed;
+  top: 0;
+  background: #fff;
+  z-index: 1;
+  border-bottom: 1px solid transparent;
 }
 
 @media (max-width: 991px) {

--- a/site/themes/s2b_hugo_theme/assets/css/custom.css
+++ b/site/themes/s2b_hugo_theme/assets/css/custom.css
@@ -87,6 +87,10 @@ main .donate a {
   border-bottom: 1px solid transparent;
 }
 
+#heading-breadcrumbs h1 {
+  text-align: center;
+}
+
 @media (max-width: 991px) {
   .home-carousel h1 {
     font-size: 32px;
@@ -109,8 +113,18 @@ main .donate a {
   -webkit-filter: none;
 }
 
+section,
+div.section {
+  margin-bottom: 0;
+}
+
 .icon {
   color: currentColor;
+}
+
+a i.fa,
+button i.fa {
+  margin: 0 5px;
 }
 
 /* see https://github.com/shift-org/shift-docs/issues/326 */

--- a/site/themes/s2b_hugo_theme/assets/css/custom.css
+++ b/site/themes/s2b_hugo_theme/assets/css/custom.css
@@ -2,6 +2,7 @@
 :root {
   --primary-accent: #ff9819;
   --navbar-focus: #ffc14d;
+  --navbar-border-top: #ffaf4d;
 }
 
 .box-image-text .image {

--- a/site/themes/s2b_hugo_theme/assets/css/custom.css
+++ b/site/themes/s2b_hugo_theme/assets/css/custom.css
@@ -23,6 +23,10 @@ footer #footer-ul a {
   color: #ccc;
 }
 
+footer #footer-ul a:hover {
+  color: #38a7bb;
+}
+
 footer a {
   text-decoration: underline;
 }
@@ -46,6 +50,10 @@ header {
 
 #navbar ul.nav > li > a {
   text-decoration: none;
+}
+
+.navbar ul.dropdown-menu li a {
+  color: #555555;
 }
 
 main a {
@@ -99,6 +107,10 @@ main .donate a {
   max-width: auto;
   filter: none;
   -webkit-filter: none;
+}
+
+.icon {
+  color: currentColor;
 }
 
 /* see https://github.com/shift-org/shift-docs/issues/326 */

--- a/site/themes/s2b_hugo_theme/assets/css/custom.css
+++ b/site/themes/s2b_hugo_theme/assets/css/custom.css
@@ -23,6 +23,13 @@ footer #footer-ul a {
   color: #ccc;
 }
 
+#footer-ul li {
+  padding-left: 10px;
+  padding-right:10px;
+  text-transform: uppercase;
+  display: inline;
+}
+
 footer #footer-ul a:hover {
   color: #38a7bb;
 }
@@ -56,6 +63,14 @@ header {
   color: #555555;
 }
 
+.header-dark-mask {
+  background: var(--primary-accent);
+  opacity: 0.8;
+  padding: 20px 0;
+  margin-bottom: 40px;
+  z-index: 1;
+}
+
 main a {
   color: #337AB7;
   text-decoration: underline;
@@ -87,8 +102,20 @@ main .donate a {
   border-bottom: 1px solid transparent;
 }
 
+#heading-breadcrumbs {
+  background: url('../img/banner_bikes_city-bw.webp') center center repeat;
+  padding: 0;
+  margin-bottom: 0;
+  z-index: -1;
+}
+
 #heading-breadcrumbs h1 {
   text-align: center;
+}
+
+.home-carousel {
+  background: url('../img/S2B_photo_grid_2094x796.jpg') center center repeat;
+  background-size: cover;
 }
 
 @media (max-width: 991px) {

--- a/site/themes/s2b_hugo_theme/assets/css/theme.css
+++ b/site/themes/s2b_hugo_theme/assets/css/theme.css
@@ -350,7 +350,7 @@ ul.list-style-none {
 .navbar.navbar-light ul.nav > li.open > a:hover,
 .navbar.navbar-light ul.nav > li > a:focus,
 .navbar.navbar-light ul.nav > li.open > a:focus {
-  border-top: solid 5px #ffaf4d;
+  border-top: solid 5px var(--primary-accent);
   background: #fff !important;
   color: #555555 !important;
 }
@@ -376,7 +376,7 @@ ul.list-style-none {
   left: 0;
 }
 .navbar ul.dropdown-menu li a:hover {
-  color: #ffaf4d;
+  color: var(--primary-accent);
   text-decoration: none;
   background: none;
   left: 2px;
@@ -428,7 +428,7 @@ ul.list-style-none {
   transition: all 0.2s ease-out;
 }
 .navbar .yamm-content ul li a:hover {
-  color: #ffaf4d;
+  color: var(--primary-accent);
   text-decoration: none;
   padding-left: 2px;
 }
@@ -461,12 +461,12 @@ ul.list-style-none {
 .navbar .btn-default:focus,
 .navbar .btn-default.navbar-toggle:focus {
   background-color: #fff;
-  border-color: #ffaf4d;
-  color: #ffaf4d;
+  border-color: var(--primary-accent);
+  color: var(--primary-accent);
 }
 .navbar #search {
   clear: both;
-  border-top: solid 1px #ffaf4d;
+  border-top: solid 1px var(--primary-accent);
   text-align: right;
 }
 .navbar #search form {
@@ -818,7 +818,6 @@ fieldset[disabled] .btn-template-primary.active {
   background: var(--primary-accent);
   opacity: 0.9;
   filter: alpha(opacity=90);
-  z-index: -1;
 }
 .jumbotron h1,
 .jumbotron h2,
@@ -899,7 +898,7 @@ fieldset[disabled] .btn-template-primary.active {
 .panel.sidebar-menu .panel-heading h4,
 .panel.sidebar-menu .panel-heading h5 {
   display: inline-block;
-  border-bottom: solid 5px #ff8d00;
+  border-bottom: solid 5px var(--primary-accent);
   line-height: 1.1;
   margin-bottom: 0;
   padding-bottom: 10px;
@@ -1161,7 +1160,8 @@ fieldset[disabled] .btn-template-primary.active {
 }
 .home-carousel {
   position: relative;
-  background: url('../img/S2B_photo_grid_2094x796.jpg') center center repeat;
+  /* commented-out to avoid unnecessary network request for stock image */
+  /* background: url('../img/photogrid.jpg') center center repeat; */
   background-size: cover;
   -webkit-transition: all 0.2s ease-out;
   -moz-transition: all 0.2s ease-out;
@@ -1744,19 +1744,10 @@ fieldset[disabled] .btn-template-primary.active {
   border: none;
 }
 #heading-breadcrumbs {
-  background: url('../img/banner_bikes_city-bw.webp') center center repeat;
-  padding: 0;
-  margin-bottom: 0;
-  z-index: -1;
-}
-
-.header-dark-mask {
-  background: #ff8d00;
-  opacity: 0.8;
-  filter: alpha(opacity=90);
+  /* commented-out to avoid unnecessary network request for stock image */
+  /* background: url('../img/texture-bw.png') center center repeat; */
   padding: 20px 0;
   margin-bottom: 40px;
-  z-index: 1;
 }
 #heading-breadcrumbs.no-mb {
   margin-bottom: 0;
@@ -2562,14 +2553,6 @@ fieldset[disabled] .btn-template-primary.active {
   padding-left: 0;
   list-style: none;
 }
-
-#footer-ul li {
-  padding-left: 10px;
-  padding-right:10px;
-  text-transform: uppercase;
-  display: inline;
-
-}
 #footer ul a {
   color: #999999;
 }
@@ -3203,7 +3186,7 @@ body {
   color: #555555;
 }
 a {
-  color: #ff8d00;
+  color: var(--primary-accent);
   text-decoration: none;
 }
 a:hover,

--- a/site/themes/s2b_hugo_theme/assets/css/theme.css
+++ b/site/themes/s2b_hugo_theme/assets/css/theme.css
@@ -1,3 +1,15 @@
+/* Themed colors */
+:root {
+  --primary-accent: #38a7bb;
+  --navbar-border-top: #20616d;
+  --button-border: #2a7d8c;
+  --link-focus: #267280;
+  --form-shadow: rgba(56, 167, 187, 0.6);
+  --pagination-bg: #a7dbe5;
+  --link-hover-bg: #2c8494;
+  --navbar-focus: #80cbd9;
+}
+
 .clearfix:before,
 .clearfix:after,
 .navbar:before,
@@ -63,10 +75,10 @@ button i.fa {
   cursor: pointer !important;
 }
 .required {
-  color: #FF9819;
+  color: var(--primary-accent);
 }
 .accent {
-  color: #FF9819;
+  color: var(--primary-accent);
 }
 .text-uppercase {
   text-transform: uppercase;
@@ -99,7 +111,7 @@ div.section {
 .heading h4,
 .heading h5 {
   display: inline-block;
-  border-bottom: solid 5px #FF9819;
+  border-bottom: solid 5px var(--primary-accent);
   line-height: 1.1;
   margin-bottom: 0;
   padding-bottom: 10px;
@@ -113,7 +125,7 @@ div.section {
 .heading h4 i.fa,
 .heading h5 i.fa {
   display: inline-block;
-  background: #FF9819;
+  background: var(--primary-accent);
   width: 30px;
   height: 30px;
   vertical-align: middle;
@@ -148,7 +160,7 @@ div.section {
 .ul-icons li i {
   width: 20px;
   height: 20px;
-  background: #FF9819;
+  background: var(--primary-accent);
   color: #fff;
   text-align: center;
   border-radius: 10px;
@@ -312,7 +324,7 @@ ul.list-style-none {
   border-top: solid 5px transparent;
 }
 .navbar ul.nav > li > a:hover {
-  border-top: solid 5px #FF9819;
+  border-top: solid 5px var(--primary-accent);
 }
 .navbar ul.nav > li.active > a,
 .navbar ul.nav > li.open > a {
@@ -505,7 +517,7 @@ body.boxed .navbar-affixed-top.affix {
   margin-bottom: 20px;
 }
 #login-modal a {
-  color: #FF9819;
+  color: var(--primary-accent);
 }
 #login-modal p {
   font-weight: 300;
@@ -545,18 +557,18 @@ body.boxed .navbar-affixed-top.affix {
   border-radius: 0;
 }
 .btn-template-main {
-  color: #FF9819;
+  color: var(--primary-accent);
   background-color: #ffffff;
-  border-color: #FF9819;
+  border-color: var(--primary-accent);
 }
 .btn-template-main:hover,
 .btn-template-main:focus,
 .btn-template-main:active,
 .btn-template-main.active,
 .open > .dropdown-toggle.btn-template-main {
-  color: #FF9819;
+  color: var(--primary-accent);
   background-color: #e6e6e6;
-  border-color: #FF9819;
+  border-color: var(--button-border);
 }
 .btn-template-main:active,
 .btn-template-main.active,
@@ -579,19 +591,19 @@ fieldset[disabled] .btn-template-main:active,
 .btn-template-main[disabled].active,
 fieldset[disabled] .btn-template-main.active {
   background-color: #ffffff;
-  border-color: #FF9819;
+  border-color: var(--primary-accent);
 }
 .btn-template-main .badge {
   color: #ffffff;
-  background-color: #FF9819;
+  background-color: var(--primary-accent);
 }
 .btn-template-main:hover,
 .btn-template-main:focus,
 .btn-template-main:active,
 .btn-template-main.active {
-  background: #FF9819;
+  background: var(--primary-accent);
   color: #ffffff;
-  border-color: #FF9819;
+  border-color: var(--primary-accent);
 }
 .btn-template-transparent-primary {
   color: #ffffff;
@@ -639,7 +651,7 @@ fieldset[disabled] .btn-template-transparent-primary.active {
 .btn-template-transparent-primary:active,
 .btn-template-transparent-primary.active {
   background: #fff;
-  color: #FF9819;
+  color: var(--primary-accent);
   border-color: #fff;
 }
 .btn-template-transparent-black {
@@ -693,8 +705,8 @@ fieldset[disabled] .btn-template-transparent-black.active {
 }
 .btn-template-primary {
   color: #ffffff;
-  background-color: #FF9819;
-  border-color: #FF9819;
+  background-color: var(--primary-accent);
+  border-color: var(--primary-accent);
 }
 .btn-template-primary:hover,
 .btn-template-primary:focus,
@@ -725,11 +737,11 @@ fieldset[disabled] .btn-template-primary:active,
 .btn-template-primary.disabled.active,
 .btn-template-primary[disabled].active,
 fieldset[disabled] .btn-template-primary.active {
-  background-color: #FF9819;
-  border-color: #FF9819;
+  background-color: var(--primary-accent);
+  border-color: var(--primary-accent);
 }
 .btn-template-primary .badge {
-  color: #FF9819;
+  color: var(--primary-accent);
   background-color: #ffffff;
 }
 #intro {
@@ -805,7 +817,7 @@ fieldset[disabled] .btn-template-primary.active {
   left: 0;
   width: 100%;
   height: 100%;
-  background: #FF9819;
+  background: var(--primary-accent);
   opacity: 0.9;
   filter: alpha(opacity=90);
   z-index: -1;
@@ -976,7 +988,7 @@ fieldset[disabled] .btn-template-primary.active {
   padding: 5px;
   border: solid 1px #eeeeee;
   border-radius: 0;
-  color: #FF9819;
+  color: var(--primary-accent);
   margin: 5px 5px 5px 0;
   text-transform: uppercase;
   letter-spacing: 0.08em;
@@ -984,9 +996,9 @@ fieldset[disabled] .btn-template-primary.active {
   font-size: 12px;
 }
 .panel.sidebar-menu ul.tag-cloud li a:hover {
-  color: #FF9819;
+  color: var(--primary-accent);
   text-decoration: none;
-  border-color: #FF9819;
+  border-color: var(--primary-accent);
 }
 .panel.sidebar-menu ul.popular,
 .panel.sidebar-menu ul.recent {
@@ -1074,7 +1086,7 @@ fieldset[disabled] .btn-template-primary.active {
   padding: 6px 20px 6px 20px;
   margin: 30px 10px 10px -71px;
   color: #fff;
-  background-color: #FF9819;
+  background-color: var(--primary-accent);
   font-family: "Roboto", Helvetica, Arial, sans-serif;
 }
 .ribbon .theribbon:before,
@@ -1118,7 +1130,7 @@ fieldset[disabled] .btn-template-primary.active {
 .owl-theme .owl-controls .owl-page.active span,
 .owl-carousel .owl-controls.clickable .owl-page:hover span,
 .owl-theme .owl-controls.clickable .owl-page:hover span {
-  background: #FF9819;
+  background: var(--primary-accent);
 }
 .owl-carousel .owl-controls .owl-buttons,
 .owl-theme .owl-controls .owl-buttons {
@@ -1133,7 +1145,7 @@ fieldset[disabled] .btn-template-primary.active {
   line-height: 25px;
   margin: 0 5px 0 0;
   font-size: 18px;
-  color: #FF9819;
+  color: var(--primary-accent);
   padding: 0;
   background: #fff;
   border-radius: 13px;
@@ -1156,7 +1168,7 @@ fieldset[disabled] .btn-template-primary.active {
   left: 0;
   width: 100%;
   height: 100%;
-  background: #FF9819;
+  background: var(--primary-accent);
   opacity: 0.9;
   filter: alpha(opacity=90);
 }
@@ -1299,7 +1311,7 @@ fieldset[disabled] .btn-template-primary.active {
   height: 50px;
 }
 .testimonials .item .testimonial .bottom .icon {
-  color: #FF9819;
+  color: var(--primary-accent);
   font-size: 30px;
   float: left;
   width: 20%;
@@ -1511,7 +1523,7 @@ fieldset[disabled] .btn-template-primary.active {
   height: 100%;
   opacity: 0;
   filter: alpha(opacity=0);
-  background: #FF9819;
+  background: var(--primary-accent);
 }
 .box-image .name {
   position: absolute;
@@ -1589,7 +1601,7 @@ fieldset[disabled] .btn-template-primary.active {
   height: 100%;
   opacity: 0;
   filter: alpha(opacity=0);
-  background: #FF9819;
+  background: var(--primary-accent);
 }
 .box-image-text .top .name {
   position: absolute;
@@ -1763,7 +1775,7 @@ fieldset[disabled] .btn-template-primary.active {
 }
 .bar {
   position: relative;
-  background: #FF9819;
+  background: var(--primary-accent);
   padding: 60px 0;
 }
 .bar.background-pentagon {
@@ -1897,14 +1909,14 @@ fieldset[disabled] .btn-template-primary.active {
   margin-bottom: 20px;
   padding-bottom: 15px;
   text-align: center;
-  border: solid 1px #FF9819;
+  border: solid 1px var(--primary-accent);
   overflow: hidden;
 }
 .packages .package .package-header {
   height: 57px;
   color: #fff;
   line-height: 57px;
-  background: #FF9819;
+  background: var(--primary-accent);
 }
 .packages .package .package-header h5 {
   color: #fff;
@@ -1977,8 +1989,8 @@ fieldset[disabled] .btn-template-primary.active {
   height: 300px;
 }
 #map.with-border {
-  border-top: solid 1px #FF9819;
-  border-bottom: solid 1px #FF9819;
+  border-top: solid 1px var(--primary-accent);
+  border-bottom: solid 1px var(--primary-accent);
 }
 #blog-listing-big .post,
 #blog-homepage .post {
@@ -2001,7 +2013,7 @@ fieldset[disabled] .btn-template-primary.active {
 #blog-homepage .post h2 a:hover,
 #blog-listing-big .post h4 a:hover,
 #blog-homepage .post h4 a:hover {
-  color: #FF9819;
+  color: var(--primary-accent);
 }
 #blog-listing-big .post .author-category,
 #blog-homepage .post .author-category {
@@ -2021,7 +2033,7 @@ fieldset[disabled] .btn-template-primary.active {
 }
 #blog-listing-big .post .date-comments a:hover,
 #blog-homepage .post .date-comments a:hover {
-  color: #FF9819;
+  color: var(--primary-accent);
 }
 @media (min-width: 768px) {
   #blog-listing-big .post .date-comments,
@@ -2071,7 +2083,7 @@ fieldset[disabled] .btn-template-primary.active {
   color: #555555;
 }
 #blog-listing-medium .post h2 a:hover {
-  color: #FF9819;
+  color: var(--primary-accent);
 }
 #blog-listing-medium .post .author-category {
   float: left;
@@ -2093,7 +2105,7 @@ fieldset[disabled] .btn-template-primary.active {
   margin-right: 20px;
 }
 #blog-listing-medium .post .date-comments a:hover {
-  color: #FF9819;
+  color: var(--primary-accent);
 }
 @media (min-width: 768px) {
   #blog-listing-medium .post .date-comments {
@@ -2360,7 +2372,7 @@ fieldset[disabled] .btn-template-primary.active {
 }
 #productMain .sizes a.active,
 #productMain .sizes a:hover {
-  background: #FF9819;
+  background: var(--primary-accent);
   color: #fff;
 }
 #productMain .sizes input {
@@ -2377,7 +2389,7 @@ fieldset[disabled] .btn-template-primary.active {
   border: solid 1px transparent;
 }
 #thumbs a.active {
-  border-color: #FF9819;
+  border-color: var(--primary-accent);
 }
 #product-social {
   text-align: center;
@@ -2430,7 +2442,7 @@ fieldset[disabled] .btn-template-primary.active {
 }
 #checkout .nav {
   margin-bottom: 20px;
-  border-bottom: solid 1px #FF9819;
+  border-bottom: solid 1px var(--primary-accent);
 }
 #checkout .nav li {
   height: 100%;
@@ -3118,7 +3130,7 @@ fieldset[disabled] .btn-template-primary.active {
 }
 .navbar-default .navbar-toggle:hover,
 .navbar-default .navbar-toggle:focus {
-  background-color: #FF9819;
+  background-color: var(--primary-accent);
 }
 .navbar-default .navbar-toggle .icon-bar {
   background-color: #888888;
@@ -3130,7 +3142,7 @@ fieldset[disabled] .btn-template-primary.active {
 .navbar-default .navbar-nav > .open > a,
 .navbar-default .navbar-nav > .open > a:hover,
 .navbar-default .navbar-nav > .open > a:focus {
-  background-color: #FF9819;
+  background-color: var(--primary-accent);
   color: #ffffff;
 }
 @media (max-width: 767px) {
@@ -3139,13 +3151,13 @@ fieldset[disabled] .btn-template-primary.active {
   }
   .navbar-default .navbar-nav .open .dropdown-menu > li > a:hover,
   .navbar-default .navbar-nav .open .dropdown-menu > li > a:focus {
-    color: #FF9819;
+    color: var(--primary-accent);
   }
   .navbar-default .navbar-nav .open .dropdown-menu > .active > a,
   .navbar-default .navbar-nav .open .dropdown-menu > .active > a:hover,
   .navbar-default .navbar-nav .open .dropdown-menu > .active > a:focus {
     color: #ffffff;
-    background-color: #FF9819;
+    background-color: var(--primary-accent);
   }
   .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a,
   .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:hover,
@@ -3268,7 +3280,7 @@ label {
   border-radius: 0;
 }
 .form-control:focus {
-  border-color: #FF9819;
+  border-color: var(--primary-accent);
   outline: 0;
   -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(56, 167, 187, 0.6);
   box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(56, 167, 187, 0.6);
@@ -3291,14 +3303,14 @@ label {
 .pager li > a,
 .pager li > span {
   background-color: #ffffff;
-  border: 1px solid #FF9819;
+  border: 1px solid var(--primary-accent);
   border-radius: 0;
 }
 .pager li > a:hover,
 .pager li > a:focus {
   text-decoration: none;
   color: #fff;
-  background-color: #FF9819;
+  background-color: var(--primary-accent);
 }
 .pager .disabled > a,
 .pager .disabled > a:hover,
@@ -3319,7 +3331,7 @@ label {
   padding: 6px 12px;
   line-height: 1.42857143;
   text-decoration: none;
-  color: #FF9819;
+  color: var(--primary-accent);
   background-color: #ffffff;
   border: 1px solid #dddddd;
 }
@@ -3327,7 +3339,7 @@ label {
 .pagination > li > span:hover,
 .pagination > li > a:focus,
 .pagination > li > span:focus {
-  color: #FF9819;
+  color: var(--primary-accent);
   background-color: #a7dbe5;
   border-color: #dddddd;
 }
@@ -3339,8 +3351,8 @@ label {
 .pagination > .active > span:focus {
   z-index: 2;
   color: #ffffff;
-  background-color: #FF9819;
-  border-color: #FF9819;
+  background-color: var(--primary-accent);
+  border-color: var(--primary-accent);
 }
 .pagination > .disabled > span,
 .pagination > .disabled > span:hover,
@@ -3422,14 +3434,14 @@ p {
   font-style: italic;
 }
 .text-primary {
-  color: #FF9819;
+  color: var(--primary-accent);
 }
 a.text-primary:hover {
   color: #2c8494;
 }
 .bg-primary {
   color: #fff;
-  background-color: #FF9819;
+  background-color: var(--primary-accent);
 }
 a.bg-primary:hover {
   background-color: #2c8494;
@@ -3442,7 +3454,7 @@ blockquote {
   padding: 10px 20px;
   margin: 0 0 20px;
   font-size: 14px;
-  border-left: 5px solid #FF9819;
+  border-left: 5px solid var(--primary-accent);
 }
 blockquote footer,
 blockquote small,
@@ -3459,7 +3471,7 @@ blockquote .small:before {
 }
 .blockquote-reverse,
 blockquote.pull-right {
-  border-right: 5px solid #FF9819;
+  border-right: 5px solid var(--primary-accent);
 }
 address {
   margin-bottom: 20px;
@@ -3504,22 +3516,22 @@ address {
   border-color: #ccc;
 }
 .panel-primary {
-  border-color: #FF9819;
+  border-color: var(--primary-accent);
 }
 .panel-primary > .panel-heading {
   color: #ffffff;
-  background-color: #FF9819;
-  border-color: #FF9819;
+  background-color: var(--primary-accent);
+  border-color: var(--primary-accent);
 }
 .panel-primary > .panel-heading + .panel-collapse > .panel-body {
-  border-top-color: #FF9819;
+  border-top-color: var(--primary-accent);
 }
 .panel-primary > .panel-heading .badge {
-  color: #FF9819;
+  color: var(--primary-accent);
   background-color: #ffffff;
 }
 .panel-primary > .panel-footer + .panel-collapse > .panel-body {
-  border-bottom-color: #FF9819;
+  border-bottom-color: var(--primary-accent);
 }
 .panel-primary .panel-title {
   font-weight: 300;
@@ -3536,7 +3548,7 @@ a.badge:focus {
 }
 a.list-group-item.active > .badge,
 .nav-pills > .active > a > .badge {
-  color: #FF9819;
+  color: var(--primary-accent);
   background-color: #ffffff;
 }
 .nav-pills > li > a > .badge {

--- a/site/themes/s2b_hugo_theme/assets/css/theme.css
+++ b/site/themes/s2b_hugo_theme/assets/css/theme.css
@@ -3198,7 +3198,7 @@ a {
 }
 a:hover,
 a:focus {
-  color: #e57e00;
+  color: var(--link-focus);
   text-decoration: underline;
 }
 a:focus {

--- a/site/themes/s2b_hugo_theme/assets/css/theme.css
+++ b/site/themes/s2b_hugo_theme/assets/css/theme.css
@@ -714,7 +714,7 @@ fieldset[disabled] .btn-template-transparent-black.active {
 .btn-template-primary.active,
 .open > .dropdown-toggle.btn-template-primary {
   color: #ffffff;
-  background-color: #2c8494;
+  background-color: var(--link-hover-bg);
   border-color: #2a7d8c;
 }
 .btn-template-primary:active,
@@ -3282,8 +3282,8 @@ label {
 .form-control:focus {
   border-color: var(--primary-accent);
   outline: 0;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(56, 167, 187, 0.6);
-  box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(56, 167, 187, 0.6);
+  -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px var(--form-shadow);
+  box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px var(--form-shadow);
 }
 .form-group {
   margin-bottom: 20px;
@@ -3340,7 +3340,7 @@ label {
 .pagination > li > a:focus,
 .pagination > li > span:focus {
   color: var(--primary-accent);
-  background-color: #a7dbe5;
+  background-color: var(--pagination-bg);
   border-color: #dddddd;
 }
 .pagination > .active > a,
@@ -3437,14 +3437,14 @@ p {
   color: var(--primary-accent);
 }
 a.text-primary:hover {
-  color: #2c8494;
+  color: var(--link-hover-bg);
 }
 .bg-primary {
   color: #fff;
   background-color: var(--primary-accent);
 }
 a.bg-primary:hover {
-  background-color: #2c8494;
+  background-color: var(--link-hover-bg);
 }
 abbr[title],
 abbr[data-original-title] {

--- a/site/themes/s2b_hugo_theme/assets/css/theme.css
+++ b/site/themes/s2b_hugo_theme/assets/css/theme.css
@@ -329,7 +329,7 @@ ul.list-style-none {
 .navbar ul.nav > li.active > a,
 .navbar ul.nav > li.open > a {
   text-decoration: none !important;
-  border-top: solid 5px #ffc14d;
+  border-top: solid 5px var(--navbar-border-top);
 }
 @media (max-width: 768px) {
   .navbar ul.nav > li.active > a,
@@ -341,12 +341,12 @@ ul.list-style-none {
   }
 }
 .navbar.navbar-light ul.nav > li.active > a {
-  border-top: solid 5px #ffaf4d;
+  border-top: solid 5px var(--navbar-border-top);
   background: #fff !important;
   color: #555555 !important;
 }
 .navbar.navbar-light ul.nav > li.active > a:hover {
-  border-top: solid 5px #ffaf4d;
+  border-top: solid 5px var(--navbar-border-top);
 }
 .navbar.navbar-light ul.nav > li > a:hover,
 .navbar.navbar-light ul.nav > li.open > a:hover,

--- a/site/themes/s2b_hugo_theme/assets/css/theme.css
+++ b/site/themes/s2b_hugo_theme/assets/css/theme.css
@@ -139,7 +139,7 @@ div.section {
   display: inline-block;
   width: 80px;
   height: 80px;
-  color: currentColor;
+  color: #fff;
   line-height: 80px;
   border-radius: 40px;
   border: solid 1px #fff;
@@ -369,7 +369,7 @@ ul.list-style-none {
 }
 .navbar ul.dropdown-menu li a {
   position: relative;
-  color: #555555;
+  color: #999999;
   font-size: 12px;
   display: block;
   -webkit-transition: all 0.2s ease-out;
@@ -1447,8 +1447,8 @@ fieldset[disabled] .btn-template-primary.active {
   margin-bottom: 40px;
 }
 .box-simple .icon {
-  color: #38a7bb;
-  border-color: #38a7bb;
+  color: var(--primary-accent);
+  border-color: var(--primary-accent);
   -webkit-transition: all 0.2s ease-out;
   -moz-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
@@ -2192,6 +2192,12 @@ fieldset[disabled] .btn-template-primary.active {
 #blog-post #post-content {
   margin-bottom: 20px;
 }
+#blog-post #post-content img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: auto;
+}
 #blog-post .comment {
   margin-bottom: 25px;
 }
@@ -2509,7 +2515,7 @@ fieldset[disabled] .btn-template-primary.active {
   margin-bottom: 30px;
 }
 #get-it {
-  background: #38a7bb;
+  background: var(--primary-accent);
   padding: 50px 0 30px;
   color: #fff;
   text-align: center;
@@ -2553,7 +2559,7 @@ fieldset[disabled] .btn-template-primary.active {
   list-style: none;
 }
 
-#footer-ul li{
+#footer-ul li {
   padding-left: 10px;
   padding-right:10px;
   text-transform: uppercase;
@@ -2564,7 +2570,7 @@ fieldset[disabled] .btn-template-primary.active {
   color: #999999;
 }
 #footer ul a:hover {
-  color: #38a7bb;
+  color: var(--primary-accent);
   text-decoration: none;
 }
 #footer .photostream div {
@@ -2631,7 +2637,7 @@ fieldset[disabled] .btn-template-primary.active {
   margin: 0 10px 0 0;
 }
 #footer .social a:hover {
-  color: #38a7bb;
+  color: var(--primary-accent);
 }
 #copyright {
   background: #333;
@@ -2707,10 +2713,10 @@ fieldset[disabled] .btn-template-primary.active {
 .nav .open > a:hover,
 .nav .open > a:focus {
   background-color: #eeeeee;
-  border-color: #38a7bb;
+  border-color: var(--primary-accent);
 }
 .nav-tabs {
-  border-bottom: 1px solid #38a7bb;
+  border-bottom: 1px solid var(--primary-accent);
 }
 .nav-tabs > li {
   float: left;
@@ -2723,20 +2729,20 @@ fieldset[disabled] .btn-template-primary.active {
   border-radius: 0 0 0 0;
 }
 .nav-tabs > li > a:hover {
-  border-color: #eeeeee #eeeeee #38a7bb;
+  border-color: #eeeeee #eeeeee var(--primary-accent);
 }
 .nav-tabs > li.active > a,
 .nav-tabs > li.active > a:hover,
 .nav-tabs > li.active > a:focus {
   color: #555555;
   background-color: #ffffff;
-  border: 1px solid #38a7bb;
+  border: 1px solid var(--primary-accent);
   border-bottom-color: transparent;
   cursor: default;
 }
 .nav-tabs.nav-justified {
   width: 100%;
-  border-bottom: solid 1px #38a7bb;
+  border-bottom: solid 1px var(--primary-accent);
   border-bottom: 0;
 }
 .nav-tabs.nav-justified > li {
@@ -2757,11 +2763,11 @@ fieldset[disabled] .btn-template-primary.active {
 .nav-tabs.nav-justified > .active > a,
 .nav-tabs.nav-justified > .active > a:hover,
 .nav-tabs.nav-justified > .active > a:focus {
-  border: 1px solid #38a7bb;
+  border: 1px solid var(--primary-accent);
 }
 @media (min-width: 768px) {
   .nav-tabs.nav-justified > li > a {
-    border-bottom: 1px solid #38a7bb;
+    border-bottom: 1px solid var(--primary-accent);
     border-radius: 0 0 0 0;
   }
   .nav-tabs.nav-justified > .active > a,
@@ -2783,7 +2789,7 @@ fieldset[disabled] .btn-template-primary.active {
 .nav-pills > li.active > a:hover,
 .nav-pills > li.active > a:focus {
   color: #ffffff;
-  background-color: #38a7bb;
+  background-color: var(--primary-accent);
 }
 .nav-stacked > li {
   float: none;
@@ -2794,7 +2800,7 @@ fieldset[disabled] .btn-template-primary.active {
 }
 .nav-justified {
   width: 100%;
-  border-bottom: solid 1px #38a7bb;
+  border-bottom: solid 1px var(--primary-accent);
 }
 .nav-justified > li {
   float: none;
@@ -2817,11 +2823,11 @@ fieldset[disabled] .btn-template-primary.active {
 .nav-tabs-justified > .active > a,
 .nav-tabs-justified > .active > a:hover,
 .nav-tabs-justified > .active > a:focus {
-  border: 1px solid #38a7bb;
+  border: 1px solid var(--primary-accent);
 }
 @media (min-width: 768px) {
   .nav-tabs-justified > li > a {
-    border-bottom: 1px solid #38a7bb;
+    border-bottom: 1px solid var(--primary-accent);
     border-radius: 0 0 0 0;
   }
   .nav-tabs-justified > .active > a,
@@ -3204,7 +3210,7 @@ a:focus {
 a:focus {
   outline: thin dotted;
   outline: 5px auto -webkit-focus-ring-color;
-  outline-offset: -2px;Ø
+  outline-offset: -2px;
 }
 .img-rounded {
   border-radius: 50%;
@@ -3555,7 +3561,7 @@ a.list-group-item.active > .badge,
   margin-left: 3px;
 }
 .progress-bar-primary {
-  background-color: #ffaf4d;
+  background-color: var(--primary-accent);
 }
 .progress-striped .progress-bar-primary {
   background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);

--- a/site/themes/s2b_hugo_theme/assets/css/theme.css
+++ b/site/themes/s2b_hugo_theme/assets/css/theme.css
@@ -3111,13 +3111,13 @@ fieldset[disabled] .btn-template-primary.active {
 .navbar-default .navbar-nav > li > a:hover,
 .navbar-default .navbar-nav > li > a:focus {
   color: #555555;
-  background-color: #ffc14d;
+  background-color: var(--navbar-focus);
 }
 .navbar-default .navbar-nav > .active > a,
 .navbar-default .navbar-nav > .active > a:hover,
 .navbar-default .navbar-nav > .active > a:focus {
   color: #ffffff;
-  background-color: #ffc14d;
+  background-color: var(--primary-accent);
 }
 .navbar-default .navbar-nav > .disabled > a,
 .navbar-default .navbar-nav > .disabled > a:hover,

--- a/site/themes/s2b_hugo_theme/assets/css/theme.css
+++ b/site/themes/s2b_hugo_theme/assets/css/theme.css
@@ -715,7 +715,7 @@ fieldset[disabled] .btn-template-transparent-black.active {
 .open > .dropdown-toggle.btn-template-primary {
   color: #ffffff;
   background-color: var(--link-hover-bg);
-  border-color: #2a7d8c;
+  border-color: var(--button-border);
 }
 .btn-template-primary:active,
 .btn-template-primary.active,

--- a/site/themes/s2b_hugo_theme/assets/css/theme.css
+++ b/site/themes/s2b_hugo_theme/assets/css/theme.css
@@ -67,10 +67,6 @@ button {
   -moz-transition: all 0.2s ease-out;
   transition: all 0.2s ease-out;
 }
-a i.fa,
-button i.fa {
-  margin: 0 5px;
-}
 .clickable {
   cursor: pointer !important;
 }
@@ -94,7 +90,7 @@ p.lead {
 }
 section,
 div.section {
-  /*margin-bottom: 40px;*/
+  margin-bottom: 40px;
 }
 .no-mb {
   margin-bottom: 0 !important;
@@ -119,11 +115,11 @@ div.section {
   text-transform: uppercase;
   letter-spacing: 0.06em;
 }
-.heading h1 i.fa,
-.heading h2 i.fa,
-.heading h3 i.fa,
-.heading h4 i.fa,
-.heading h5 i.fa {
+.heading h1 i[class^="fa"],
+.heading h2 i[class^="fa"],
+.heading h3 i[class^="fa"],
+.heading h4 i[class^="fa"],
+.heading h5 i[class^="fa"] {
   display: inline-block;
   background: var(--primary-accent);
   width: 30px;
@@ -265,13 +261,15 @@ ul.list-style-none {
   width: 24px;
   height: 24px;
   border-radius: 12px;
-  line-height: 20px;
+  line-height: 24px;
   font-size: 12px;
   text-align: center;
-  vertical-align: bottom;
 }
 #top .social a:hover {
   color: #fff;
+  background: var(--primary-accent);
+  -webkit-transform: scale(1.1);
+  transform: scale(1.1);
 }
 #top .social a:hover.facebook {
   background-color: #4460ae;
@@ -994,11 +992,18 @@ fieldset[disabled] .btn-template-primary.active {
   letter-spacing: 0.08em;
   font-weight: 700;
   font-size: 12px;
+  text-decoration: none;
 }
 .panel.sidebar-menu ul.tag-cloud li a:hover {
   color: var(--primary-accent);
-  text-decoration: none;
   border-color: var(--primary-accent);
+}
+.panel.sidebar-menu ul.tag-cloud li.active a {
+  color: #FFFFFF;
+  background-color: var(--primary-accent);
+}
+.panel.sidebar-menu ul.tag-cloud li.active a:hover {
+  color: #FFFFFF;
 }
 .panel.sidebar-menu ul.popular,
 .panel.sidebar-menu ul.recent {
@@ -1759,7 +1764,6 @@ fieldset[disabled] .btn-template-primary.active {
 #heading-breadcrumbs h1 {
   color: #333333;
   text-transform: uppercase;
-  text-align: center;
   font-size: 30px;
   font-weight: 700;
   letter-spacing: 0.08em;
@@ -3213,7 +3217,7 @@ a:focus {
   outline-offset: -2px;
 }
 .img-rounded {
-  border-radius: 50%;
+  border-radius: 0;
 }
 hr {
   margin-top: 20px;


### PR DESCRIPTION
The [upstream theme](https://github.com/devcows/hugo-universal-theme) has been updated a number of times since we initially [forked](https://github.com/stephaniecp/s2b_hugo_theme) it years ago. 

The main change here is switching to CSS variables for theme colors. The intended method to customize the theme is to leave theme.css alone, and add your customizations in custom.css. However, before CSS variables it was tedious to override a large number of styles, so we made changes to the original theme file. Now with CSS variables we can easily redefine the colors we want in our custom.css file. 

Visually the site should be nearly identical to before. The only visible changes are some minor shifts to shades of orange due to normalizing where the variables are applied in the base theme file. The differences are subtle and don't have any real impact to the look of the site, so it was worth it to simplify the code a bit.

I also normalized some other theme edits (padding, margins, etc) with the upstream styles, and moved our customizations to custom.css where needed.