### PR TITLE
Tweak view options display on events list

### DIFF
--- a/site/themes/s2b_hugo_theme/assets/css/cal/main.css
+++ b/site/themes/s2b_hugo_theme/assets/css/cal/main.css
@@ -470,7 +470,7 @@ button.expand-details svg {
 }
 
 .search-events {
-  display: inline-block;
+  display: flex;
 }
 
 .go-to-date {
@@ -481,6 +481,23 @@ button.expand-details svg {
 .event-list-options {
   display: flex;
   justify-content: space-between;
+}
+
+@media (width <= 992px) {
+  .event-list-options {
+    flex-direction: column;
+  }
+
+  .event-list-options > * {
+    text-align: center;
+    margin: 0.5rem auto;
+  }
+}
+
+summary {
+  display: revert;
+  text-align: center;
+  margin-bottom: 1rem;
 }
 
 .error {

--- a/site/themes/s2b_hugo_theme/layouts/calevents/single.html
+++ b/site/themes/s2b_hugo_theme/layouts/calevents/single.html
@@ -15,7 +15,6 @@
 
                 {{ partial "cal/shift-feed.html" . }}
 
-                {{ partial "cal/view-options.html" . }}
                 {{ partial "cal/event-list-options" . }}
 
                 <p id="search-summary"></p>

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/event-list-options.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/event-list-options.html
@@ -1,15 +1,32 @@
-<div class="event-list-options">
-  <div class="show-details">
-    <button type="button" id="show-details" class="btn">Toggle details</button>
-  </div>
-  <form class="search-events" action="/calendar/" method="GET">
-    <label for="search-events-field" class="sr-only">Search events</label>
-    <input type="text" name="q" id="search-events-field" placeholder="Search Events">
-    <button type="submit" class="btn">Search</button>
-  </form>
-  <form class="go-to-date" action="/calendar/" method="GET">
-    <label for="go-to-date-field">Go to date</label>
-    <input type="date" name="startdate" id="go-to-date-field" min="2008-01-01">
-    <button type="submit" class="btn">Go</button>
-  </form>
-</div>
+<details id="view-options">
+  <summary>View options</summary>
+  {{ partial "cal/view-options.html" . }}
+
+  <div class="event-list-options">
+    <div class="show-details">
+      <button type="button" id="show-details" class="btn">Toggle details</button>
+    </div>
+    <form class="search-events" action="/calendar/search/" method="GET">
+      <label for="search-events-field">Search events</label>
+      <input type="text" name="q" id="search-events-field" placeholder="keywords">
+      <button type="submit" class="btn">Search</button>
+    </form>
+    <form class="go-to-date" action="/calendar/" method="GET">
+      <label for="go-to-date-field">Go to date</label>
+      <input type="date" name="startdate" id="go-to-date-field" min="2008-01-01">
+      <button type="submit" class="btn">Go</button>
+    </form>
+</details>
+
+<script>
+  // expand the view options section if:
+  //   the screen is large; or
+  //   the user has chosen a non-default option (e.g. entered a search query)
+  let viewOptions = document.querySelector("details#view-options");
+  let mql = window.matchMedia("(min-width: 992px)");
+  let params = new URLSearchParams(location.search).size;
+
+  if (mql.matches || params > 0) {
+      viewOptions.open = true;
+  }
+</script>

--- a/site/themes/s2b_hugo_theme/layouts/partials/cal/event-list-options.html
+++ b/site/themes/s2b_hugo_theme/layouts/partials/cal/event-list-options.html
@@ -7,7 +7,7 @@
       <button type="button" id="show-details" class="btn">Toggle details</button>
     </div>
     <form class="search-events" action="/calendar/search/" method="GET">
-      <label for="search-events-field">Search events</label>
+      <label for="search-events-field" class="sr-only">Search events</label>
       <input type="text" name="q" id="search-events-field" placeholder="keywords">
       <button type="submit" class="btn">Search</button>
     </form>


### PR DESCRIPTION
Collapse view options by default on small screens, unless you've changed a view option (entered a search query; chosen "Go to date…"; toggled view to show all details).