### PR TITLE
search: add page numbers to results

### DIFF
--- a/cal/src/calSearch.js
+++ b/cal/src/calSearch.js
@@ -15,21 +15,22 @@ export async function fetchSearch(q, offset) {
 // internal functions
 // ---------------------------------------------------------------------
 function buildPage(q, offset, res) {
+  const pageNum = Math.round(0.5 + (offset / siteConfig.searchWidth));
   return {
     page: {
-      title: `${q} - searching ${siteConfig.title}`,
+      title: `${q} - Page ${pageNum} searching ${siteConfig.title}`,
       banner: siteConfig.defaultListBanner,
       // desc
     },
     data: {
-      q, 
-      offset,
       // the number of events is the "width"
       // if offset + width >= total; there's no more results.
       events: res.events, 
       // FIX: server should return this if possible
       // ( unless it can't and then the client can count by offset.
-      total: res.total || res.events.length,
+      // total: res.total || res.events.length,
+      // 
+      pageNum,
     },
     shortcuts: buildShortcuts(q, offset, res.events.length)
   }; 
@@ -45,20 +46,20 @@ function buildShortcuts(q, offset, count) {
   }
   function shift(vm, offset) {
     vm.$router.push({query: { 
-      q, offset,
+      q, offset: offset || undefined, // when zero, hide the offset.
     }});
   }
   return {
     prev: offset > 0 ? (vm) => {
-      const next = Math.max(0, offset - count);
+      const next = Math.max(0, offset - siteConfig.searchWidth);
       return { 
         click() {
           shift(vm, next);
         }
       };
     } : disabled,
-    next: count > 0 ? (vm) => {
-      const next = offset + count;
+    next: count == siteConfig.searchWidth ? (vm) => {
+      const next = offset + siteConfig.searchWidth;
       return { 
         click() {
           shift(vm, next);

--- a/cal/src/siteConfig.js
+++ b/cal/src/siteConfig.js
@@ -53,6 +53,8 @@ export default {
   // see buildPedalDates.html
   pedalp, 
   title: "Shift",
+  // for now pagination is a fixed size.
+  searchWidth: 25,
   // dayjs date
   getFestival(date) {
     const year = date.year().toString();

--- a/docs/CalVue.md
+++ b/docs/CalVue.md
@@ -1,8 +1,18 @@
 Cal Single Page App Status 
 ============
 
+* pagination
+  - change offset = 0 to be no offset
+  - Found 25 events containing "ride". 
+  -> Page 1 of 25+ events containing "ride". 
+
 * fix the menu display -- try as tabs
 * add pedalp info
+* pedalp image should show whenever it appears in the week
+
+
+[ ] pagination: 10 or 20 per page.  - i wonder if pagination might be able to be generic (re: search): ex. give page a count, and let shortcuts handle it. ( or a shared function )
+
 
 ### Favorites
 
@@ -10,7 +20,7 @@ Cal Single Page App Status
     maybe those could be new buttons under the top bar of buttons on a new row.
 [ ] filtering: show all, show future
 [ ] an empty page should provide information about favoriting
-[ ] pagination: 10 or 20 per page.  - i wonder if pagination might be able to be generic (re: search): ex. give page a count, and let shortcuts handle it. ( or a shared function )
+
 [ ] a disclaimer about opening each one to see the latest information. * could maybe replace the current disclaimer? )
 [ ] TODO: some sort of animation / popup when when favorite status changes
     -- maybe like some little ghost text that say "saved!" "removed!" and fades out -- hovers about the shortcut; but doesn't harm the layout --


### PR DESCRIPTION
disable prev at the first page, next at the last page ( based on a fixed number of expected results )