### PR TITLE
Use params for (most) festival details

### DIFF
--- a/site/config/_default/hugo.toml
+++ b/site/config/_default/hugo.toml
@@ -98,7 +98,6 @@ disableKinds = ["taxonomy", "term"]
 # Festival details
 [params.festival]
     name = "Bike Summer"
-    latest = 2025
     active = true # set to true when festival is happening soon or now
     donationsURL = "https://www.paypal.com/donate/?cmd=_s-xclick&hosted_button_id=NQAUFEUSM49ZJ"
 

--- a/site/config/_default/hugo.toml
+++ b/site/config/_default/hugo.toml
@@ -92,6 +92,16 @@ disableKinds = ["taxonomy", "term"]
     # mastodon verification
     verificationURL = "https://pdx.social/@shift2bikes"
 
+    # link for accepting donations
+    donationsURL = "https://www.paypal.com/donate/?cmd=_s-xclick&hosted_button_id=BNL2NY7U8GH3Q"
+
+# Festival details
+[params.festival]
+    name = "Bike Summer"
+    latest = 2025
+    active = true # set to true when festival is happening soon or now
+    donationsURL = "https://www.paypal.com/donate/?cmd=_s-xclick&hosted_button_id=NQAUFEUSM49ZJ"
+
 # Main page image carousel
 [params.carousel]
     enable = true

