### PR TITLE
WIP - datepicker.js — 3 fixes:

### DIFF
--- a/site/themes/s2b_hugo_theme/assets/js/cal/addevent.js
+++ b/site/themes/s2b_hugo_theme/assets/js/cal/addevent.js
@@ -323,9 +323,9 @@
         var $form = $('#event-entry');
         $.extend(previewEvent, shiftEvent, eventFromForm());
 
-        previewEvent['displayStartTime'] = dayjs(previewEvent['time'], 'hh:mm:ss').format('h:mm A');
+        previewEvent['displayStartTime'] = dayjs(previewEvent['time'], 'HH:mm:ss').format('h:mm A');
         if ( previewEvent['eventduration'] ){
-            var endTime = dayjs(previewEvent['time'], 'hh:mm:ss')
+            var endTime = dayjs(previewEvent['time'], 'HH:mm:ss')
                 .add(previewEvent['eventduration'], 'minutes')
                 .format('HH:mm');
             previewEvent['endtime'] = endTime; // e.g. 18:00

--- a/site/themes/s2b_hugo_theme/assets/js/cal/datepicker.js
+++ b/site/themes/s2b_hugo_theme/assets/js/cal/datepicker.js
@@ -125,17 +125,26 @@
         return Mustache.render(dateStatusesTemplate, {dateStatuses});
     }
 
-    function isToday(date) {
-        return dayjs().isSame(date, 'day');
+    // Return the current date in Pacific time as a YYYY-MM-DD string.
+    // Using Intl.DateTimeFormat ensures correctness regardless of the browser's local timezone.
+    function getPacificToday() {
+        return new Date().toLocaleDateString('en-CA', {
+            timeZone: 'America/Los_Angeles',
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit'
+        });
     }
 
-    // return the utc YYYY-MM-DD string of the passed date
-    // note: 'date' is sometimes a utc string, or a dayjs object.
+    function isToday(date) {
+        return dayjs(date).format('YYYY-MM-DD') === getPacificToday();
+    }
+
+    // return the YYYY-MM-DD string of the passed date
+    // note: 'date' is sometimes a string, or a dayjs object.
     // see also: main.js viewEvents()
-   function toUtcString(date) {
-        // tbd: does the server actually handle dates as utc?
-        // i believe times ( ex. start times ) are assumed local.
-        return dayjs(date).utc().format('YYYY-MM-DD');
+    function toUtcString(date) {
+        return dayjs(date).format('YYYY-MM-DD');
     }
 
     function isSelected(date) {
@@ -237,7 +246,7 @@
     // fix: should this scroll the first scheduled day into view
     // ( ex. when editing existing events )
     function initDatePicker() {
-        const now = dayjs();
+        const now = dayjs(getPacificToday());
         earliestMonth = now;
         latestMonth = now.add(1, 'month');
 

--- a/site/themes/s2b_hugo_theme/assets/js/cal/main.js
+++ b/site/themes/s2b_hugo_theme/assets/js/cal/main.js
@@ -36,10 +36,10 @@ $(document).ready(function() {
                         mustacheData.dates.push(groupedByDate[date]);
                     }
 
-                    value.displayStartTime = dayjs(value.time, 'hh:mm:ss').format('h:mm A');
+                    value.displayStartTime = dayjs(value.time, 'HH:mm:ss').format('h:mm A');
                     value.displayDate = dayjs(value.date).format('ddd, MMM D, YYYY');
                     if (value.endtime) {
-                      value.displayEndTime = dayjs(value.endtime, 'hh:mm:ss').format('h:mm A');
+                      value.displayEndTime = dayjs(value.endtime, 'HH:mm:ss').format('h:mm A');
                     }
 
                     value.audienceLabel = container.getAudienceLabel(value.audience);


### PR DESCRIPTION
  - Added getPacificToday() using Intl.DateTimeFormat with timeZone: 'America/Los_Angeles', which returns the correct Pacific date regardless of the browser's timezone
  - isToday() now compares against the Pacific date instead of the local date
  - toUtcString() no longer calls .utc() — converting local-midnight dayjs objects to UTC was shifting dates backward for users east of UTC (e.g., a user clicking "Jan 5" in the calendar would accidentally store Jan 4)
  - initDatePicker() now starts from the Pacific "today" date

  addevent.js — 1 fix:
  - 'hh:mm:ss' → 'HH:mm:ss' in the preview time parser; the lowercase hh is 12-hour format and would misparse afternoon times like "14:30:00", causing the preview to display wrong end times for PM events

  main.js — 1 fix:
  - Same 'hh:mm:ss' → 'HH:mm:ss' fix for event time display in the calendar list view