### PR TITLE
Remove stale Flourish/PHP references from docs and comments (#734)

### DIFF
--- a/app/endpoints/delete_event.js
+++ b/app/endpoints/delete_event.js
@@ -11,7 +11,7 @@
  *   }
  *
  * If there was an error ( for example, if the id was missing or the event wasn't found )
- * returns http 400 "Bad Request" and a json error response (see errors.php)
+ * returns http 400 "Bad Request" and a json error response (see util/errors.js)
  *
  */
 const config = require("../config");

--- a/app/endpoints/events.js
+++ b/app/endpoints/events.js
@@ -103,13 +103,11 @@ function getSummaries(dailies) {
 }
 exports.getSummaries = getSummaries;
 
-// the php version had each daily query for its event
-// and then tacked the end time to the end of the daily json
-// relying on flourish to ( presumably ) filter out the redundant event queries.
-// this pools the events to avoid multiple queries:
-// so to keep the endtime after each daily, we have to tack it on manually.
+// pool the events so each daily doesn't separately query for its (shared) event.
+// the end time lives on the event, but needs to appear after each daily's json,
+// so it's tacked on manually below.
 function specialSummary(evt) {
-  // an invalid duration generates a null here; just like the php.
+  // an invalid duration generates a null here.
   const endTime = to24HourString(evt.getEndTime());
   return [ evt.getJSON(), endTime ];
 }

--- a/app/endpoints/retrieve_event.js
+++ b/app/endpoints/retrieve_event.js
@@ -9,7 +9,7 @@
  *
  * On success, returns a json summary of event.
  * If there was an error ( for example, if the id was missing or the event wasn't found )
- * returns http 400 "Bad Request" with a json error response ( see errors.php )
+ * returns http 400 "Bad Request" with a json error response ( see util/errors.js )
  *
  *  See also:
  *  https://github.com/shift-org/shift-docs/blob/main/docs/CALENDAR_API.md#retrieving-public-event-data

--- a/app/models/calDaily.js
+++ b/app/models/calDaily.js
@@ -37,7 +37,7 @@ const methods =  {
 
   // store the status and newflash if they changed.
   // promises this after storing the change.
-  // note: flourish stored empty strings as null; so we do the same.
+  // note: empty strings are stored as null, to stay consistent with existing data.
   _updateStatus(dateStatus) {
     let changed = false;
     const newStatus = dateStatus.status || null;
@@ -328,7 +328,7 @@ class CalDaily {
    * @param  statusMap a js Map containing {YYYY-MM-DD: dateStatus }
    * @return the promise of valid CalDaily(s)
    *
-   * @see: DateStatus.php, manage_event.php
+   * @see: dateStatus.js, manage_event.js
    */
   static reconcile(evt, statusMap, softDelete = true) {
     return CalDaily.getByEventID(evt.id).then((dailies) => {

--- a/app/models/calEventValidator.js
+++ b/app/models/calEventValidator.js
@@ -76,11 +76,9 @@ function makeValidator(input, errors) {
     requiredTime(field) {
       // interestingly: the upload is in AM/PM style
       // but the server stores and reports in 24 hour style.
-      // and flourish stores communicates 'time' fields as an fTime
-      // while mysql stores as a 'hh:mm:ss' with no meridian
-      // so flourish must automatically transform to 24 time.
+      // mysql stores 'time' fields as 'hh:mm:ss' with no meridian,
+      // so we convert to 24 hour here.
       // https://dev.mysql.com/doc/refman/8.0/en/time.html
-      // https://flourishlib.com/docs/fTime.html
       const str = getString(field);
       if (validator.isEmpty(str)) {
         errors.addError('time');
@@ -96,8 +94,7 @@ function makeValidator(input, errors) {
         }
       }
     },
-    // to mimic php/flourish empty strings are converted to null.
-    // https://flourishlib.com/docs/fActiveRecord.html#ColumnOperations
+    // empty strings are converted to null, to stay consistent with existing data.
     nullString(field, maxLen = 255) {
       const str = getString(field);
       if (validator.isEmpty(str)) {

--- a/docs/TABLES.md
+++ b/docs/TABLES.md
@@ -45,7 +45,7 @@ See also:
   - **tinytitle** string 
 
     event string used for the printed calendar.
-    if not specified, manage_event.php slices the first 24 characters of the long title.
+    if not specified, the manage_event endpoint slices the first 24 characters of the long title.
 
   - **audience** char
 
@@ -59,13 +59,11 @@ See also:
 
   - **image** string
 
-    server location is configured via config.php:
-      $IMAGEDIR = "/opt/backend/eventimages";
-      $IMAGEURL = "/eventimages";
-    
-    mange_event.php accepts gif, jpeg, pjpeg, png, up to 2 megs.
-    https://flourishlib.com/docs/fValidation.html
-    https://flourishlib.com/docs/fUpload.html
+    the storage location and url path are configured in `app/config.js`
+    ( `config.image.dir` and `config.image.path` ).
+
+    the `manage_event` endpoint accepts gif, jpeg, pjpeg, png images,
+    up to `config.image.maxFileSize`.
 
   - **tinytitle** string
   

--- a/docs/cache_busting.md
+++ b/docs/cache_busting.md
@@ -7,7 +7,7 @@ use cases
 4. uploading a new image
 
 
-in the legacy case ( 3 ), say, for example, there is an old event with id `666` and an image called `legacy.png`. The php renames the file ( even during a GET ) to match its id ( ie. `666.png` ) and this becomes the stable case ( 2 ) thereafter.
+in the legacy case ( 3 ), an old event might have an image stored under a name unrelated to its id ( ex. `legacy.png` ). these files are served directly by their stored name.
 
 calevent image field examples
 --------------------
@@ -16,15 +16,14 @@ calevent image field examples
 5. **legacy name** -- i have no idea if any of these actually exist, but some images used to have a format different than the "base format". ( maybe some `legacy.png` )
 3. **base format** -- the db record matches the file on disk. its name follows from the event id. for example, for event `123` the image field is `123.png`
 4. **extended format** -- for cache busting, appends the calevent sequence number to the base format. for example, the image field might be `123-44.png`
-2. **upload finalized** -- in `manage_event.php` `upload_attached_file()`, after the upload has completed but before event management has finished, the event image field gets updated to match the name of the uploaded file. This name is determined by the flourish file uploader. It is temporary, and will become the base ( or extended ) format after `updateImageUrl()` is called.
+2. **upload finalized** -- when an image is uploaded, `manage_event` ( `app/endpoints/manage_event.js` ) saves the file via `app/uploader.js` and sets the image field to the extended format, `<id>-<sequence><ext>`. the sequence number comes from the event's `changes` counter.
 	
 filenames on disk
 ------------------
 
 1. **pre-upload**, the image has whatever name the user has assigned: ex. `/my/local/computer/puppet.png`
-2. **upload in progress**, flourish appears to upload files to a temp directory on the server with a randomly assigned temporary name: ex, maybe, `/tmp/tmphhh`
-2. **upload finalized**, flourish assigns a unique, non conflicting name based on the user's original file. For example: `/opt/backend/eventimages/puppet.png` or if there is already some `puppet.png` on the server, `/opt/backend/eventimages/puppet_copy_1.png`.  This name is not stored to the db, only set in memory.
-3. any time **updateImageUrl()** is called, the php code may rename the image file. It uses a name based on the event id. For example, for event 123, `/opt/backend/eventimages/123.png`. **Note:** this is the same as the "base format", it's never the "extended format".
+2. **uploaded**, the upload is received in memory by [multer](https://github.com/expressjs/multer) ( see `app/uploader.js` ), so no temporary file is left on disk.
+3. **stored**, `uploader.write()` writes the file under a name based on the event id, in the directory set by `config.image.dir`. for event 123, that's ex. `/opt/backend/eventimages/123.png`. **Note:** this is always the "base format", never the "extended format"; the sequence number only appears in the db image field and the url.
 
 
 image urls

--- a/site/themes/s2b_hugo_theme/assets/js/cal/addevent.js
+++ b/site/themes/s2b_hugo_theme/assets/js/cal/addevent.js
@@ -235,7 +235,7 @@
                       err = returnVal.responseJSON.error;
                     } else if (returnVal.status === 413) {
                       // 413 - "Request Entity Too Large" gets sent by nginx above its client_max_body_size;
-                      // so the error message sent by flourish.
+                      // nginx (not the backend) sends it, so we construct the error message here.
                       err = {
                         message: 'There were errors in your fields',
                         fields: {


### PR DESCRIPTION
Closes #734.

The PHP backend — and the [Flourish](https://flourishlib.com/) library it used — was removed in #694. As a result, various comments and docs still describe behavior in terms of Flourish, PHP source files, or PHP-only mechanics that no longer exist. This reworks those references to describe what the **current Node code actually does**.

## Flourish references
- **`app/endpoints/events.js`** — describe the event pooling / end-time handling directly, instead of contrasting it with the old PHP/ORM behavior.
- **`app/models/calDaily.js`** & **`app/models/calEventValidator.js`** — state the current null / 24-hour-conversion behavior and its rationale (consistency with existing data), dropping the Flourish framing and the dead `flourishlib.com` doc links.
- **`docs/TABLES.md`** — point the image config at `app/config.js` (`config.image.*`) and the `manage_event` endpoint, instead of `config.php` / `manage_event.php` / `$IMAGEDIR`.
- **`docs/cache_busting.md`** — rewrite the upload flow to match the Node implementation (in-memory [multer](https://github.com/expressjs/multer) upload; `uploader.write()` writing the base-format `id.ext`; the sequence number living only in the db field and URL). Removes `upload_attached_file()`, `updateImageUrl()`, and the GET-time renaming that no longer exist. Kept the still-accurate cache-busting concept and nginx URL handling.
- **`site/themes/s2b_hugo_theme/assets/js/cal/addevent.js`** — replace the dangling "so the error message sent by flourish" comment with a clearer note that nginx (not the backend) sends the 413.

## Related dead PHP source-file references (same spirit)
- **`app/endpoints/retrieve_event.js`** & **`app/endpoints/delete_event.js`** — `see errors.php` → `see util/errors.js`.
- **`app/models/calDaily.js`** — `@see: DateStatus.php, manage_event.php` → `dateStatus.js, manage_event.js`.
- **`docs/TABLES.md`** — "`manage_event.php` slices the first 24 characters…" → "the `manage_event` endpoint slices…".

## Deliberately left as-is
- **`/api/*.php` URL paths** — the endpoints are still served at these URLs (`appEndpoints.js` hosts each at `/api/<name>.php`), so request examples, tests, nginx routes, and the frontend API config that reference them remain correct.
- **`docs/AllEvents.md`** — a historical design memo describing the PHP-era implementation; its `.php` references are accurate to the era it narrates, so rewriting filenames there would misrepresent the history rather than fix anything.

These are comment/documentation edits only; no behavior changes.