### PR TITLE
Update multer to ~2.1.1 to rid us of a high severity sec vuln.

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -10,7 +10,7 @@
     "express": "~4.22.0",
     "knex": "~2.5.1",
     "lodash": "~4.17.21",
-    "multer": "~2.0.2",
+    "multer": "~2.1.1",
     "mysql2": "~3.14.0",
     "nodemailer": "~7.0.11",
     "nunjucks": "~3.2.4",


### PR DESCRIPTION
Release notes say this should be non-breaking.  