### PR TITLE
 deprecating the Pedalpalooza-specific iCal feed - #870 

### DIFF
--- a/docs/AllEvents.md
+++ b/docs/AllEvents.md
@@ -18,7 +18,7 @@ I've been able to import single events ( and update them ) into MacOS Calendar.a
 
 1. **New endpoints**
 
-    It's intended to be able to support `/cal/icalpp.php`, `/cal/pedalpalooza-calendar.php`,  and `/api/ics.php` -- might want to reroute old paths to the new ones? but that's maybe some ngnix configuration work i'm not entirely sure about.
+    It's intended to be able to support `/cal/icalpp.php`, `/cal/shift-calendar.php`,  and `/api/ics.php` -- might want to reroute old paths to the new ones? but that's maybe some ngnix configuration work i'm not entirely sure about.
     
     Alt: could have the php files in those locations include and call the new php code?
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -88,14 +88,14 @@
 ## legacy (people have been using it for years) ical feed for pedalpalooza.
 [[redirects]]
   from = "/cal/icalpp.php"
-  to = "https://api.shift2bikes.org/api/pedalpalooza-calendar.php"
+  to = "https://api.shift2bikes.org/api/shift-calendar.php"
   status = 200
   force = true
 
 ## the official pedalpalooza feed
 [[redirects]]
   from = "/cal/pedalpalooza-calendar.php"
-  to = "https://api.shift2bikes.org/api/pedalpalooza-calendar.php"
+  to = "https://api.shift2bikes.org/api/shift-calendar.php"
   status = 200
   force = true
 

--- a/netlify.toml.example
+++ b/netlify.toml.example
@@ -80,7 +80,7 @@
 
 [[redirects]]
   from = "/my/specialpath"
-  to = "https://api.primarydomain.org/api/pedalpalooza-calendar.php"
+  to = "https://api.primarydomain.org/api/special-back-end-path"
   status = 200
   force = true
 

--- a/services/nginx/conf.d/shift.conf
+++ b/services/nginx/conf.d/shift.conf
@@ -37,14 +37,6 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
 
-    # webcal endpoint for only pedalpalooza subscriptions:
-    # ex.  webcal://www.shift2bikes.org/cal/pedalpalooza-calendar.php
-    location = /api/pedalpalooza-calendar.php {
-        # set to a constant range for this year's pedalp
-        proxy_pass http://node:3080/api/ical.php?startdate=2025-06-01&enddate=2025-08-31&filename=pedalpalooza-2025.ics;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    }
-
     # webcal endpoint for that includes all shift events:
     location = /api/shift-calendar.php {
         proxy_pass http://node:3080/api/ical.php;

--- a/site/content/pages/calendar-faq.md
+++ b/site/content/pages/calendar-faq.md
@@ -99,15 +99,11 @@ Email the [Shift calendar crew](mailto:bikecal@shift2bikes.org) if you need help
 
 ## Subscribing to the calendar
 
-You can use the following steps to see bike events on your phone or computer's built-in calendar app. As new rides are created, they will show up on your calendar automatically (usually within 24 hours of the ride being posted by the organizer). This is a convenient way to stay up to date, but remember these are community led events: you will see all sorts of rides intended for all different riders.
+You can see events using your phone or computer's built-in calendar app. As new rides are created, they will show up on your calendar automatically (usually within 24 hours of the ride being posted by the organizer). Keep in mind, events are posted to the Shift calendar by community members, not by Shift; you will see all sorts of rides.
 
-There are are two calendars you can subscribe to:
+[webcal://www.shift2bikes.org/cal/shift-calendar.php](webcal://www.shift2bikes.org/cal/shift-calendar.php)
 
-* **The Pedalpalooza calendar**: This will show only the events happening during the official Pedalpalooza summer festival. [webcal://www.shift2bikes.org/cal/pedalpalooza-calendar.php](webcal://www.shift2bikes.org/cal/pedalpalooza-calendar.php)
-
-* **The Community calendar**: This will show all Pedalpalooza events, but also any other bike rides that might happen over the course of year. [webcal://www.shift2bikes.org/cal/shift-calendar.php](webcal://www.shift2bikes.org/cal/shift-calendar.php)
-
-On many devices, clicking on either of those links will open your calendar app automatically. Your app will then guide you through the steps to subscribe. For Android devices (or for Google Calendar on iOS devices) you will need to follow these instructions.
+On many devices, clicking the above link will open your calendar app automatically. It should then guide you through the steps to subscribe. If that doesn't work, you will need to follow these instructions:
 
 ### Android and Google Calendar:
 

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-feed.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-feed.html
@@ -1,6 +1,6 @@
 {{/* see also shift-feed.html */}}
 <div id="pp-calendar-feed" class="pp-banner" style="text-align: center; padding-top: 1rem; margin-top: 1rem;">
   <p>Want to see rides using your computer or phone's calendar app?</p>
-  <p><button type="button" id="feed-sub" class="btn" data-url="webcal://www.shift2bikes.org/cal/pedalpalooza-calendar.php">Subscribe to the Pedalpalooza festival calendar</button></p>
+  <p><button type="button" id="feed-sub" class="btn" data-url="webcal://www.shift2bikes.org/cal/shift-calendar.php">Subscribe to the Pedalpalooza festival calendar</button></p>
   <p>If that doesn't open your calendar app, see <a href="/pages/calendar-faq/#subscribing-to-the-calendar">other ways to subscribe to the calendar</a>.</p>
 </div>


### PR DESCRIPTION
supports #870  by removing the backend's knowledge of the special pedalp feed, and then it uses netlify redirects to map the old pedalp feeds to the shift one. it also updates the site docs and links so the pedalp feed is no longer referenced.