### PR TITLE
added word wrap for event titles

### DIFF
--- a/site/themes/s2b_hugo_theme/assets/css/cal/main.css
+++ b/site/themes/s2b_hugo_theme/assets/css/cal/main.css
@@ -356,7 +356,7 @@ h3 {
 button.expand-details {
     user-select: text;
     display: flex;
-    overflow-wrap: anywhere; 
+    overflow-wrap: anywhere;
 }
 
 button.expand-details svg {

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/events.html
@@ -67,7 +67,6 @@
                       </svg>
 
                       [[#cancelled]]<del>[[/cancelled]]
-                      R2R2R2R Kenilworth>GalacticDisco>Loud&Lit
                       [[title]]
 
                       [[#cancelled]]


### PR DESCRIPTION
fixes #963 

Before 

<img width="1125" height="2436" alt="image" src="https://github.com/user-attachments/assets/e8e41966-db0a-4f24-9c75-ece662634c73" />


After 

<img width="297" height="642" alt="Screenshot 2025-10-01 at 7 19 12 PM" src="https://github.com/user-attachments/assets/2ea5cc7a-efcd-44b0-8e19-ab63545d8e6b" />
<img width="637" height="639" alt="Screenshot 2025-10-01 at 7 19 24 PM" src="https://github.com/user-attachments/assets/f81e45fb-f5ac-477e-8bbd-fa2464349099" />

