### PR TITLE
tilde lock dependencies; remove compose shrink lock

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -6,17 +6,17 @@
   "author": "SHIFT calendar crew",
   "license": "MIT",
   "dependencies": {
-    "dayjs": "^1.11.7",
-    "express": "^4.22.0",
-    "knex": "^2.4.2",
-    "lodash": "^4.17.21",
-    "multer": "^2.0.2",
-    "mysql2": "^3.9.8",
-    "nodemailer": "^7.0.11",
-    "nunjucks": "^3.2.3",
-    "sqlite3": "^5.1.6",
-    "validator": "^13.15.22",
-    "wordwrapjs": "^5.1.0"
+    "dayjs": "~1.11.13",
+    "express": "~4.22.0",
+    "knex": "~2.5.1",
+    "lodash": "~4.17.21",
+    "multer": "~2.0.2",
+    "mysql2": "~3.14.0",
+    "nodemailer": "~7.0.11",
+    "nunjucks": "~3.2.4",
+    "sqlite3": "~5.1.7",
+    "validator": "~13.15.22",
+    "wordwrapjs": "~5.1.0"
   },
   "scripts": {
     "start": "node app.js",

--- a/cal/package.json
+++ b/cal/package.json
@@ -9,13 +9,13 @@
     "deploy": "vite build --outDir ../site/public/events"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^6.7.2",
-    "@fortawesome/free-regular-svg-icons": "^6.7.2",
-    "@fortawesome/free-solid-svg-icons": "^6.7.2",
-    "@fortawesome/vue-fontawesome": "^3.0.8",
-    "dayjs": "1.11.13",
-    "vue": "3.5.13",
-    "vue-router": "4.5.0"
+    "@fortawesome/fontawesome-svg-core": "~6.7.2",
+    "@fortawesome/free-regular-svg-icons": "~6.7.2",
+    "@fortawesome/free-solid-svg-icons": "~6.7.2",
+    "@fortawesome/vue-fontawesome": "~3.1.2",
+    "dayjs": "~1.11.13",
+    "vue": "~3.5.25",
+    "vue-router": "~4.6.3"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.1",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,12 +82,9 @@ services:
     volumes:
       # map the shift node code and package files;
       # and attach to the volume for its modules.
-      # remaps "package-lock" to "npm-shrinkwrap"
-      # to ensure "npm i" uses a fixed set of dependencies.
       - ./app:/shift/app/
       - ./tools:/shift/tools/
       - ./package.json:/shift/package.json
-      - ./package-lock.json:/shift/npm-shrinkwrap.json
       - modules:/shift/node_modules/
 
       # provide access to images:

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "1.0.0",
   "type": "module",
   "dependencies": {
-    "concurrently": "8.2.2",
-    "env-cmd": "10.1.0",
-    "exec-bin": "1.0.0",
-    "hugo-installer": "4.0.1"
+    "concurrently": "~8.2.2",
+    "env-cmd": "~10.1.0",
+    "exec-bin": "~1.0.0",
+    "hugo-installer": "~4.0.1"
   },
   "workspaces": [
     "app",

--- a/tools/package.json
+++ b/tools/package.json
@@ -6,14 +6,12 @@
   "author": "SHIFT calendar crew",
   "license": "MIT",
   "dependencies": {
-    "@faker-js/faker": "^8.4.1",
-    "env-cmd": "^10.1.0",
-    "express": "^4.22.0",
-    "express-http-proxy": "^2.0.0",
-    "http-proxy-middleware": "^2.0.7",
-    "nodemailer": "^7.0.11",
+    "@faker-js/faker": "~8.4.1",
+    "env-cmd": "~10.1.0",
+    "express-http-proxy": "~2.1.1",
+    "http-proxy-middleware": "~3.0.5",
     "shift-docs": "1.0.0",
-    "sqlstring": "^2.3.3"
+    "sqlstring": "~2.3.3"
   },
   "scripts": {
     "preview": "env-cmd -f dev.env node preview.js",


### PR DESCRIPTION
#1029 removed `package-lock.json`, and linked some packages to specific dependencies instead.
this changes those dependencies to `~` style, and it updates our other `package.json` files to match.
it raises the versions up to what they had been in the package-lock prior to 1029, and removes the now unneeded lock->shrinkwrap mapping in docker's compose.

this doesn't address dependencies of dependencies: that's considered an okay risk since all of our direct dependencies are well known and well maintained projects.