### PR TITLE
Bump dayjs to latest patch (~1.11.21) (#743)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,7 @@
   "author": "SHIFT calendar crew",
   "license": "MIT",
   "dependencies": {
-    "dayjs": "~1.11.13",
+    "dayjs": "~1.11.21",
     "express": "~4.22.0",
     "knex": "~2.5.1",
     "lodash": "~4.17.21",

--- a/cal/package.json
+++ b/cal/package.json
@@ -13,7 +13,7 @@
     "@fortawesome/free-regular-svg-icons": "~6.7.2",
     "@fortawesome/free-solid-svg-icons": "~6.7.2",
     "@fortawesome/vue-fontawesome": "~3.1.2",
-    "dayjs": "~1.11.13",
+    "dayjs": "~1.11.21",
     "vue": "~3.5.25",
     "vue-router": "~4.6.3"
   },


### PR DESCRIPTION
Closes #743.

Day.js is already at the latest published patch, **1.11.21** (npm has nothing newer in the 1.11.x line or beyond), and `package-lock.json` already resolves to it. The only thing lagging was the declared floor in the two workspace manifests, which still read `~1.11.13`.

This bumps the `dayjs` range to `~1.11.21` in both `app/package.json` and `cal/package.json` so the manifests reflect the current patch. The lockfile needed no change (already synced), and `npm install` confirmed that.

No runtime change: the installed dayjs version is identical before and after, so this only aligns the manifest floors with the already-current lockfile.