### PR TITLE
Fallback error message if events request doesn't include JSON

### DIFF
--- a/site/themes/s2b_hugo_theme/assets/css/cal/main.css
+++ b/site/themes/s2b_hugo_theme/assets/css/cal/main.css
@@ -475,3 +475,8 @@ button.expand-details {
   display: flex;
   justify-content: space-between;
 }
+
+.error {
+  padding: 1rem;
+  text-align: center;
+}

--- a/site/themes/s2b_hugo_theme/assets/js/cal/addevent.js
+++ b/site/themes/s2b_hugo_theme/assets/js/cal/addevent.js
@@ -26,7 +26,13 @@
                     populateEditForm( data, callback );
                 },
                 error: function(data) {
-                    callback( data.responseJSON.error.message );
+                    let msg = data.responseJSON?.error?.message;
+                    if (!msg) {
+                        msg = `${data.status} ${data.statusText}`;
+                    }
+                    template = $('#request-error').html();
+                    rendered = Mustache.render(template, { "error": msg } );
+                    callback(rendered);
                 }
             };
             $.ajax(opts);

--- a/site/themes/s2b_hugo_theme/assets/js/cal/main.js
+++ b/site/themes/s2b_hugo_theme/assets/js/cal/main.js
@@ -83,7 +83,11 @@ $(document).ready(function() {
                 callback(info);
             },
             error: function(data) {
-                callback( data.responseJSON.error.message );
+                if (data.responseJSON) {
+                  callback( `Error: ${data.responseJSON.error.message}` );
+                } else {
+                  callback( `Error: ${data.status} ${data.statusText}` );
+                }
             }
         };
         $.ajax(opts);

--- a/site/themes/s2b_hugo_theme/assets/js/cal/main.js
+++ b/site/themes/s2b_hugo_theme/assets/js/cal/main.js
@@ -83,10 +83,11 @@ $(document).ready(function() {
                 callback(info);
             },
             error: function(data) {
-                if (data.responseJSON) {
-                  callback( `Error: ${data.responseJSON.error.message}` );
+                const msg = data.responseJSON?.error?.message;
+                if (msg) {
+                    callback( `Error: ${msg}` );
                 } else {
-                  callback( `Error: ${data.status} ${data.statusText}` );
+                    callback( `Error: ${data.status} ${data.statusText}` );
                 }
             }
         };

--- a/site/themes/s2b_hugo_theme/assets/js/cal/main.js
+++ b/site/themes/s2b_hugo_theme/assets/js/cal/main.js
@@ -83,12 +83,13 @@ $(document).ready(function() {
                 callback(info);
             },
             error: function(data) {
-                const msg = data.responseJSON?.error?.message;
-                if (msg) {
-                    callback( `Error: ${msg}` );
-                } else {
-                    callback( `Error: ${data.status} ${data.statusText}` );
+                let msg = data.responseJSON?.error?.message;
+                if (!msg) {
+                    msg = `${data.status} ${data.statusText}`;
                 }
+                template = $('#request-error').html();
+                rendered = Mustache.render(template, { "error": msg } );
+                callback(rendered);
             }
         };
         $.ajax(opts);

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
@@ -345,3 +345,7 @@
   [[/dates]]
 
 </script>
+
+<script id="request-error" type="text/template">
+  <p class="error">Error: [[ error ]]</p>
+</script>


### PR DESCRIPTION
If an events request returns an error but doesn't include a JSON object, show the status code and text instead.