### PR TITLE
fixup google calendar links

### DIFF
--- a/cal/src/calHelpers.js
+++ b/cal/src/calHelpers.js
@@ -56,20 +56,16 @@ export default {
 
   // duplicated from calendars helpers
   getAddToGoogleLink(event) {
-      const googleCalUrl = new URL('https://www.google.com/calendar/render');
+      const googleCalUrl = new URL('https://calendar.google.com/calendar/render');
 
-      const startDate = dayjs(`${event.date} ${event.time}`).toISOString();
-      const duration = event.duration ?? 60; // Google requires a duration and defaults to 60 minutes anyway
-      const endDate = dayjs(startDate).add(dayjs.duration({ 'minute': duration })).toISOString();
-      /**
-       * Matches anything that is not a word or whitespace
-       * @example
-       * "2025-05-21T16:30:00.000Z".replace(regex, '') // 20250521T163000000Z
-      */
-      const regex = /[^\w\s]/gi;
-
-      // Remove colons and periods for Google Calendar URL (2025-05-21T16:30:00.000Z => 20250521T163000000Z)
-      const calendarDates = `${startDate.replace(regex, '')}/${endDate.replace(regex, '')}`;
+      const startDate = dayjs(`${event.date} ${event.time}`);
+      const duration = event.duration ?? 60; // Google requires a duration
+      const endDate = dayjs(startDate).add(dayjs.duration({ 'minute': duration }));
+      
+      const googleFormat = 'YYYYMMDDTHHmmssZ'; // on simon's phone, millsecs creates an all day event
+      const startString = startDate.format(googleFormat);
+      const endString = endDate.format(googleFormat);
+      const calendarDates = `${startString}/${endString}`;
 
       googleCalUrl.search = new URLSearchParams({
         action: "TEMPLATE",
@@ -77,8 +73,8 @@ export default {
         location: event.address,
         details: `${event.details}\n\n${event.shareable}`,
         dates: calendarDates,
-        sf: true, // ??
-        output: 'xml'
+        // FIX: this seems better than timezoneless but probably should be configurable.
+        ctz: `America/Los_Angeles`
       });
 
       return googleCalUrl.toString();

--- a/cal/src/calHelpers.js
+++ b/cal/src/calHelpers.js
@@ -62,7 +62,7 @@ export default {
       const duration = event.eventduration ?? 60; // Google requires a duration
       const endDate = dayjs(startDate).add(dayjs.duration({ 'minute': duration }));
       
-      const googleFormat = 'YYYYMMDDTHHmmss[Z]'; // on simon's phone, millsecs creates an all day event
+      const googleFormat = 'YYYYMMDDTHHmmss'; // on simon's phone, millsecs creates an all day event
       const startString = startDate.format(googleFormat);
       const endString = endDate.format(googleFormat);
       const calendarDates = `${startString}/${endString}`;

--- a/cal/src/calHelpers.js
+++ b/cal/src/calHelpers.js
@@ -59,10 +59,10 @@ export default {
       const googleCalUrl = new URL('https://calendar.google.com/calendar/render');
 
       const startDate = dayjs(`${event.date} ${event.time}`);
-      const duration = event.duration ?? 60; // Google requires a duration
+      const duration = event.eventduration ?? 60; // Google requires a duration
       const endDate = dayjs(startDate).add(dayjs.duration({ 'minute': duration }));
       
-      const googleFormat = 'YYYYMMDDTHHmmssZ'; // on simon's phone, millsecs creates an all day event
+      const googleFormat = 'YYYYMMDDTHHmmss[Z]'; // on simon's phone, millsecs creates an all day event
       const startString = startDate.format(googleFormat);
       const endString = endDate.format(googleFormat);
       const calendarDates = `${startString}/${endString}`;

--- a/site/themes/s2b_hugo_theme/assets/js/cal/helpers.js
+++ b/site/themes/s2b_hugo_theme/assets/js/cal/helpers.js
@@ -77,10 +77,10 @@
         const googleCalUrl = new URL('https://calendar.google.com/calendar/render');
 
         const startDate = dayjs(`${event.date} ${event.time}`);
-        const duration = event.duration ?? 60; // Google requires a duration
+        const duration = event.eventduration ?? 60; // Google requires a duration
         const endDate = dayjs(startDate).add(dayjs.duration({ 'minute': duration }));
         
-        const googleFormat = 'YYYYMMDDTHHmmssZ'; // on simon's phone, millsecs creates an all day event
+        const googleFormat = 'YYYYMMDDTHHmmss[Z]'; // on simon's phone, millsecs creates an all day event
         const startString = startDate.format(googleFormat);
         const endString = endDate.format(googleFormat);
         const calendarDates = `${startString}/${endString}`;

--- a/site/themes/s2b_hugo_theme/assets/js/cal/helpers.js
+++ b/site/themes/s2b_hugo_theme/assets/js/cal/helpers.js
@@ -80,7 +80,7 @@
         const duration = event.duration ?? 60; // Google requires a duration
         const endDate = dayjs(startDate).add(dayjs.duration({ 'minute': duration }));
         
-        const googleFormat = 'YYYYMMDDTHHmmssZ'; const googleFormat = 'YYYYMMDDTHHmmssZ'; // on simon's phone, millsecs creates an all day event
+        const googleFormat = 'YYYYMMDDTHHmmssZ'; // on simon's phone, millsecs creates an all day event
         const startString = startDate.format(googleFormat);
         const endString = endDate.format(googleFormat);
         const calendarDates = `${startString}/${endString}`;

--- a/site/themes/s2b_hugo_theme/assets/js/cal/helpers.js
+++ b/site/themes/s2b_hugo_theme/assets/js/cal/helpers.js
@@ -71,30 +71,28 @@
         }
     };
 
+    // ex. https://calendarlinkgenerator.com/google-calendar-link-generator
+    // duplicated in calHelpers.js
     $.fn.getAddToGoogleLink = function(event) {
-        const googleCalUrl = new URL('https://www.google.com/calendar/render');
+        const googleCalUrl = new URL('https://calendar.google.com/calendar/render');
 
-        const startDate = dayjs(`${event.date} ${event.time}`).toISOString();
-        const duration = event.duration ?? 60; // Google requires a duration and defaults to 60 minutes anyway
-        const endDate = dayjs(startDate).add(dayjs.duration({ 'minute': duration })).toISOString();
-        /**
-         * Matches anything that is not a word or whitespace
-         * @example
-         * "2025-05-21T16:30:00.000Z".replace(regex, '') // 20250521T163000000Z
-        */
-        const regex = /[^\w\s]/gi;
-
-        // Remove colons and periods for Google Calendar URL (2025-05-21T16:30:00.000Z => 20250521T163000000Z)
-        const calendarDates = `${startDate.replace(regex, '')}/${endDate.replace(regex, '')}`;
-
+        const startDate = dayjs(`${event.date} ${event.time}`);
+        const duration = event.duration ?? 60; // Google requires a duration
+        const endDate = dayjs(startDate).add(dayjs.duration({ 'minute': duration }));
+        
+        const googleFormat = 'YYYYMMDDTHHmmssZ'; const googleFormat = 'YYYYMMDDTHHmmssZ'; // on simon's phone, millsecs creates an all day event
+        const startString = startDate.format(googleFormat);
+        const endString = endDate.format(googleFormat);
+        const calendarDates = `${startString}/${endString}`;
+        
         googleCalUrl.search = new URLSearchParams({
           action: "TEMPLATE",
           text: `shift2Bikes: ${event.title}`,
           location: event.address,
           details: `${event.details}\n\n${event.shareable}`,
           dates: calendarDates,
-          sf: true, // ??
-          output: 'xml'
+          // FIX: this seems better than timezoneless but probably should be configurable.
+          ctz: `America/Los_Angeles`
         });
 
         return googleCalUrl.toString();

--- a/site/themes/s2b_hugo_theme/assets/js/cal/helpers.js
+++ b/site/themes/s2b_hugo_theme/assets/js/cal/helpers.js
@@ -80,7 +80,7 @@
         const duration = event.eventduration ?? 60; // Google requires a duration
         const endDate = dayjs(startDate).add(dayjs.duration({ 'minute': duration }));
         
-        const googleFormat = 'YYYYMMDDTHHmmss[Z]'; // on simon's phone, millsecs creates an all day event
+        const googleFormat = 'YYYYMMDDTHHmmss'; // on simon's phone, millsecs creates an all day event
         const startString = startDate.format(googleFormat);
         const endString = endDate.format(googleFormat);
         const calendarDates = `${startString}/${endString}`;


### PR DESCRIPTION
remove milliseconds; that works on desktop and when cutting and pasting directly into chrome, but not with links from the calendar on android ( at least not on simon's phone ) remove the sf, and output -- these don't seem to be needed add the timezone for good measure ( as discussed with josh )