### PR TITLE
Make front-end API requests more consistent, surface error messages on events endpoint

### DIFF
--- a/site/themes/s2b_hugo_theme/assets/js/cal/addevent.js
+++ b/site/themes/s2b_hugo_theme/assets/js/cal/addevent.js
@@ -11,10 +11,10 @@
     $.fn.getAddEventForm = function(id, secret, callback) {
         if (id && secret) {
             // TODO: loading spinner
-            $.ajax({
+            var opts = {
+                type: 'GET',
                 url: '/api/retrieve_event.php?id=' + id + "&secret=" + secret,
                 headers: { 'Api-Version': API_VERSION },
-                type: 'GET',
                 success: function(data) {
                     data.secret = secret;
                     data.readComic = true;
@@ -24,7 +24,8 @@
                 error: function(data) {
                     callback( data.responseJSON.error.message );
                 }
-            });
+            };
+            $.ajax(opts);
         } else {
             populateEditForm({ datestatuses: [] }, callback);
         }

--- a/site/themes/s2b_hugo_theme/assets/js/cal/main.js
+++ b/site/themes/s2b_hugo_theme/assets/js/cal/main.js
@@ -14,10 +14,10 @@ $(document).ready(function() {
             throw Error("requires id or range");
         }
 
-        $.ajax({
+        var opts = {
+            type: 'GET',
             url: url,
             headers: { 'Api-Version': API_VERSION },
-            type: 'GET',
             success: function(data) {
                 var groupedByDate = [];
 
@@ -78,8 +78,12 @@ $(document).ready(function() {
                     document.title = event.title + " - Calendar - " + SITE_TITLE;
                 }
                 callback(info);
+            },
+            error: function(data) {
+                callback( data.responseJSON.error.message );
             }
-        });
+        };
+        $.ajax(opts);
     }
 
     // compute range and details settings from the url options.


### PR DESCRIPTION
* Improved consistency across endpoints for how API requests are made from the front-end. Mostly just baby steps towards a larger refactor; see [issue #660](https://github.com/shift-org/shift-docs/issues/660).
* Modified front end to display error messages returned from the events API. It's exceedingly bare bones — just dumps some plain text on screen. But this makes a base to build on, and will give something for users to report to us if the API is down unexpectedly. Currently, the request silently fails and you must dig into the browser inspector/console to find the specific error.