### PR TITLE
Default MySQL server and client to utf8mb4 (#796)

### DIFF
--- a/app/db.js
+++ b/app/db.js
@@ -110,7 +110,10 @@ function unpackConfig({ type, connect, debug }) {
       port : connect.port,
       user : connect.user,
       password : connect.pass,
-      database : connect.name
+      database : connect.name,
+      // match the utf8mb4 database/server so 4-byte characters
+      // ( ex. emoji ) round-trip cleanly. re: #796
+      charset : 'utf8mb4',
     },
     // knex recommends setting the min pool size to 0
     // ( for backcompat, their default is 2. )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,8 @@ services:
       - MYSQL_HOST
     volumes:
       - db:/var/lib/mysql/
+      # force utf8mb4 for the server defaults and the mysql client ( re: #796 )
+      - ./services/db/conf.d/charset.cnf:/etc/mysql/conf.d/charset.cnf
     ports:
       - 3306
 

--- a/services/db/conf.d/charset.cnf
+++ b/services/db/conf.d/charset.cnf
@@ -1,0 +1,19 @@
+# Force UTF-8 (utf8mb4) everywhere. See issue #796.
+#
+# The database and its tables were already converted to utf8mb4 in
+# migration 0005_char_set_and_collation.sql, but the *server* defaults
+# and the `mysql` command-line client still negotiated latin1, so
+# non-ASCII characters showed up as `?` in terminal output.
+#
+# Setting these here (rather than per-session) makes utf8mb4 the durable
+# default for every connection and every `mysql` session.
+
+[mysqld]
+character-set-server=utf8mb4
+collation-server=utf8mb4_general_ci
+
+[client]
+default-character-set=utf8mb4
+
+[mysql]
+default-character-set=utf8mb4


### PR DESCRIPTION
Closes #796.

The `shift` database and its active tables (`calevent`, `caldaily`) were already converted to utf8mb4 in migration `0005_char_set_and_collation.sql`. However, the MySQL **server defaults** (`character_set_server`, `collation_server`) and the `mysql` command-line client still negotiated latin1, so non-ASCII characters showed up as `?` in terminal output. Those session settings don't persist, which was the open question in the issue.

## Changes

- **`services/db/conf.d/charset.cnf`** (new) sets `character-set-server` / `collation-server` under `[mysqld]`, plus `default-character-set=utf8mb4` under `[client]` and `[mysql]`, so every server start and every `mysql` session defaults to utf8mb4.
- **`docker-compose.yml`** mounts that file into the `db` container at `/etc/mysql/conf.d/charset.cnf`. A single-file mount preserves the image's own `conf.d` defaults; the official mysql image `!includedir`s this directory, so it is read at startup (no volume re-init needed).
- **`app/db.js`** adds `charset: 'utf8mb4'` to the knex/mysql2 connection so the Node backend round-trips 4-byte characters (e.g. emoji) consistently.

The old unused latin1 tables are left alone; they are tracked separately under #812.

## Verification

`npm test` passes (53/53; the SQLite path is unaffected).

To confirm the session settings against MySQL, bring up the stack and pipe the query in via `mysql-pipe` (piping avoids the `./shift mysql -e "..."` form, whose unquoted argument passing word-splits the statement):

```
./shift up
printf "SHOW VARIABLES LIKE 'character_set%%';\nSHOW VARIABLES LIKE 'collation%%';\n" | ./shift mysql-pipe
```

All values except `character_set_filesystem` (binary) and `character_set_system` (utf8mb3) should read `utf8mb4`.