### PR TITLE
Semantic improvements for suggestion email helper on add/edit form 

### DIFF
--- a/site/themes/s2b_hugo_theme/assets/css/cal/addevent.css
+++ b/site/themes/s2b_hugo_theme/assets/css/cal/addevent.css
@@ -203,23 +203,27 @@ form#event-entry .date-select-container-style {
 }
 
 #email-suggestion {
-    display:none;
-    color: red;
+    color: #d00000;
     font-style: italic;
     margin-top: 5px;
 }
 
-#email-suggestion .correction {
+#email-suggestion .email-address {
     color: blue;
-    cursor: pointer;
+    text-decoration: underline;
+}
+
+#email-suggestion button {
+    background: none;
+    border: none;
 }
 
 #email-suggestion .glyphicon {
     color: grey;
-    cursor: pointer;
     margin-left: 3px;
     border: 1px solid lightgray;
     border-radius: 3px;
+    font-style: normal;
 }
 
 #event-fields .image-form {

--- a/site/themes/s2b_hugo_theme/assets/js/cal/addevent.js
+++ b/site/themes/s2b_hugo_theme/assets/js/cal/addevent.js
@@ -417,31 +417,30 @@
     $(document).on( 'blur', '#email', function () {
         $( this ).mailcheck( {
             suggested: function ( element, suggestion ) {
-                var template = $( '#email-suggestion-template' ).html(),
+                const template = $( '#email-suggestion-template' ).html(),
                     data = { suggestion: suggestion.full },
                     message = Mustache.render( template, data );
                 $( '#email-suggestion' )
-                    .html( message )
-                    .show();
+                    .html( message );
             },
             empty: function ( element ) {
-                $( '#emailMsg' )
-                    .hide();
+                $( '#email-suggestion' )
+                    .empty();
             }
         } );
     } );
 
-    $(document).on('click', '#email-suggestion .correction', function () {
-        $('#email').val( $( this ).text() );
-        $('#email-suggestion')
-            .hide();
+    $(document).on('click', '#email-suggestion [data-js-correction]', function () {
+        $('#email').val( $( '#email-suggestion .email-address' ).text() );
+        $('#email').focus();
+        $('#email-suggestion').empty();
     } );
 
-    $(document).on('click', '#email-suggestion .glyphicon-remove', function () {
-        $('#email-suggestion')
-            .hide();
+    $(document).on('click', '#email-suggestion [data-js-dismiss]', function () {
         // They clicked the X button, turn mailcheck off
         // TODO: Remember unwanted corrections in local storage, don't offer again
+        $('#email-suggestion').empty();
+        $('#email').next('input').focus();
         $(document).off('blur', '#email');
     } );
 

--- a/site/themes/s2b_hugo_theme/assets/js/cal/addevent.js
+++ b/site/themes/s2b_hugo_theme/assets/js/cal/addevent.js
@@ -418,14 +418,12 @@
         $( this ).mailcheck( {
             suggested: function ( element, suggestion ) {
                 const template = $( '#email-suggestion-template' ).html(),
-                    data = { suggestion: suggestion.full },
-                    message = Mustache.render( template, data );
-                $( '#email-suggestion' )
-                    .html( message );
+                      data = { suggestion: suggestion.full },
+                      message = Mustache.render( template, data );
+                $( '#email-suggestion' ).html( message );
             },
             empty: function ( element ) {
-                $( '#email-suggestion' )
-                    .empty();
+                $( '#email-suggestion' ).empty();
             }
         } );
     } );

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html
@@ -332,9 +332,9 @@
 
             <div class="form-group">
               <label class="control-label req-label" for="email">Email</label>
-              <input type="text" class="form-control" name="email" id="email" value="[[email]]" autocomplete="email" aria-describedby="email-help" required="true" aria-invalid="false" />
+              <input type="text" class="form-control" name="email" id="email" value="[[email]]" autocomplete="email" aria-describedby="email-help email-suggestion" required="true" aria-invalid="false" />
               <p class="input-help" id="email-help">This must be a valid email address where we can reach you. A confirmation message will be mailed to this address.</p>
-              <div id="email-suggestion"></div>
+              <div id="email-suggestion" aria-live="polite"></div>
 
               <div>
                 <label class="control-label" for="hideemail">
@@ -554,6 +554,6 @@
 </script>
 
 <script id="email-suggestion-template" type="text/template">
-  Did you mean <span class="correction">[[ suggestion ]]</span>?
-  <sup><span class="glyphicon glyphicon-remove"></span></sup>
+  <button type="button" data-js-correction>Did you mean <span class="email-address">[[ suggestion ]]</span>?</button>
+  <button type="button" data-js-dismiss><span class="glyphicon glyphicon-remove" role="img" aria-label="Dismiss"></span></button>
 </script>


### PR DESCRIPTION
* Use proper semantic buttons for email suggestion (previously, suggestion "buttons" were clickable but not keyboard-focusable)
* Use `aria-live` announcement when suggestion appears