### PR TITLE
Change PP cal page to the TBA landing page

### DIFF
--- a/docs/PEDALPALOOZA.md
+++ b/docs/PEDALPALOOZA.md
@@ -8,7 +8,7 @@
 
 approx. January–March
 
-* Change `/site/content/pedalpalooza-calendar.md` page type from `calevents` to `pp-landing`; un-comment the "stay tuned" body text. Update the front matter to the current year: `title`, `year`, `startdate`, `enddate`, and `daterange`. Temporarily set the evergreen image.
+* Change `/site/content/pedalpalooza-calendar.md` page type from `calevents` to `pp-landing`. Update the front matter to the current year: `title`, `year`, `startdate`, `enddate`, and `daterange`. Temporarily set the evergreen image.
 * Un-comment the contents of `/site/data/carousel/pedalpalooza.yaml`. Change the year, and temporarily set the evergreen image (`images/carousel/pedalpalooza-general.png`). Leave it at its current carousel position for now.
 * Update the Pedalpalooza ical feed dates in `/services/nginx/conf.d/shift.conf` ( specifies start and end dates, and exported filename. )
 
@@ -17,7 +17,7 @@ approx. January–March
 
 approx. April–early May
 
-* Change `/site/content/pedalpalooza-calendar.md` page type back to `calevents`; comment out the "stay tuned" body text
+* Change `/site/content/pedalpalooza-calendar.md` page type back to `calevents`.
 * Move the Pedalpalooza carousel to the first position
 * Set the real image in the carousel
 * Set the real image in the pp-header banner

--- a/docs/PEDALPALOOZA.md
+++ b/docs/PEDALPALOOZA.md
@@ -8,7 +8,7 @@
 
 approx. January–March
 
-* Change `/site/content/pedalpalooza-calendar.md` page type from `calevents` to `pp-landing`. Update the front matter to the current year: `title`, `year`, `startdate`, `enddate`, and `daterange`. Temporarily set the evergreen image.
+* Change `/site/content/pedalpalooza-calendar.md` page type from `calfestival` to `pp-landing`. Update the front matter to the current year: `title`, `year`, `startdate`, `enddate`, and `daterange`. Temporarily set the evergreen image.
 * Un-comment the contents of `/site/data/carousel/pedalpalooza.yaml`. Change the year, and temporarily set the evergreen image (`images/carousel/pedalpalooza-general.png`). Leave it at its current carousel position for now.
 * Update the Pedalpalooza ical feed dates in `/services/nginx/conf.d/shift.conf` ( specifies start and end dates, and exported filename. )
 
@@ -17,7 +17,7 @@ approx. January–March
 
 approx. April–early May
 
-* Change `/site/content/pedalpalooza-calendar.md` page type back to `calevents`.
+* Change `/site/content/pedalpalooza-calendar.md` page type back to `calfestival`.
 * Move the Pedalpalooza carousel to the first position
 * Set the real image in the carousel
 * Set the real image in the pp-header banner

--- a/site/content/pedalpalooza-calendar.md
+++ b/site/content/pedalpalooza-calendar.md
@@ -3,23 +3,13 @@ title: "Pedalpalooza calendar"
 description: "Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
-type: calfestival
+type: pp-landing
 pp: true
-year: 2024
-startdate: 2024-06-01
-enddate: 2024-08-31
-daterange: June 1–August 31, 2024
-banner-image: "/images/pp/pp2024-banner.png"
-poster-image: "/images/pp/pp2024.png"
+year: 2025
+startdate: 2025-06-01
+enddate: 2025-08-31
+daterange: June 1–August 31, 2025
+banner-image: "/images/pp/pp-general-banner.png"
+poster-image: "/images/pp/pp-general.png"
 
 ---
-
-<!--
-[Use only when in "landing page" mode before full launch for the year]
--->
-
-<!--
-Stay tuned for more information on [Pedalpalooza](/pages/pedalpalooza/) 2024! Be sure to follow [Pedalpalooza on Instagram](https://www.instagram.com/pedalpaloozapdx/) and [Pedalpalooza.org](https://www.pedalpalooza.org/) for updates!
-
-Seeking inspiration? View the [Pedalpalooza archives](/archive/pedal-palooza-archives/) for past bicycle fun events. Looking for current events? Check out the current [ride calendar](/calendar/).
--->

--- a/site/themes/s2b_hugo_theme/layouts/pp-landing/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/pp-landing/single.html
@@ -10,7 +10,9 @@
                       <!-- <span class="pp-daterange">{{ .Param "daterange" }}</span> -->
                     </div>
 
-                  {{ .Content }}
+                    <p>Stay tuned for more information on the next <a href="/pages/pedalpalooza/">Pedalpalooza</a>! Be sure to follow <a href="https://www.bike-summer.org">Bike-Summer.org</a> and <a href="https://www.instagram.com/pedalpaloozapdx/">Pedalpalooza on Instagram</a> for updates!</p>
+
+                    <p>Seeking inspiration? View the <a href="/archive/pedal-palooza-archives/">Pedalpalooza archives</a> for past bicycle fun events. Looking for current events? Check out the current <a href="/calendar/">ride calendar</a>.</p>
                   
                   </div> <!-- end pp_heading -->
                   


### PR DESCRIPTION
* Changed Pedalpalooza calendar page from 2024 calendar to "TBA" landing page
* Moved the "coming soon" content out of the Markdown content and moved it into the landing page partial. Now it sits in the only place where it's needed, so no need to comment/uncomment it throughout the year; also updated docs to reflect this.