### PR TITLE
Collapse a redirect double-hop; audit legacy redirects (#650)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -122,10 +122,12 @@
   to = "/calendar/"
   status = 301
 
-## a special redirect for a URL that someone made up
+## a special redirect for a URL that someone made up.
+## points straight at the current Bike Summer page to avoid a double hop
+## through /pages/pedalpalooza ( which is itself only a redirect to it ).
 [[redirects]]
   from = "/calendar/pedalpalooza"
-  to = "/pages/pedalpalooza"
+  to = "/pages/bike-summer"
   status = 301
 
 ## old Pedalpalooza page should link to new one

--- a/netlify.toml
+++ b/netlify.toml
@@ -122,9 +122,7 @@
   to = "/calendar/"
   status = 301
 
-## a special redirect for a URL that someone made up.
-## points straight at the current Bike Summer page to avoid a double hop
-## through /pages/pedalpalooza ( which is itself only a redirect to it ).
+## a special redirect for a URL that someone made up
 [[redirects]]
   from = "/calendar/pedalpalooza"
   to = "/pages/bike-summer"


### PR DESCRIPTION
Addresses #650 (audit + trim legacy redirects in `netlify.toml` and nginx).

On audit, almost everything flagged as potential "legacy cruft" turns out to still be load-bearing, so this is a deliberately small change. Details below so a maintainer can decide whether a more aggressive prune is worth the risk of breaking old inbound links.

## Change

Collapse the `/calendar/pedalpalooza` redirect double-hop. It pointed at `/pages/pedalpalooza`, which is itself only a redirect to `/pages/bike-summer`, so this now points straight at `/pages/bike-summer` (one fewer 301 round-trip; no user-facing link breaks; destination page confirmed present).

## Audit

### nginx (`services/nginx/conf.d/shift.conf`) - nothing to remove
The issue asks specifically about `/legacy` or `/backend` details. There are **no** `/legacy` or `/backend` redirects. The only `/opt/backend/eventimages` references are the live event-image storage path, and every `proxy_pass` targets a current endpoint. (The `/api/*.php` URLs remain the real API paths even after the PHP source was removed in #694.)

### netlify.toml - kept, with rationale
Everything else is still serving a purpose, so removing it would regress rather than clean up:

- **Domain canonicalization** (`shift2bikes.com`, `shifttobikes.org`, ... -> `www.shift2bikes.org`): alternate domains still resolve here.
- **Backend/proxy** (`/api/*`, `/eventimages/*`, `/socialapi/`): live functionality.
- **iCal feeds** (`/cal/icalpp.php`, `/cal/pedalpalooza-calendar.php`, `/cal/shift-calendar.php`): in use; `icalpp.php` is explicitly annotated as a years-old feed people still rely on.
- **Legacy links** (`/cal/*`, `/pedalpalooza`, `/pages/pedalpalooza`, `/pedalpalooza-calendar`, `/wiki/shift-shop:rack-rental`, `/pages/playbooks`): these exist precisely to preserve old inbound links (some from offsite pages we can't edit, e.g. PBoT). Removing them 404s those links. All redirect targets were verified to still exist (`bike-summer`, `bike-summer-calendar`, `bike-racks`, `meeting-notes`).
- **SPA handlers** (`/addevent/*`, `/calendar/*`, `/events/*`) and the **Android PWA** `/.well-known/assetlinks.json`: live routing.

### Deliberately left alone
- **`/campaign1` -> `/`** is a sample/placeholder campaign redirect. It is a removal candidate, but PR #1056 is actively reworking campaign redirects, so it is left to avoid conflict.

## Verification

`netlify.toml` is Netlify infrastructure config with no local test path; verified by inspection, and the destination (`site/content/pages/bike-summer.md`) exists. nginx is unchanged.