### PR TITLE
Clean-up following removal of festival-specific iCal feed

### DIFF
--- a/docs/shift2bikes-specifics.md
+++ b/docs/shift2bikes-specifics.md
@@ -77,7 +77,7 @@ We struggled to get this working well, so there is probably dark magic here.  Cr
    1. `app/config.js`: reply email address, ical guid(s), etc.
    2. `app/endpoints/ical.js` (and `test/ical_test.js`): more ical guid generation
    3. `site/content/404.md`, `addevent.md`,` site/themes/s2b_hugo_theme/layouts/partials/cal/edit.html`, `pp-header.html`: support emails
-   4. `site/themes/s2b_hugo_theme/layouts/partials/cal/shift-feed.html`, `pp-feed.html`: ical subscription links
+   4. `site/themes/s2b_hugo_theme/layouts/partials/cal/shift-feed.html`: ical subscription link
    5. probably some content pages ( ex. for documentation, links, or email: but nothing that would directly affect functionality )
   
    

--- a/site/content/pages/calendar-faq.md
+++ b/site/content/pages/calendar-faq.md
@@ -107,7 +107,7 @@ On many devices, clicking the above link will open your calendar app automatical
 
 ### Android and Google Calendar:
 
-1. Copy one of the calendar links above. (On Android, by pressing and holding the link until the "Copy link address" menu appears, and then selecting that option.)
+1. Copy the calendar link above. (On Android, by pressing and holding the link until the "Copy link address" menu appears, and then selecting that option.)
 2. Visit [Google Calendar](https://calendar.google.com/calendar/u/0/r/settings/addbyurl) and if asked log into your Google account.
 3. On that Google Calendar page, paste the link you copied into the "URL of Calendar" box (press on that box and hold until the "Paste" menu appears, then choose that option).
 4. Finally, click the "Add calendar" button.

--- a/site/themes/s2b_hugo_theme/layouts/calfestival/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/calfestival/single.html
@@ -35,7 +35,7 @@
 
                 <!-- only display on current year -->
                 {{ if eq (.Param "year") 2025 }}
-                  {{ partial "cal/pp-feed.html" . }}
+                  {{ partial "cal/shift-feed.html" . }}
                 {{ end }}
 
                 <!-- events list; don't display for old PP pages with static content -->

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-feed.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/pp-feed.html
@@ -1,6 +1,0 @@
-{{/* see also shift-feed.html */}}
-<div id="pp-calendar-feed" class="pp-banner" style="text-align: center; padding-top: 1rem; margin-top: 1rem;">
-  <p>Want to see rides using your computer or phone's calendar app?</p>
-  <p><button type="button" id="feed-sub" class="btn" data-url="webcal://www.shift2bikes.org/cal/shift-calendar.php">Subscribe to the Pedalpalooza festival calendar</button></p>
-  <p>If that doesn't open your calendar app, see <a href="/pages/calendar-faq/#subscribing-to-the-calendar">other ways to subscribe to the calendar</a>.</p>
-</div>

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/shift-feed.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/shift-feed.html
@@ -1,6 +1,5 @@
-{{/* see also pp-feed.html */}}
 <div id="pp-calendar-feed" class="pp-banner" style="text-align: center; padding-top: 1rem; margin-top: 1rem;">
   <p>Want to see rides using your computer or phone's calendar app?</p>
-  <p><button type="button" id="feed-sub" class="btn" data-url="webcal://www.shift2bikes.org/cal/shift-calendar.php">Subscribe to the Shift calendar feed</button></p>
+  <p><button type="button" id="feed-sub" class="btn" data-url="webcal://www.shift2bikes.org/cal/shift-calendar.php">Subscribe to Shift calendar</button></p>
   <p>If that doesn't open your calendar app, see <a href="/pages/calendar-faq/#subscribing-to-the-calendar">other ways to subscribe to the calendar</a>.</p>
 </div>


### PR DESCRIPTION
Follow-up from #927: 
* Removes now-unused PP feed and associated content
* Shortens name of subscribe button (longer name caused unnecessary horizontal scrolling on some mobile devices)