--- a/site/content/archive/pedal-palooza-archives.md
+++ b/site/content/archive/pedal-palooza-archives.md
@@ -10,94 +10,94 @@ weight: 2
 
 In 2002, Portland hosted [Bike Summer](https://criticalmass.wikia.com/wiki/Bike_Summer!), and it was great! So every summer since then, we've had a summer bike festival. From 2004 it was called <dfn>Pedalpalooza</dfn>, and in 2022 it returned to its roots with the original name Bike Summer. Choose one of the following years to see its calendar of events.
 
-*   [2024](/archive/pedalpalooza/pedalpalooza-2024/)
+*   [Bike Summer 2024](/archive/pedalpalooza/pedalpalooza-2024/)
 
     Started on a Saturday and ended Labor Day weekend, with oodles of rides large and small, every day! 875 events!
 
-*   [2023](/archive/pedalpalooza/pedalpalooza-2023/)
+*   [Bike Summer 2023](/archive/pedalpalooza/pedalpalooza-2023/)
 
     Bike Summer was once again big, bold, and full of bike fun! 836 events!
 
-*   [2022](/archive/pedalpalooza/pedalpalooza-2022/)
+*   [Bike Summer 2022](/archive/pedalpalooza/pedalpalooza-2022/)
 
     Bike Summer 20th anniversary! We biked and biked and biked all of June, July, and August! Even bigger than last year — 800 events!!
 
-*   [2021](/archive/pedalpalooza/pedalpalooza-2021/)
+*   [Pedalpalooza 2021](/archive/pedalpalooza/pedalpalooza-2021/)
 
     Back and bigger than ever — 3 whole months! Bike summer lasted all of June, July, and August. Over 600 events!!
 
-*   [2020](/archive/pedalpalooza/pedalpalooza-2020/)
+*   [Pedalpalooza 2020](/archive/pedalpalooza/pedalpalooza-2020/)
 
     Something different this year — we rode separate, but together. 5 weeks long, with a different theme every day!
 
-*   [2019](/archive/pedalpalooza/pedalpalooza-2019/)
+*   [Pedalpalooza 2019](/archive/pedalpalooza/pedalpalooza-2019/)
 
     Started on a Saturday, lasted all month! 342 events!
 
-*   [2018](/archive/pedalpalooza/pedalpalooza-2018/)
+*   [Pedalpalooza 2018](/archive/pedalpalooza/pedalpalooza-2018/)
 
     Another month of bike fun — all of June! 309 events!
 
-*   [2017](/archive/pedalpalooza/pedalpalooza-2017/)
+*   [Pedalpalooza 2017](/archive/pedalpalooza/pedalpalooza-2017/)
 
     A whole month of bike fun, June 1 - June 30th. 327 events!
 
-*   [2016](/archive/pedalpalooza/pedalpalooza-2016/)
+*   [Pedalpalooza 2016](/archive/pedalpalooza/pedalpalooza-2016/)
 
     292 events!
 
-*   [2015](/archive/pedalpalooza/pedalpalooza-2015/)
+*   [Pedalpalooza 2015](/archive/pedalpalooza/pedalpalooza-2015/)
 
     294 events!
 
-*   [2014](/archive/pedalpalooza/pedalpalooza-2014/)
+*   [Pedalpalooza 2014](/archive/pedalpalooza/pedalpalooza-2014/)
 
     298 events! 308 if you count repeats.
 
-*   [2013](/archive/pedalpalooza/pedalpalooza-2013/)
+*   [Pedalpalooza 2013](/archive/pedalpalooza/pedalpalooza-2013/)
 
     280 events, 3+ weeks of bike fun, from June 6th through 29th. The big naked ride Saturday, June 8th, was almost certainly the largest ever, anywhere.
 
-*   [2012](/archive/pedalpalooza/pedalpalooza-2012/)
+*   [Pedalpalooza 2012](/archive/pedalpalooza/pedalpalooza-2012/)
 
     For the first time, we expanded to 3+ weeks of bike fun! The intent was to spread out roughly the same number of events over more days, so you could participate in more of them. 298 events... or 313 if you count each instance of repeating events.
 
-*   [2011](/archive/pedalpalooza/pedalpalooza-2011/)
+*   [Pedalpalooza 2011](/archive/pedalpalooza/pedalpalooza-2011/)
 
     About 270 events — slightly less than 2010\. The big naked ride was also slightly down, due to weather fears. Be brave! Be ambitious! Try harder in 2012!
 
-*   [2010](/archive/pedalpalooza/pedalpalooza-2010/)
+*   [Pedalpalooza 2010](/archive/pedalpalooza/pedalpalooza-2010/)
 
     We had roughly 300 events, and a very strong attendance. The naked ride alone had somewhere between 7000 and 12,500 riders.
 
-*   [2009](/archive/pedalpalooza/pedalpalooza-2009/)
+*   [Pedalpalooza 2009](/archive/pedalpalooza/pedalpalooza-2009/)
 
     In 2009 the number of events was down a tiny bit, but the number of people at each event seemed to double. One highlight is that we had about 5000 people for the World Naked Bike Ride... or nearly 1% of Portlanders!
 
-*   [2008](/archive/pedalpalooza/pedalpalooza-2008/)
+*   [Pedalpalooza 2008](/archive/pedalpalooza/pedalpalooza-2008/)
 
     Vastly larger than previous years. The Portland Mercury increased their involvement. Shift hosted the International Toward Carfree Cities Conference. The City of Portland had its first Sunday Parkways (Ciclovia). Soaring fuel pricess increased interest in bikes. The result: 185 events in the printed calendar, and 197 events in the online calendar (not counting repeating events). Larger crowds all around. Wonderful. I'm still sleepy.
 
-*   [2007](/archive/pedalpalooza/pedalpalooza-2007/)
+*   [Pedalpalooza 2007](/archive/pedalpalooza/pedalpalooza-2007/)
 
     The printed calendar had 130 events, and the online calendar ended up with 140\. That's may sound a hair's breadth smaller than PP2006, but actually most of the events attracted far more people in 2007\. Yea Bikes! Go Team! Rah! Rah! [Ride Reports (PDF)](http://www.shift2bikes.org/pedalpalooza/ridereports/pp_reports_2007.pdf)
 
-*   [2006](/archive/pedalpalooza/pedalpalooza-2006/)
+*   [Pedalpalooza 2006](/archive/pedalpalooza/pedalpalooza-2006/)
 
     The printed calendar had 133 events, and the online calendar ended up with 143 (taking cancellations into account). Which was your favorite?
 
-*   [2005](/archive/pedalpalooza/pedalpalooza-2005/)
+*   [Pedalpalooza 2005](/archive/pedalpalooza/pedalpalooza-2005/)
 
     That Pedalpalooza was huge. The printed calendar had 95 events, but the online calendar, which could be updated throughout the festival, ended up with 114 events.
 
-*   [2004](/archive/pedalpalooza/pedalpalooza-2004/)
+*   [Pedalpalooza 2004](/archive/pedalpalooza/pedalpalooza-2004/)
 
     The first year that it was called "Pedalpalooza" and the first with a 16-day Thursday-to-Saturday schedule. It had 68 events.
 
-*   [2003](/archive/pedalpalooza/pedalpalooza-2003/)
+*   [Mini Bike Summer 2003](/archive/pedalpalooza/pedalpalooza-2003/)
 
     Mini BikeSummer. 49 events. Apparently, Portland was the first (and so far only?) BikeSummer site to continue the festival on following years. This first year, it was organized in cooperation with [Zoobomb](https://www.zoobombpdx.org/). (A brief [history of Shift and Zoobomb](/archive/shift-and-zoobomb-history/).)
 
-*   [2002](/archive/pedalpalooza/pedalpalooza-2002/)
+*   [Bike Summer 2002](/archive/pedalpalooza/pedalpalooza-2002/)
 
     BikeSummer! In August, not June? Wow, the things we forget. 97 events.

--- a/site/content/archive/pedalpalooza/pedalpalooza-2002.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2002.md
@@ -1,5 +1,5 @@
 ---
-title: 2002 Pedalpalooza calendar
+title: 2002 Bike Summer calendar
 weight: 2
 id: pedalpalooza-calendar
 type: calfestival

--- a/site/content/archive/pedalpalooza/pedalpalooza-2003.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2003.md
@@ -4,6 +4,7 @@ description: "2003 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
 type: calfestival
+festival.name: "Mini Bike Summer"
 pp: true
 year: 2003
 startdate: 2003-06-13

--- a/site/content/archive/pedalpalooza/pedalpalooza-2003.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2003.md
@@ -1,6 +1,6 @@
 ---
-title: "2003 Pedalpalooza calendar"
-description: "2003 Pedalpalooza calendar"
+title: "2003 Mini Bike Summer calendar"
+description: "2003 Mini Bike Summer calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
 type: calfestival

--- a/site/content/archive/pedalpalooza/pedalpalooza-2004.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2004.md
@@ -4,6 +4,7 @@ description: "2004 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
 type: calfestival
+festival.name: "Pedalpalooza"
 pp: true
 year: 2004
 startdate: 2004-06-10

--- a/site/content/archive/pedalpalooza/pedalpalooza-2005.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2005.md
@@ -4,6 +4,7 @@ description: "2005 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
 type: calfestival
+festival.name: "Pedalpalooza"
 pp: true
 year: 2005
 startdate: 2005-06-09

--- a/site/content/archive/pedalpalooza/pedalpalooza-2006.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2006.md
@@ -4,6 +4,7 @@ description: "2006 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
 type: calfestival
+festival.name: "Pedalpalooza"
 pp: true
 year: 2006
 startdate: 2006-06-08

--- a/site/content/archive/pedalpalooza/pedalpalooza-2007.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2007.md
@@ -4,6 +4,7 @@ description: "2007 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
 type: calfestival
+festival.name: "Pedalpalooza"
 pp: true
 year: 2007
 startdate: 2007-06-07

--- a/site/content/archive/pedalpalooza/pedalpalooza-2008.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2008.md
@@ -4,6 +4,7 @@ description: "2008 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
 type: calfestival
+festival.name: "Pedalpalooza"
 pp: true
 year: 2008
 startdate: 2008-06-12

--- a/site/content/archive/pedalpalooza/pedalpalooza-2009.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2009.md
@@ -4,6 +4,7 @@ description: "2009 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
 type: calfestival
+festival.name: "Pedalpalooza"
 pp: true
 year: 2009
 startdate: 2009-06-11

--- a/site/content/archive/pedalpalooza/pedalpalooza-2010.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2010.md
@@ -4,6 +4,7 @@ description: "2010 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
 type: calfestival
+festival.name: "Pedalpalooza"
 pp: true
 year: 2010
 startdate: 2010-06-10

--- a/site/content/archive/pedalpalooza/pedalpalooza-2011.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2011.md
@@ -4,6 +4,7 @@ description: "2011 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
 type: calfestival
+festival.name: "Pedalpalooza"
 pp: true
 year: 2011
 startdate: 2011-06-09

--- a/site/content/archive/pedalpalooza/pedalpalooza-2012.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2012.md
@@ -4,6 +4,7 @@ description: "2012 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
 type: calfestival
+festival.name: "Pedalpalooza"
 pp: true
 year: 2012
 startdate: 2012-06-07

--- a/site/content/archive/pedalpalooza/pedalpalooza-2013.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2013.md
@@ -4,6 +4,7 @@ description: "2013 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
 type: calfestival
+festival.name: "Pedalpalooza"
 pp: true
 year: 2013
 startdate: 2013-06-06

--- a/site/content/archive/pedalpalooza/pedalpalooza-2014.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2014.md
@@ -4,6 +4,7 @@ description: "2014 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
 type: calfestival
+festival.name: "Pedalpalooza"
 pp: true
 year: 2014
 startdate: 2014-06-05

--- a/site/content/archive/pedalpalooza/pedalpalooza-2015.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2015.md
@@ -4,6 +4,7 @@ description: "2015 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
 type: calfestival
+festival.name: "Pedalpalooza"
 pp: true
 year: 2015
 startdate: 2015-06-04

--- a/site/content/archive/pedalpalooza/pedalpalooza-2016.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2016.md
@@ -4,6 +4,7 @@ description: "2016 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
 type: calfestival
+festival.name: "Pedalpalooza"
 pp: true
 year: 2016
 startdate: 2016-06-09

--- a/site/content/archive/pedalpalooza/pedalpalooza-2017.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2017.md
@@ -4,6 +4,7 @@ description: "2017 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
 type: calfestival
+festival.name: "Pedalpalooza"
 pp: true
 year: 2017
 startdate: 2017-06-01

--- a/site/content/archive/pedalpalooza/pedalpalooza-2018.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2018.md
@@ -4,6 +4,7 @@ description: "2018 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
 type: calfestival
+festival.name: "Pedalpalooza"
 pp: true
 year: 2018
 startdate: 2018-06-01

--- a/site/content/archive/pedalpalooza/pedalpalooza-2019.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2019.md
@@ -4,6 +4,7 @@ description: "2019 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
 type: calfestival
+festival.name: "Pedalpalooza"
 pp: true
 year: 2019
 startdate: 2019-06-01

--- a/site/content/archive/pedalpalooza/pedalpalooza-2020.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2020.md
@@ -4,6 +4,7 @@ description: "2020 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
 type: pp-theme-cal
+festival.name: "Pedalpalooza"
 pp: true
 year: 2020
 startdate: 2020-06-01

--- a/site/content/archive/pedalpalooza/pedalpalooza-2021.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2021.md
@@ -4,6 +4,7 @@ description: "2021 Pedalpalooza calendar"
 keywords: ["pedalpalooza"]
 id: pedalpalooza-calendar
 type: calfestival
+festival.name: "Pedalpalooza"
 pp: true
 year: 2021
 startdate: 2021-06-01

--- a/site/content/archive/pedalpalooza/pedalpalooza-2022.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2022.md
@@ -1,7 +1,7 @@
 ---
-title: "2022 Pedalpalooza calendar"
-description: "2022 Pedalpalooza calendar"
-keywords: ["pedalpalooza"]
+title: "2022 Bike Summer calendar"
+description: "2022 Bike Summer calendar"
+keywords: ["pedalpalooza", "bike summer"]
 id: pedalpalooza-calendar
 type: calfestival
 pp: true

--- a/site/content/archive/pedalpalooza/pedalpalooza-2023.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2023.md
@@ -1,7 +1,7 @@
 ---
-title: "2023 Pedalpalooza calendar"
-description: "2023 Pedalpalooza calendar"
-keywords: ["pedalpalooza"]
+title: "2023 Bike Summer calendar"
+description: "2023 Bike Summer calendar"
+keywords: ["pedalpalooza", "bike summer"]
 id: pedalpalooza-calendar
 type: calfestival
 pp: true

--- a/site/content/archive/pedalpalooza/pedalpalooza-2024.md
+++ b/site/content/archive/pedalpalooza/pedalpalooza-2024.md
@@ -1,7 +1,7 @@
 ---
-title: "2024 Pedalpalooza calendar"
-description: "2024 Pedalpalooza calendar"
-keywords: ["pedalpalooza"]
+title: "2024 Bike Summer calendar"
+description: "2024 Bike Summer calendar"
+keywords: ["pedalpalooza", "bike summer"]
 id: pedalpalooza-calendar
 type: calfestival
 pp: true

--- a/site/content/pages/donate.md
+++ b/site/content/pages/donate.md
@@ -17,9 +17,8 @@ Donations to Shift are tax-deductible via our fiscal sponsor, [Umbrella](https:/
 You can donate via PayPal with the Donate button below:
 
 <div class="donate">
-  <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=BNL2NY7U8GH3Q" target="_blank" data-content="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=BNL2NY7U8GH3Q" data-type="external" role="button" id="comp-j2nmjo3ulink" class="style-j2nmcorulink"><span id="comp-j2nmjo3ulabel" class="style-j2nmcorulabel">Donate</span></a>
+  <a href="{{% param "donationsURL" %}}" target="_blank">Donate</a>
 </div>
-
 
 Donations can also be made by mailing a check to Umbrella:
 

--- a/site/content/pages/get-involved.md
+++ b/site/content/pages/get-involved.md
@@ -20,5 +20,5 @@ Shift welcomes all respectful participants. There are a lot of ways to get invol
 * **Donate!**  The PayPal button at the bottom of the page here lets you give a tax deductible donation to Shift via our fiscal sponsor Umbrella.  You can see how we use this money on our [expenses page](/pages/budget-finance-stuff/).
 
 <div class="donate">
-  <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=BNL2NY7U8GH3Q" target="_blank" data-content="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=BNL2NY7U8GH3Q" data-type="external" role="button" id="comp-j2nmjo3ulink" class="style-j2nmcorulink"><span id="comp-j2nmjo3ulabel" class="style-j2nmcorulabel">Donate</span></a>
+  <a href="{{% param "donationsURL" %}}" target="_blank">Donate</a>
 </div>

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-header.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-header.html
@@ -1,37 +1,35 @@
 <div class="pp-banner">
-  <a href="{{ .Param "poster-image" }}"><img alt="Pedalpalooza" id="pedalpalooza-img" src="{{ .Param "banner-image" }}"></a>
+  <a href="{{ .Param "poster-image" }}"><img alt="{{ .Param "festival.name" }}" id="pedalpalooza-img" src="{{ .Param "banner-image" }}"></a>
   <div>
-    <span class="pp-headline">Bike Summer!</span>
+    <span class="pp-headline">{{ .Param "festival.name" }}</span>
     <span class="pp-daterange">{{ .Param "daterange" }}</span>
   </div>
   <button type="button" aria-expanded="true" class="expand-details" data-toggle-target="#pp-description">
     <svg class="icon expand" role="img" aria-hidden="true">
       <use href="#icon-arrow-down" />
     </svg>
-    <span>About Bike Summer</span>
+    <span>About {{ .Param "festival.name" }}</span>
   </button>
   <div id="pp-description">
       <p><a href="/pages/bike-summer/">Bike Summer</a> (aka Pedalpalooza) is a festival of bikey fun. Hundreds of different events are organized by people like you. Most rides are free and all are open to the public to join.</p>
 
-      {{ if ge (.Param "year") 2021 }}
-      <p>Bike Summer is <strong>three whole months</strong> of fun on two wheels. 
+      {{ if eq (.Param "festival.latest") (.Param "year") }}
+      <p>{{ .Param "festival.name" }} is <strong>three whole months</strong> of fun on two wheels. 
 
-      {{ if eq (.Param "year") 2025 }}<a href="/addevent/"><strong>Add your events for June, July, and August {{ .Param "year" }} now!</strong></a>{{ end }}
+      {{ if eq (.Param "festival.active") true }}<a href="/addevent/"><strong>Add your events for June, July, and August {{ .Param "year" }} now!</strong></a> Seeking inspiration? {{ end }}
 
-      Seeking inspiration? View the <a href="/archive/pedal-palooza-archives/">archives</a> of past festivals. If you need help creating or editing an event, check out the <a href="/pages/calendar-faq/">calendar FAQ</a> or <a href="mailto:bikecal@shift2bikes.org">contact the calendar crew</a>.</p>
+      View the <a href="/archive/pedal-palooza-archives/">archives</a> of past festivals. If you need help creating or editing an event, check out the <a href="/pages/calendar-faq/">calendar FAQ</a> or <a href="mailto:bikecal@shift2bikes.org">contact the calendar crew</a>.</p>
 
 <p>Check <a href="https://www.bike-summer.org/">Bike-Summer.org</a> for updates, follow <a href="https://www.instagram.com/pedalpaloozapdx/">Bike Summer on Instagram</a>, and tag posts about rides <strong>@pedalpaloozapdx</strong>!</p>
-      {{ end }}
 
-      {{ if eq (.Param "year") 2025 }}
       <div class="donate">
         <p>
           <span>Support Bike Summer</span>
-          <a href="https://www.paypal.com/donate/?cmd=_s-xclick&hosted_button_id=NQAUFEUSM49ZJ" target="_blank">Donate to Bike Summer</a>
+          <a href="{{ .Param "festival.donationsURL" }}" target="_blank">Donate to {{ .Param "festival.name" }}</a>
         </p>
         <p>
           <span>Support year-round bike fun</span>
-          <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=BNL2NY7U8GH3Q" target="_blank" data-content="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=BNL2NY7U8GH3Q" data-type="external" role="button" id="comp-j2nmjo3ulink" class="style-j2nmcorulink"><span id="comp-j2nmjo3ulabel" class="style-j2nmcorulabel">Donate to Shift</span></a>
+          <a href="{{ .Param "donationsURL" }}" target="_blank">Donate to {{ .Site.Title }}</a>
         </p>
       </div>
 

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-header.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-header.html
@@ -13,7 +13,7 @@
   <div id="pp-description">
       <p><a href="/pages/bike-summer/">Bike Summer</a> (aka Pedalpalooza) is a festival of bikey fun. Hundreds of different events are organized by people like you. Most rides are free and all are open to the public to join.</p>
 
-      {{ if eq (.Param "festival.latest") (.Param "year") }}
+      {{ if eq (now.Year) (.Param "year") }}
       <p>{{ .Param "festival.name" }} is <strong>three whole months</strong> of fun on two wheels. 
 
       {{ if eq (.Param "festival.active") true }}<a href="/addevent/"><strong>Add your events for June, July, and August {{ .Param "year" }} now!</strong></a> Seeking inspiration? {{ end }}

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-header.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-header.html
@@ -24,7 +24,7 @@
 
       <div class="donate">
         <p>
-          <span>Support Bike Summer</span>
+          <span>Support {{ .Param "festival.name" }}</span>
           <a href="{{ .Param "festival.donationsURL" }}" target="_blank">Donate to {{ .Param "festival.name" }}</a>
         </p>
         <p>


### PR DESCRIPTION
Moves some (though not all) Bike Summer/Pedalpalooza strings into params.

Fixes #920.