### PR TITLE
Fix Hugo build version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,8 @@ services:
     # note: this container is only needed for local development.
     # for production, netlify serves the hugo content instead.
     # see also: ./shift watch ( sub_watch() )
-    image: floryn90/hugo:0.155.3-busybox
+    # also set the version in netlify.toml
+    image: floryn90/hugo:0.152.2-busybox
     volumes:
       - ./site/:/src/
       - ./site/public/:/output/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     # note: this container is only needed for local development.
     # for production, netlify serves the hugo content instead.
     # see also: ./shift watch ( sub_watch() )
-    # also set the version in netlify.toml
+    # also set the version in package.json
     image: floryn90/hugo:0.152.2-busybox
     volumes:
       - ./site/:/src/

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,6 +10,7 @@
 
 [build.environment]
   # extra environment variables if needed.
+  HUGO_VERSION = "0.152.2" # also set the version in docker-compose.yml
 
 # we need to manually copy the 404 page over for now, in every environment
 # cf https://github.com/shift-org/shift-docs/issues/862

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,7 +10,6 @@
 
 [build.environment]
   # extra environment variables if needed.
-  HUGO_VERSION = "0.152.2" # also set the version in docker-compose.yml
 
 # we need to manually copy the 404 page over for now, in every environment
 # cf https://github.com/shift-org/shift-docs/issues/862

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "deploy:vite": "npm -w cal run deploy",
     "postdeploy": "cp site/public/404/index.html site/public/404.html",
     
-    "postinstall": "hugo-installer --version 0.144.2",
+    "postinstall": "hugo-installer --version 0.152.2",
     "test": "npm -w app test --",
 
     "preview": "concurrently --kill-others-on-fail \"npm:preview-*\"",


### PR DESCRIPTION
* Reverts to known-working version of Hugo. 
* Also specifies the same version in `package.json`

Following #1047, local Hugo builds were resulting in a 404 error when trying to visit `/calendar`. Other calendar pages, including the cal grid page and Bike Summer calendar, were working.

This didn't manifest in production because it was actually running an older version of Hugo (v.0.144.2). This was because we also specify the version in `package.json`, but the versions had drifted because we (well, I 😅 ) forgot to update both.