### PR TITLE
Wait for stop

### DIFF
--- a/shift
+++ b/shift
@@ -148,11 +148,7 @@ sub_start() { # <service>, ..     - Alias for up
 }
 
 sub_stop() { # <service>, ...     - Stop service(s)
-    sub_compose stop $@ -t=8
-}
-
-sub_kill() { # <service>, ...     - Kill service(s)
-    sub_compose kill $@
+    sub_compose stop $@
 }
 
 sub_restart() { # <service>, ...  - Trigger entrypoint.sh, required after modifying anything in borzoi


### PR DESCRIPTION
- have "stop" actually call "stop" not "kill" ( a user could still run `./shift compose kill` if they really wanted to emergency terminate services )
- allow shift up to wait ( max 8 seconds ) for the stop/recreate to succeed
- let "start" be an alias of "up" -- they both recreated, but only one was waiting for the node service to come online.
- fix that `./shift down` didn't pass its parameters ( ex. `./shift down node`)
- remove the old call to `docker-compose`, production and dev (should in theory) all be on `docker compose` now.

TODO: should find the right bash way to make `./shift up` terminate on error