### PR TITLE
removed specific css for canceled tag so its text size matches 

### DIFF
--- a/site/themes/s2b_hugo_theme/assets/css/cal/main.css
+++ b/site/themes/s2b_hugo_theme/assets/css/cal/main.css
@@ -194,10 +194,6 @@ svg.icon {
 {
     text-decoration: none;
 }
-.event.cancelled h3 ins
-{
-    font-size: 1.4rem;
-}
 
 #fullcalendar .fc-event.cancelled {
     background-color: white;


### PR DESCRIPTION
This PR matches the text size of CANCELLED tag to it surrounding 

Fixes #962 
Issue: Font size of cancelled tag is a bit too big 
![image](https://github.com/user-attachments/assets/045df256-7c52-4717-b773-5c4b78edc470)

