### PR TITLE
Make TBA/TBD address check case-insensitive and pattern-aware

### DIFF
--- a/cal/src/LocLink.vue
+++ b/cal/src/LocLink.vue
@@ -14,7 +14,7 @@ export default  {
     // ported from helpers.js getMapLink
     mapLink() {
       const { address } = this.evt;
-      if (!address || address == 'TBA' || address == 'TBD') {
+      if (!address || /^(tba|tbd)\b/i.test(address)) {
         // if address is null or not available yet, don't try to map it
         return null;
       } else if (address.match(urlPattern)) {

--- a/site/themes/s2b_hugo_theme/assets/js/cal/helpers.js
+++ b/site/themes/s2b_hugo_theme/assets/js/cal/helpers.js
@@ -17,7 +17,7 @@
     };
 
     $.fn.getMapLink = function(address) {
-        if (!address || address == 'TBA' || address == 'TBD') {
+        if (!address || /^(tba|tbd)\b/i.test(address)) {
             // if address is null or not available yet, don't try to map it
             return null;
         }


### PR DESCRIPTION
Fix #1010: Make TBA/TBD address check case-insensitive and pattern-aware

### Problem
Map link helper only checks for exact `'TBA'` or `'TBD'`, failing for lowercase (`tba`) or patterns like `"tba - more details"`.

Example: [Event 22915](https://www.shift2bikes.org/calendar/event-22915) has address `"tba"` (lowercase) which incorrectly attempts to map.

### Solution
Replace exact comparison with regex: `/^(tba|tbd)\b/i`

Handles: `TBA`, `tba`, `Tba`, `TBD`, `tbd`, `"TBA - details"`, `"tbd: location TBD"`

### Changes
- `site/themes/s2b_hugo_theme/assets/js/cal/helpers.js` (line 19)
- `cal/src/LocLink.vue` (line 17)

Minimal change (2 lines), no breaking changes, existing tests pass.