### PR TITLE
Set an absolute baseURL per netlify context for the sitemap (#1082)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,17 +11,28 @@
 [build.environment]
   # extra environment variables if needed.
 
+# HUGO_BASEURL overrides `baseURL` in site/config/_default/hugo.toml
+# ( which stays "/" so local dev and any un-cased build work on any host ).
+# hugo needs an absolute baseURL for a valid sitemap: <loc> entries must be
+# fully qualified urls, so relative paths get rejected by search engines.
+# cf https://github.com/shift-org/shift-docs/issues/1082
+#
+# note: netlify only expands env vars like $DEPLOY_PRIME_URL inside `command`,
+# not inside a [context.*.environment] table, so we set it inline here.
+
 # we need to manually copy the 404 page over for now, in every environment
 # cf https://github.com/shift-org/shift-docs/issues/862
 [context.deploy-preview]
   # -D builds draft content for deploy previews
   # ( the doubledash is needed to pass the argument through to hugo )
   # cf https://docs.netlify.com/site-deploys/deploy-previews/
-  command = 'npm run deploy -- -D'
+  # DEPLOY_PRIME_URL is this preview's own origin, so assets and the
+  # /api proxy still resolve against the preview rather than production.
+  command = 'HUGO_BASEURL="$DEPLOY_PRIME_URL" npm run deploy -- -D'
 
 [context.branch-deploy]
   # operates on custom branches, same as deploy-preview.
-  command = 'npm run deploy -- -D'
+  command = 'HUGO_BASEURL="$DEPLOY_PRIME_URL" npm run deploy -- -D'
 
 [context.production]
   # see this guide about why we do this funky thing with ssh: 
@@ -31,9 +42,10 @@
   # and replace with one of the 'npm run deploy' commands from above.
   #
   # NOTE: This pulls new code to the api server!
-  # drafts are excluded (no `-D` option) for prod build.  
-  #  
-  command = 'npm run deploy && mkdir -p ~/.ssh && echo -e "${SSH_KEY//_/\\n}" > ~/.ssh/id_rsa && chmod og-rwx ~/.ssh/id_rsa && ssh -v -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@api.shift2bikes.org "cd /opt/shift-docs && ./shift pull" || (echo "you seem to be building without ssh access - see https://github.com/shift-org/shift-docs#netlify-deployment for details" ; /bin/false)'
+  # drafts are excluded (no `-D` option) for prod build.
+  # HUGO_BASEURL is the canonical host ( matching the domain redirects above ),
+  # so the sitemap points at the version of the site we actually serve.
+  command = 'HUGO_BASEURL="https://www.shift2bikes.org" npm run deploy && mkdir -p ~/.ssh && echo -e "${SSH_KEY//_/\\n}" > ~/.ssh/id_rsa && chmod og-rwx ~/.ssh/id_rsa && ssh -v -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@api.shift2bikes.org "cd /opt/shift-docs && ./shift pull" || (echo "you seem to be building without ssh access - see https://github.com/shift-org/shift-docs#netlify-deployment for details" ; /bin/false)'
 
 ## ---------------------------------------------------------------------------
 ## domain redirects to serve alternative domains.  First, we canonicalize


### PR DESCRIPTION
Fixes #1082.

`https://www.shift2bikes.org/sitemap.xml` builds and serves (200), but every entry is a relative path:

```xml
<loc>/pages/bike-summer/</loc>
```

The [sitemap protocol](https://www.sitemaps.org/protocol.html) requires `<loc>` to be a fully qualified URL, so these entries are almost certainly being discarded by search engines. Hugo builds `<loc>` from each page's `.Permalink`, which derives from `baseURL`, and `baseURL = "/"`.

## Why not just change baseURL in hugo.toml

`baseURL = "/"` is load-bearing. The theme resolves assets and the calendar's own API calls through `absURL`:

```
site/themes/s2b_hugo_theme/layouts/partials/cal/scripts.html:140:  url: '{{ absURL "api/events.php" }}',
site/themes/s2b_hugo_theme/layouts/partials/head-content.html:29:  <link rel="icon" href="{{ absURL "favicon.ico" }}">
```

With a relative base these resolve same-origin, which is what lets one build work unchanged on localhost, on deploy previews, and in production. Hardcoding the production URL into `hugo.toml` would make previews and local dev load assets from, and fetch event data from, `www.shift2bikes.org`.

## The change

`baseURL` stays `/` in `hugo.toml`. `netlify.toml` overrides it per build context via `HUGO_BASEURL` (hugo maps that env var onto `baseURL`):

| Context | HUGO_BASEURL | Result |
|---|---|---|
| production | `https://www.shift2bikes.org` (canonical host, matching the domain redirects at the top of `netlify.toml`) | sitemap points at the site we actually serve |
| deploy-preview / branch-deploy | `$DEPLOY_PRIME_URL` (that build's own origin) | assets and the `/api` proxy resolve against the preview, not production |
| local dev / any uncased build | unset, so `/` from `hugo.toml` | relative, works on any host |

It is set inline in each `command` rather than in a `[context.*.environment]` table, because netlify only expands env vars like `$DEPLOY_PRIME_URL` inside `command`. A `[context.*.environment]` value is a literal string, so `HUGO_BASEURL = "$DEPLOY_PRIME_URL"` there would hand hugo the literal text `$DEPLOY_PRIME_URL`.

## Verification

Built with hugo 0.152.2, reproducing each context's environment:

```
production (HUGO_BASEURL literal):
  <loc>https://www.shift2bikes.org/archive/get-lit/</loc>

deploy-preview (DEPLOY_PRIME_URL expanded by the shell, as netlify does):
  <loc>https://deploy-preview-1082--shift.netlify.app/archive/get-lit/</loc>
  home page's calendar call: url: 'https://deploy-preview-1082--shift.netlify.app/api/events.php'

local dev (no env, baseURL stays "/"):
  <loc>/archive/get-lit/</loc>
```

So the sitemap becomes absolute in the two deployed contexts, previews stay self-contained (the `/api/*` proxy handles the preview-origin API calls), and local dev is unchanged. `netlify.toml` was confirmed to still parse as valid TOML.

## Notes

- This does not touch the production sitemap listing `/404/`. That is handled by #1083 (which excludes the 404 page from the sitemap).
- Adjacent to #1083, which also edits `netlify.toml`; whichever merges second may need a trivial rebase, but there is no logical conflict.
- Once this is deployed, the `Sitemap:` line added by #1080 (robots.txt) points at a valid sitemap.
